### PR TITLE
Implement overload for RayIntersectsPlane

### DIFF
--- a/Source/SIMPLib/Math/GeometryMath.cpp
+++ b/Source/SIMPLib/Math/GeometryMath.cpp
@@ -850,6 +850,57 @@ char GeometryMath::RayIntersectsPlane(const float* a, const float* b, const floa
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+char GeometryMath::RayIntersectsPlane(const float* n, const float d, const float* q, const float* r, float* p)
+{
+  float rq[3];
+  float num, denom, t;
+
+  num = d - ((q[0] * n[0]) + (q[1] * n[1]) + (q[2] * n[2]));
+  rq[0] = r[0] - q[0];
+  rq[1] = r[1] - q[1];
+  rq[2] = r[2] - q[2];
+  denom = (rq[0] * n[0]) + (rq[1] * n[1]) + (rq[2] * n[2]);
+
+  if(denom == 0.0)
+  {
+    if(num == 0.0)
+    {
+      return 'p';
+    }
+    else
+    {
+      return '0';
+    }
+  }
+  else
+  {
+    t = num / denom;
+    for(int i = 0; i < 3; i++)
+    {
+      p[i] = q[i] + (t * (r[i] - q[i]));
+    }
+    if(t > 0.0 && t < 1.0)
+    {
+      return '1';
+    }
+    else if(num == 0.0)
+    {
+      return 'q';
+    }
+    else if(num == denom)
+    {
+      return 'r';
+    }
+    else
+    {
+      return '0';
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 char GeometryMath::PointInTriangle3D(const float* a, const float* b, const float* c, int m, const float* p)
 {
   float pp[3], aP[3], bP[3], cP[3];

--- a/Source/SIMPLib/Math/GeometryMath.h
+++ b/Source/SIMPLib/Math/GeometryMath.h
@@ -342,6 +342,17 @@ class SIMPLib_EXPORT GeometryMath
      */
     static char RayIntersectsPlane(const float* a, const float* b, const float* c, const float* q, const float* r, float* p, int& m);
 
+    /**
+    * @brief Determines if a segment between two points intersects a plane defined by a normal and distance
+    * @param n
+    * @param d
+    * @param q
+    * @param r
+    * @param p
+    * @return
+    */
+    static char RayIntersectsPlane(const float* n, const float d, const float* q, const float* r, float* p);
+
   protected:
     GeometryMath();
 


### PR DESCRIPTION
This version of the RayIntersectsPlane function takes the plane as defined in
point-normal form for easy use of the plane equation.

updates #21 
closes #21 