### PR TITLE
Fix crashing in findDerivatives() due to possible grain size of 0

### DIFF
--- a/Source/SIMPLib/Geometry/ImageGeom.cpp
+++ b/Source/SIMPLib/Geometry/ImageGeom.cpp
@@ -830,9 +830,11 @@ void ImageGeom::findDerivatives(DoubleArrayType::Pointer field, DoubleArrayType:
 #endif
 
 #ifdef SIMPLib_USE_PARALLEL_ALGORITHMS
+  size_t grain = dims[2] == 1 ? 1 : dims[2] / init.default_num_threads();
+
   if(doParallel == true)
   {
-    tbb::parallel_for(tbb::blocked_range3d<size_t, size_t, size_t>(0, dims[2], dims[2] / init.default_num_threads(), 0, dims[1], dims[1], 0, dims[0], dims[0]),
+    tbb::parallel_for(tbb::blocked_range3d<size_t, size_t, size_t>(0, dims[2], grain, 0, dims[1], dims[1], 0, dims[0], dims[0]),
                       FindImageDerivativesImpl(this, field, derivatives), tbb::auto_partitioner());
   }
   else

--- a/Source/SIMPLib/Geometry/RectGridGeom.cpp
+++ b/Source/SIMPLib/Geometry/RectGridGeom.cpp
@@ -944,9 +944,11 @@ void RectGridGeom::findDerivatives(DoubleArrayType::Pointer field, DoubleArrayTy
 #endif
 
 #ifdef SIMPLib_USE_PARALLEL_ALGORITHMS
+  size_t grain = dims[2] == 1 ? 1 : dims[2] / init.default_num_threads();
+
   if(doParallel == true)
   {
-    tbb::parallel_for(tbb::blocked_range3d<size_t, size_t, size_t>(0, dims[2], dims[2] / init.default_num_threads(), 0, dims[1], dims[1], 0, dims[0], dims[0]),
+    tbb::parallel_for(tbb::blocked_range3d<size_t, size_t, size_t>(0, dims[2], grain, 0, dims[1], dims[1], 0, dims[0], dims[0]),
                       FindRectGridDerivativesImpl(this, field, derivatives), tbb::auto_partitioner());
   }
   else


### PR DESCRIPTION
ImageGeom and RectGridGeom will now check to see if they are 2D in the XY plane
and set the grain size accordingly

updates #13 
closes #13 