### PR TITLE
Add CMake option to disable Qt's NTFS permission checking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,17 @@ else()
 endif()
 
 # --------------------------------------------------------------------
+# Should we use enable NTFS file checking on Windows
+# --------------------------------------------------------------------
+if(WIN32)
+  set(SIMPLib_NTFS_FILE_CHECK "")
+  option(SIMPL_ENABLE_NTFS_FILE_CHECKING "Enable NTFS File Permissions Checking" ON)
+  if(SIMPL_ENABLE_NTFS_FILE_CHECKING)
+      set(SIMPLib_NTFS_FILE_CHECK "1")
+  endif()
+endif()
+
+# --------------------------------------------------------------------
 # Now that we have found all of our required libraries and packages we can start the all
 # the tests
 
@@ -370,7 +381,11 @@ ENDif(CMAKE_COMPILER_IS_GNUCXX)
 if(MSVC)
  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
  add_definitions(-D_SCL_SECURE_NO_WARNINGS)
+ set(SIMPLib_DISABLE_MSVC_WARNINGS "")
  option(SIMPL_DISABLE_MSVC_WARNINGS "Disable some MSVC Compiler warnings" OFF)
+ if(SIMPL_DISABLE_MSVC_WARNINGS)
+    set(SIMPLib_DISABLE_MSVC_WARNINGS "1")
+ endif()
 endif()
 
 

--- a/Source/SIMPLib/CoreFilters/DataContainerWriter.cpp
+++ b/Source/SIMPLib/CoreFilters/DataContainerWriter.cpp
@@ -166,8 +166,10 @@ void DataContainerWriter::dataCheck()
   }
 
 #ifdef _WIN32
-  // Turn file permission checking on
+  // Turn file permission checking on, if requested
+  #ifdef SIMPLib_NTFS_FILE_CHECK
   qt_ntfs_permission_lookup++;
+  #endif
 #endif
 
   QFileInfo dirInfo(fi.path());
@@ -178,9 +180,12 @@ void DataContainerWriter::dataCheck()
     ss = QObject::tr("The user does not have the proper permissions to write to the output file");
     notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
   }
+
 #ifdef _WIN32
-  // Turn file permission checking off
+  // Turn file permission checking off, if requested
+  #ifdef SIMPLib_NTFS_FILE_CHECK
   qt_ntfs_permission_lookup--;
+  #endif
 #endif
 }
 

--- a/Source/SIMPLib/SIMPLibConfiguration.h.in
+++ b/Source/SIMPLib/SIMPLibConfiguration.h.in
@@ -14,6 +14,9 @@
 /* define to 1 if we are using parallel algorithms */
 #cmakedefine SIMPLib_USE_PARALLEL_ALGORITHMS @SIMPLib_USE_PARALLEL_ALGORITHMS@
 
+/* define to 1 if we are enabling NTFS file checking */
+#cmakedefine SIMPLib_NTFS_FILE_CHECK @SIMPLib_NTFS_FILE_CHECK@
+
 /* define to 1 if we are using the Eigen Library*/
 #cmakedefine SIMPLib_USE_EIGEN @EIGEN_FOUND@
 
@@ -37,7 +40,7 @@
 
 /* We are going to disable some warnings just to get a grip on all the warnings that get produced
 * during an MSVC build */
-#cmakedefine SIMPLib_DISABLE_MSVC_WARNINGS
+#cmakedefine SIMPLib_DISABLE_MSVC_WARNINGS @SIMPLib_DISABLE_MSVC_WARNINGS@
 
 #define __SHOW_DEBUG_MSG__ false
 


### PR DESCRIPTION
Also make the necessary tweaks in DataContainerWriter to ensure the checking
does not occur, if requested.  Minor tweak to the CMake option for disabling
MSVC warnings (which was never getting #defined because no CMake variable actually
existed for the configuration).

updates #9 
closes #9 