### PR TITLE
Fix deepCopy() functions for IGeometry objects

### DIFF
--- a/Source/SIMPLib/Geometry/EdgeGeom.cpp
+++ b/Source/SIMPLib/Geometry/EdgeGeom.cpp
@@ -649,12 +649,15 @@ int EdgeGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 IGeometry::Pointer EdgeGeom::deepCopy()
 {
-  EdgeGeom::Pointer edgeCopy = EdgeGeom::CreateGeometry(getEdges(), getVertices(), getName());
+  EdgeGeom::Pointer edgeCopy = EdgeGeom::CreateGeometry(std::static_pointer_cast<SharedEdgeList>(getEdges()->deepCopy()), 
+                                                        std::static_pointer_cast<SharedVertexList>(getVertices()->deepCopy()),
+                                                        getName());
 
-  edgeCopy->setElementsContainingVert(getElementsContainingVert());
-  edgeCopy->setElementNeighbors(getElementNeighbors());
-  edgeCopy->setElementCentroids(getElementCentroids());
-  edgeCopy->setElementSizes(getElementSizes());
+  // No deepCopy() yet exists for DynamicListArray
+  //edgeCopy->setElementsContainingVert(std::static_pointer_cast<ElementDynamicList>(getElementsContainingVert()->deepCopy()));
+  //edgeCopy->setElementNeighbors(std::static_pointer_cast<ElementDynamicList>(getElementNeighbors()->deepCopy()));
+  edgeCopy->setElementCentroids(std::static_pointer_cast<DataArray<float>>(getElementCentroids()->deepCopy()));
+  edgeCopy->setElementSizes(std::static_pointer_cast<DataArray<float>>(getElementSizes()->deepCopy()));
   edgeCopy->setSpatialDimensionality(getSpatialDimensionality());
 
   return edgeCopy;

--- a/Source/SIMPLib/Geometry/ImageGeom.cpp
+++ b/Source/SIMPLib/Geometry/ImageGeom.cpp
@@ -1011,7 +1011,7 @@ IGeometry::Pointer ImageGeom::deepCopy()
   imageCopy->setDimensions(volDims);
   imageCopy->setResolution(spacing);
   imageCopy->setOrigin(origin);
-  imageCopy->setElementSizes(getElementSizes());
+  imageCopy->setElementSizes(std::static_pointer_cast<DataArray<float>>(getElementSizes()->deepCopy()));
   imageCopy->setSpatialDimensionality(getSpatialDimensionality());
 
   return imageCopy;

--- a/Source/SIMPLib/Geometry/QuadGeom.cpp
+++ b/Source/SIMPLib/Geometry/QuadGeom.cpp
@@ -745,14 +745,17 @@ int QuadGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 IGeometry::Pointer QuadGeom::deepCopy()
 {
-  QuadGeom::Pointer quadCopy = QuadGeom::CreateGeometry(getQuads(), getVertices(), getName());
+  QuadGeom::Pointer quadCopy = QuadGeom::CreateGeometry(std::static_pointer_cast<SharedQuadList>(getQuads()->deepCopy()), 
+                                                        std::static_pointer_cast<SharedVertexList>(getVertices()->deepCopy()),
+                                                        getName());
 
-  quadCopy->setEdges(getEdges());
-  quadCopy->setUnsharedEdges(getUnsharedEdges());
-  quadCopy->setElementsContainingVert(getElementsContainingVert());
-  quadCopy->setElementNeighbors(getElementNeighbors());
-  quadCopy->setElementCentroids(getElementCentroids());
-  quadCopy->setElementSizes(getElementSizes());
+  quadCopy->setEdges(std::static_pointer_cast<SharedEdgeList>(getEdges()->deepCopy()));
+  quadCopy->setUnsharedEdges(std::static_pointer_cast<SharedEdgeList>(getUnsharedEdges()->deepCopy()));
+  // No deepCopy() yet exists for DynamicListArray
+  //quadCopy->setElementsContainingVert(std::static_pointer_cast<ElementDynamicList>(getElementsContainingVert()->deepCopy()));
+  //quadCopy->setElementNeighbors(std::static_pointer_cast<ElementDynamicList>(getElementNeighbors()->deepCopy()));
+  quadCopy->setElementCentroids(std::static_pointer_cast<DataArray<float>>(getElementCentroids()->deepCopy()));
+  quadCopy->setElementSizes(std::static_pointer_cast<DataArray<float>>(getElementSizes()->deepCopy()));
   quadCopy->setSpatialDimensionality(getSpatialDimensionality());
 
   return quadCopy;

--- a/Source/SIMPLib/Geometry/RectGridGeom.cpp
+++ b/Source/SIMPLib/Geometry/RectGridGeom.cpp
@@ -1101,10 +1101,10 @@ IGeometry::Pointer RectGridGeom::deepCopy()
   size_t volDims[3] = { 0, 0, 0 };
   getDimensions(volDims);
   rectGridCopy->setDimensions(volDims);
-  rectGridCopy->setXBounds(getXBounds());
-  rectGridCopy->setYBounds(getYBounds());
-  rectGridCopy->setZBounds(getZBounds());
-  rectGridCopy->setElementSizes(getElementSizes());
+  rectGridCopy->setXBounds(std::static_pointer_cast<DataArray<float>>(getXBounds()->deepCopy()));
+  rectGridCopy->setYBounds(std::static_pointer_cast<DataArray<float>>(getYBounds()->deepCopy()));
+  rectGridCopy->setZBounds(std::static_pointer_cast<DataArray<float>>(getZBounds()->deepCopy()));
+  rectGridCopy->setElementSizes(std::static_pointer_cast<DataArray<float>>(getElementSizes()->deepCopy()));
   rectGridCopy->setSpatialDimensionality(getSpatialDimensionality());
 
   return rectGridCopy;

--- a/Source/SIMPLib/Geometry/TetrahedralGeom.cpp
+++ b/Source/SIMPLib/Geometry/TetrahedralGeom.cpp
@@ -849,16 +849,19 @@ int TetrahedralGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 IGeometry::Pointer TetrahedralGeom::deepCopy()
 {
-  TetrahedralGeom::Pointer tetCopy = TetrahedralGeom::CreateGeometry(getTetrahedra(), getVertices(), getName());
+  TetrahedralGeom::Pointer tetCopy = TetrahedralGeom::CreateGeometry(std::static_pointer_cast<SharedTetList>(getTetrahedra()->deepCopy()), 
+                                                                     std::static_pointer_cast<SharedVertexList>(getVertices()->deepCopy()),
+                                                                     getName());
 
-  tetCopy->setEdges(getEdges());
-  tetCopy->setUnsharedEdges(getUnsharedEdges());
-  tetCopy->setTriangles(getTriangles());
-  tetCopy->setUnsharedFaces(getUnsharedFaces());
-  tetCopy->setElementsContainingVert(getElementsContainingVert());
-  tetCopy->setElementNeighbors(getElementNeighbors());
-  tetCopy->setElementCentroids(getElementCentroids());
-  tetCopy->setElementSizes(getElementSizes());
+  tetCopy->setEdges(std::static_pointer_cast<SharedEdgeList>(getEdges()->deepCopy()));
+  tetCopy->setUnsharedEdges(std::static_pointer_cast<SharedEdgeList>(getUnsharedEdges()->deepCopy()));
+  tetCopy->setTriangles(std::static_pointer_cast<SharedTriList>(getTriangles()->deepCopy()));
+  tetCopy->setUnsharedFaces(std::static_pointer_cast<SharedTriList>(getUnsharedFaces()->deepCopy()));
+  // No deepCopy() yet exists for DynamicListArray
+  //tetCopy->setElementsContainingVert(std::static_pointer_cast<ElementDynamicList>(getElementsContainingVert()->deepCopy()));
+  //tetCopy->setElementNeighbors(std::static_pointer_cast<ElementDynamicList>(getElementNeighbors()->deepCopy()));
+  tetCopy->setElementCentroids(std::static_pointer_cast<DataArray<float>>(getElementCentroids()->deepCopy()));
+  tetCopy->setElementSizes(std::static_pointer_cast<DataArray<float>>(getElementSizes()->deepCopy()));
   tetCopy->setSpatialDimensionality(getSpatialDimensionality());
 
   return tetCopy;

--- a/Source/SIMPLib/Geometry/TriangleGeom.cpp
+++ b/Source/SIMPLib/Geometry/TriangleGeom.cpp
@@ -743,14 +743,17 @@ int TriangleGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 IGeometry::Pointer TriangleGeom::deepCopy()
 {
-  TriangleGeom::Pointer triCopy = TriangleGeom::CreateGeometry(getTriangles(), getVertices(), getName());
+  TriangleGeom::Pointer triCopy = TriangleGeom::CreateGeometry(std::static_pointer_cast<SharedTriList>(getTriangles()->deepCopy()), 
+                                                               std::static_pointer_cast<SharedVertexList>(getVertices()->deepCopy()),
+                                                               getName());
 
-  triCopy->setEdges(getEdges());
-  triCopy->setUnsharedEdges(getUnsharedEdges());
-  triCopy->setElementsContainingVert(getElementsContainingVert());
-  triCopy->setElementNeighbors(getElementNeighbors());
-  triCopy->setElementCentroids(getElementCentroids());
-  triCopy->setElementSizes(getElementSizes());
+  triCopy->setEdges(std::static_pointer_cast<SharedEdgeList>(getEdges()->deepCopy()));
+  triCopy->setUnsharedEdges(std::static_pointer_cast<SharedEdgeList>(getUnsharedEdges()->deepCopy()));
+  // No deepCopy() yet exists for DynamicListArray
+  //triCopy->setElementsContainingVert(std::static_pointer_cast<ElementDynamicList>(getElementsContainingVert()->deepCopy()));
+  //triCopy->setElementNeighbors(std::static_pointer_cast<ElementDynamicList>(getElementNeighbors()->deepCopy()));
+  triCopy->setElementCentroids(std::static_pointer_cast<DataArray<float>>(getElementCentroids()->deepCopy()));
+  triCopy->setElementSizes(std::static_pointer_cast<DataArray<float>>(getElementSizes()->deepCopy()));
   triCopy->setSpatialDimensionality(getSpatialDimensionality());
 
   return triCopy;

--- a/Source/SIMPLib/Geometry/VertexGeom.cpp
+++ b/Source/SIMPLib/Geometry/VertexGeom.cpp
@@ -445,9 +445,10 @@ int VertexGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 IGeometry::Pointer VertexGeom::deepCopy()
 {
-  VertexGeom::Pointer vertexCopy = VertexGeom::CreateGeometry(getVertices(), getName());
+  VertexGeom::Pointer vertexCopy = VertexGeom::CreateGeometry(std::static_pointer_cast<SharedVertexList>(getVertices()->deepCopy()), 
+                                                              getName());
 
-  vertexCopy->setElementSizes(getElementSizes());
+  vertexCopy->setElementSizes(std::static_pointer_cast<DataArray<float>>(getElementSizes()->deepCopy()));
   vertexCopy->setSpatialDimensionality(getSpatialDimensionality());
 
   return vertexCopy;


### PR DESCRIPTION
The fix to ensure that the deepCopy() actually occurs is to make sure to call deepCopy() on the underlying arrays.  The dynamic connectivity arrays do not have a deep copy implementation yet, so the new IGeometry object may need to recomputed these. 

updates #46 
closes #46 