### PR TITLE
Add a ‘bool forceNoAllocate’ argument to all the deepCopy() methods.

### DIFF
--- a/Source/SIMPLib/Common/FilterPipeline.cpp
+++ b/Source/SIMPLib/Common/FilterPipeline.cpp
@@ -294,7 +294,7 @@ int FilterPipeline::preflightPipeline()
     (*filter)->preflight();
     disconnectFilterNotifications((*filter).get());
 
-    (*filter)->setDataContainerArray(dca->deepCopy());
+    (*filter)->setDataContainerArray(dca->deepCopy(false));
     (*filter)->setCancel(false); // Reset the cancel flag
     preflightError |= (*filter)->getErrorCondition();
   }

--- a/Source/SIMPLib/DataArrays/DynamicListArray.hpp
+++ b/Source/SIMPLib/DataArrays/DynamicListArray.hpp
@@ -33,221 +33,308 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#ifndef _DynamicListArray_H_
-#define _DynamicListArray_H_
-
+#ifndef _dynamicListArray_H_
+#define _dynamicListArray_H_
 
 #include <vector>
 
 //-- DREAM3D Includes
-#include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
+#include "SIMPLib/SIMPLib.h"
 
 /**
  * @brief The MeshFaceNeighbors class contains arrays of Faces for each Node in the mesh. This allows quick query to the node
  * to determine what Cells the node is a part of.
  */
-template<typename T, typename K>
-class DynamicListArray
+template <typename T, typename K> class DynamicListArray
 {
+public:
+  SIMPL_SHARED_POINTERS(DynamicListArray)
+  SIMPL_STATIC_NEW_MACRO(DynamicListArray)
+  SIMPL_TYPE_MACRO(DynamicListArray)
+
+  class ElementList
+  {
   public:
+    T ncells;
+    K* cells;
+  };
 
-    SIMPL_SHARED_POINTERS(DynamicListArray)
-    SIMPL_STATIC_NEW_MACRO(DynamicListArray)
-    SIMPL_TYPE_MACRO(DynamicListArray)
-
-    class ElementList
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  virtual ~DynamicListArray()
+  {
+    // This makes sure we deallocate any lists that have been created
+    for(size_t i = 0; i < this->m_Size; i++)
     {
-      public:
-        T ncells;
-        K* cells;
-    };
-
-
-
-    // -----------------------------------------------------------------------------
-    //
-    // -----------------------------------------------------------------------------
-    virtual ~DynamicListArray()
-    {
-      // This makes sure we deallocate any lists that have been created
-      for (size_t i = 0; i < this->m_Size; i++)
+      if(this->m_Array[i].cells != nullptr)
       {
-        if ( this->m_Array[i].cells != nullptr )
-        {
-          delete [] this->m_Array[i].cells;
-        }
-      }
-      // Now delete all the "NeighborLists" structures
-      if ( this->m_Array != nullptr )
-      {
-        delete [] this->m_Array;
-      }
-
-    }
-
-    //----------------------------------------------------------------------------
-    inline void insertCellReference(size_t ptId, size_t pos, size_t cellId)
-    {
-      this->m_Array[ptId].cells[pos] = cellId;
-    }
-
-    // Description:
-    // Get a link structure given a point id.
-    ElementList& getElementList(size_t ptId) {return this->m_Array[ptId];}
-
-    /**
-     * @brief setElementList
-     * @param ptId
-     * @param nCells
-     * @param data
-     * @return
-     */
-    bool setElementList(size_t ptId, T nCells, K* data)
-    {
-      if(ptId >= m_Size) { return false; }
-      if(nullptr != m_Array[ptId].cells && m_Array[ptId].ncells > 0)
-      {
-        m_Array[ptId].cells = nullptr;
-        m_Array[ptId].ncells = 0;
-      }
-      m_Array[ptId].ncells = nCells;
-      //If nCells is huge then there could be problems with this
-      this->m_Array[ptId].cells = new K[nCells];
-      ::memcpy(m_Array[ptId].cells, data, sizeof(K) * nCells);
-      return true;
-    }
-
-    // Description:
-    // Get the number of cells using the point specified by ptId.
-    T getNumberOfElements(size_t ptId) {return this->m_Array[ptId].ncells;}
-
-    // Description:
-    // Return a list of cell ids using the point.
-    K* getElementListPointer(size_t ptId) {return this->m_Array[ptId].cells;}
-
-    // -----------------------------------------------------------------------------
-    //
-    // -----------------------------------------------------------------------------
-    void deserializeLinks(QVector<uint8_t>& buffer, size_t nElements)
-    {
-      size_t offset = 0;
-      allocate(nElements); // Allocate all the links with 0 and nullptr;
-      uint8_t* bufPtr = buffer.data();
-
-      // Walk the array and allocate all the array links to Zero and nullptr
-      T* ncells = nullptr;
-      for(size_t i = 0; i < nElements; ++i)
-      {
-        ncells = reinterpret_cast<T*>(bufPtr + offset);
-        this->m_Array[i].ncells = *ncells; // Set the number of cells in this link
-        offset += 2;
-        this->m_Array[i].cells = new K[(*ncells)]; // Allocate a new chunk of memory to store the list
-        ::memcpy(this->m_Array[i].cells, bufPtr + offset, (*ncells)*sizeof(K) ); // Copy from the buffer into the new list memory
-        offset += (*ncells) * sizeof(K); // Increment the offset
+        delete[] this->m_Array[i].cells;
       }
     }
-
-    // -----------------------------------------------------------------------------
-    //
-    // -----------------------------------------------------------------------------
-    void deserializeLinks(std::vector<uint8_t>& buffer, size_t nElements)
+    // Now delete all the "NeighborLists" structures
+    if(this->m_Array != nullptr)
     {
-      size_t offset = 0;
-      allocate(nElements); // Allocate all the links with 0 and nullptr;
-      uint8_t* bufPtr = &(buffer.front());
+      delete[] this->m_Array;
+    }
+  }
 
-      // Walk the array and allocate all the array links to Zero and nullptr
-      T* ncells = nullptr;
-      //int32_t* cells = nullptr;
-      for(size_t i = 0; i < nElements; ++i)
-      {
-        ncells = reinterpret_cast<T*>(bufPtr + offset);
-        this->m_Array[i].ncells = *ncells; // Set the number of cells in this link
-        offset += 2;
-        this->m_Array[i].cells = new K[(*ncells)]; // Allocate a new chunk of memory to store the list
-        ::memcpy(this->m_Array[i].cells, bufPtr + offset, (*ncells)*sizeof(K) ); // Copy from the buffer into the new list memory
-        offset += (*ncells) * sizeof(K); // Increment the offset
-      }
+  /**
+   * @brief size
+   * @return
+   */
+  size_t size()
+  {
+    return m_Size;
+  }
+
+  /**
+   * @brief deepCopy
+   * @param forceNoAllocate
+   * @return
+   */
+  DynamicListArray::Pointer deepCopy(bool forceNoAllocate = false)
+  {
+    DynamicListArray::Pointer copy = DynamicListArray::New();
+    std::vector<T> linkCounts(m_Size, 0);
+    if(forceNoAllocate)
+    {
+      copy->allocateLists(linkCounts);
+      return copy;
     }
 
-    /**
-     * @brief allocateLists
-     * @param linkCounts
-     */
-    void allocateLists(QVector<T>& linkCounts)
+    // Figure out how many entries, and for each entry, how many cells
+    for(size_t ptId = 0; ptId < m_Size; ptId++)
     {
-      allocate(linkCounts.size());
-      for (typename std::vector<T>::size_type i = 0; i < linkCounts.size(); i++)
+      linkCounts[ptId] = this->m_Array[ptId].ncells;
+    }
+    // Allocate all that in the copy
+    copy->allocateLists(linkCounts);
+    // Copy the data from the original to the new
+    for(size_t ptId = 0; ptId < m_Size; ptId++)
+    {
+      ElementList& elementList = getElementList(ptId);
+      copy->setElementList(ptId, elementList);
+    }
+    return copy;
+  }
+
+  /**
+   * @brief insertCellReference
+   * @param ptId
+   * @param pos
+   * @param cellId
+   */
+  inline void insertCellReference(size_t ptId, size_t pos, size_t cellId)
+  {
+    this->m_Array[ptId].cells[pos] = cellId;
+  }
+
+  /**
+   * @brief Get a link structure given a point id.
+   * @param ptId
+   * @return
+   */
+  ElementList& getElementList(size_t ptId)
+  {
+    return this->m_Array[ptId];
+  }
+
+  /**
+   * @brief setElementList
+   * @param ptId
+   * @param nCells
+   * @param data
+   * @return
+   */
+  bool setElementList(size_t ptId, T nCells, K* data)
+  {
+    if(ptId >= m_Size)
+    {
+      return false;
+    }
+    if(nullptr != m_Array[ptId].cells && m_Array[ptId].ncells > 0)
+    {
+      m_Array[ptId].cells = nullptr;
+      m_Array[ptId].ncells = 0;
+    }
+    m_Array[ptId].ncells = nCells;
+    // If nCells is huge then there could be problems with this
+    this->m_Array[ptId].cells = new K[nCells];
+    ::memcpy(m_Array[ptId].cells, data, sizeof(K) * nCells);
+    return true;
+  }
+
+  /**
+   * @brief setElementList
+   * @param ptId
+   * @param list
+   * @return
+   */
+  bool setElementList(size_t ptId, ElementList& list)
+  {
+    T nCells = list.ncells;
+    K* data = list.cells;
+    if(ptId >= m_Size)
+    {
+      return false;
+    }
+    if(nullptr != m_Array[ptId].cells && m_Array[ptId].ncells > 0)
+    {
+      m_Array[ptId].cells = nullptr;
+      m_Array[ptId].ncells = 0;
+    }
+    m_Array[ptId].ncells = nCells;
+    // If nCells is huge then there could be problems with this
+    this->m_Array[ptId].cells = new K[nCells];
+    ::memcpy(m_Array[ptId].cells, data, sizeof(K) * nCells);
+    return true;
+  }
+
+  /**
+   * @brief Get the number of cells using the point specified by ptId.
+   * @param ptId
+   * @return
+   */
+  T getNumberOfElements(size_t ptId)
+  {
+    return this->m_Array[ptId].ncells;
+  }
+
+  /**
+   * @brief Return a list of cell ids using the point.
+   * @param ptId
+   * @return
+   */
+  K* getElementListPointer(size_t ptId)
+  {
+    return this->m_Array[ptId].cells;
+  }
+
+  /**
+   * @brief deserializeLinks
+   * @param buffer
+   * @param nElements
+   */
+  void deserializeLinks(QVector<uint8_t>& buffer, size_t nElements)
+  {
+    size_t offset = 0;
+    allocate(nElements); // Allocate all the links with 0 and nullptr;
+    uint8_t* bufPtr = buffer.data();
+
+    // Walk the array and allocate all the array links to Zero and nullptr
+    T* ncells = nullptr;
+    for(size_t i = 0; i < nElements; ++i)
+    {
+      ncells = reinterpret_cast<T*>(bufPtr + offset);
+      this->m_Array[i].ncells = *ncells; // Set the number of cells in this link
+      offset += 2;
+      this->m_Array[i].cells = new K[(*ncells)];                                // Allocate a new chunk of memory to store the list
+      ::memcpy(this->m_Array[i].cells, bufPtr + offset, (*ncells) * sizeof(K)); // Copy from the buffer into the new list memory
+      offset += (*ncells) * sizeof(K);                                          // Increment the offset
+    }
+  }
+
+  /**
+   * @brief deserializeLinks
+   * @param buffer
+   * @param nElements
+   */
+  void deserializeLinks(std::vector<uint8_t>& buffer, size_t nElements)
+  {
+    size_t offset = 0;
+    allocate(nElements); // Allocate all the links with 0 and nullptr;
+    uint8_t* bufPtr = &(buffer.front());
+
+    // Walk the array and allocate all the array links to Zero and nullptr
+    T* ncells = nullptr;
+    // int32_t* cells = nullptr;
+    for(size_t i = 0; i < nElements; ++i)
+    {
+      ncells = reinterpret_cast<T*>(bufPtr + offset);
+      this->m_Array[i].ncells = *ncells; // Set the number of cells in this link
+      offset += 2;
+      this->m_Array[i].cells = new K[(*ncells)];                                // Allocate a new chunk of memory to store the list
+      ::memcpy(this->m_Array[i].cells, bufPtr + offset, (*ncells) * sizeof(K)); // Copy from the buffer into the new list memory
+      offset += (*ncells) * sizeof(K);                                          // Increment the offset
+    }
+  }
+
+  /**
+   * @brief allocateLists
+   * @param linkCounts
+   */
+  void allocateLists(QVector<T>& linkCounts)
+  {
+    allocate(linkCounts.size());
+    for(typename std::vector<T>::size_type i = 0; i < linkCounts.size(); i++)
+    {
+      this->m_Array[i].ncells = linkCounts[i];
+      this->m_Array[i].cells = new K[this->m_Array[i].ncells];
+    }
+  }
+
+  /**
+   * @brief allocateLists
+   * @param linkCounts
+   */
+  void allocateLists(std::vector<T>& linkCounts)
+  {
+    allocate(linkCounts.size());
+    for(typename std::vector<T>::size_type i = 0; i < linkCounts.size(); i++)
+    {
+      this->m_Array[i].ncells = linkCounts[i];
+      this->m_Array[i].cells = new K[this->m_Array[i].ncells];
+    }
+  }
+
+protected:
+  DynamicListArray()
+  : m_Array(nullptr)
+  , m_Size(0)
+  {
+  }
+
+  //----------------------------------------------------------------------------
+  // This will allocate memory to hold all the NeighborList structures where each
+  // structure is initialized to Zero Entries and a nullptr Pointer
+  void allocate(size_t sz, size_t ext = 1000)
+  {
+    static typename DynamicListArray<T, K>::ElementList linkInit = {0, nullptr};
+
+    // This makes sure we deallocate any lists that have been created
+    for(size_t i = 0; i < this->m_Size; i++)
+    {
+      if(this->m_Array[i].cells != nullptr)
       {
-        this->m_Array[i].ncells = linkCounts[i];
-        this->m_Array[i].cells = new K[this->m_Array[i].ncells];
+        delete[] this->m_Array[i].cells;
       }
     }
-
-    /**
-     * @brief allocateLists
-     * @param linkCounts
-     */
-    void allocateLists(std::vector<T>& linkCounts)
+    // Now delete all the "NeighborLists" structures
+    if(this->m_Array != nullptr)
     {
-      allocate(linkCounts.size());
-      for (typename std::vector<T>::size_type i = 0; i < linkCounts.size(); i++)
-      {
-        this->m_Array[i].ncells = linkCounts[i];
-        this->m_Array[i].cells = new K[this->m_Array[i].ncells];
-      }
+      delete[] this->m_Array;
     }
 
-  protected:
-    DynamicListArray() :
-      m_Array(nullptr),
-      m_Size(0)
-    {}
+    this->m_Size = sz;
+    // Allocate a whole new set of structures
+    this->m_Array = new typename DynamicListArray<T, K>::ElementList[sz];
 
-    //----------------------------------------------------------------------------
-    // This will allocate memory to hold all the NeighborList structures where each
-    // structure is initialized to Zero Entries and a nullptr Pointer
-    void allocate(size_t sz, size_t ext = 1000)
+    // Initialize each structure to have 0 entries and nullptr pointer.
+    for(size_t i = 0; i < sz; i++)
     {
-      static typename DynamicListArray<T, K>::ElementList linkInit = {0, nullptr};
-
-      // This makes sure we deallocate any lists that have been created
-      for (size_t i = 0; i < this->m_Size; i++)
-      {
-        if ( this->m_Array[i].cells != nullptr )
-        {
-          delete [] this->m_Array[i].cells;
-        }
-      }
-      // Now delete all the "NeighborLists" structures
-      if ( this->m_Array != nullptr )
-      {
-        delete [] this->m_Array;
-      }
-
-      this->m_Size = sz;
-      // Allocate a whole new set of structures
-      this->m_Array = new typename DynamicListArray<T, K>::ElementList[sz];
-
-      // Initialize each structure to have 0 entries and nullptr pointer.
-      for (size_t i = 0; i < sz; i++)
-      {
-        this->m_Array[i] = linkInit;
-      }
+      this->m_Array[i] = linkInit;
     }
+  }
 
-
-  private:
-    ElementList* m_Array;   // pointer to data
-    size_t m_Size;
-
-
+private:
+  ElementList* m_Array; // pointer to data
+  size_t m_Size;
 };
 
 typedef DynamicListArray<int32_t, int32_t> Int32Int32DynamicListArray;
 typedef DynamicListArray<uint16_t, int64_t> UInt16Int64DynamicListArray;
 typedef DynamicListArray<int64_t, int64_t> Int64Int64DynamicListArray;
 
-#endif /* _DynamicListArray_H_ */
-
+#endif /* _dynamicListArray_H_ */

--- a/Source/SIMPLib/DataContainers/AttributeMatrix.cpp
+++ b/Source/SIMPLib/DataContainers/AttributeMatrix.cpp
@@ -425,14 +425,14 @@ int AttributeMatrix::getNumAttributeArrays() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AttributeMatrix::Pointer AttributeMatrix::deepCopy()
+AttributeMatrix::Pointer AttributeMatrix::deepCopy(bool forceNoAllocate)
 {
   AttributeMatrix::Pointer newAttrMat = AttributeMatrix::New(getTupleDimensions(), getName(), getType());
 
   for(QMap<QString, IDataArray::Pointer>::iterator iter = m_AttributeArrays.begin(); iter != m_AttributeArrays.end(); ++iter)
   {
     IDataArray::Pointer d = iter.value();
-    IDataArray::Pointer new_d = d->deepCopy();
+    IDataArray::Pointer new_d = d->deepCopy(forceNoAllocate);
     if(new_d.get() == nullptr)
     {
       return AttributeMatrix::NullPointer();

--- a/Source/SIMPLib/DataContainers/AttributeMatrix.h
+++ b/Source/SIMPLib/DataContainers/AttributeMatrix.h
@@ -570,7 +570,7 @@ class SIMPLib_EXPORT AttributeMatrix : public Observable
     * @brief creates and returns a copy of the attribute matrix
     * @return On error, will return a null pointer.  It is the responsibility of the calling function to check for errors and return an error message using the PipelineMessage
     */
-    virtual AttributeMatrix::Pointer deepCopy();
+    virtual AttributeMatrix::Pointer deepCopy(bool forceNoAllocate);
 
     /**
      * @brief writeAttributeArraysToHDF5

--- a/Source/SIMPLib/DataContainers/DataContainer.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainer.cpp
@@ -398,20 +398,20 @@ int DataContainer::readAttributeMatricesFromHDF5(bool preflight, hid_t dcGid, co
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DataContainer::Pointer DataContainer::deepCopy()
+DataContainer::Pointer DataContainer::deepCopy(bool forceNoAllocate)
 {
   DataContainer::Pointer dcCopy = DataContainer::New(getName());
   dcCopy->setName(getName());
 
   if(m_Geometry.get() != nullptr)
   {
-    IGeometry::Pointer geomCopy = m_Geometry->deepCopy();
+    IGeometry::Pointer geomCopy = m_Geometry->deepCopy(forceNoAllocate);
     dcCopy->setGeometry(geomCopy);
   }
 
   for(AttributeMatrixMap_t::iterator iter = getAttributeMatrices().begin(); iter != getAttributeMatrices().end(); ++iter)
   {
-    AttributeMatrix::Pointer attrMat = (*iter)->deepCopy();
+    AttributeMatrix::Pointer attrMat = (*iter)->deepCopy(forceNoAllocate);
     dcCopy->addAttributeMatrix(attrMat->getName(), attrMat);
   }
 

--- a/Source/SIMPLib/DataContainers/DataContainer.h
+++ b/Source/SIMPLib/DataContainers/DataContainer.h
@@ -422,7 +422,7 @@ class SIMPLib_EXPORT DataContainer : public Observable
      * @brief creates copy of dataContainer
      * @return
      */
-    virtual DataContainer::Pointer deepCopy();
+    virtual DataContainer::Pointer deepCopy(bool forceNoAllocate);
 
     /**
      * @brief writeMeshToHDF5

--- a/Source/SIMPLib/DataContainers/DataContainerArray.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainerArray.cpp
@@ -247,7 +247,7 @@ void DataContainerArray::duplicateDataContainer(const QString& name, const QStri
     return;
   }
 
-  DataContainer::Pointer new_f = f->deepCopy();
+  DataContainer::Pointer new_f = f->deepCopy(false);
   new_f->setName(newName);
   addDataContainer(new_f);
 }
@@ -500,13 +500,13 @@ bool DataContainerArray::renameDataContainerBundle(const QString& oldName, const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DataContainerArray::Pointer DataContainerArray::deepCopy()
+DataContainerArray::Pointer DataContainerArray::deepCopy(bool forceNoAllocate)
 {
   DataContainerArray::Pointer dcaCopy = DataContainerArray::New();
   QList<DataContainer::Pointer> dcs = getDataContainers();
   for(int i = 0; i < dcs.size(); i++)
   {
-    DataContainer::Pointer dcCopy = dcs[i]->deepCopy();
+    DataContainer::Pointer dcCopy = dcs[i]->deepCopy(forceNoAllocate);
 #if 0
 
     // Deep copy geometry if applicable

--- a/Source/SIMPLib/DataContainers/DataContainerArray.h
+++ b/Source/SIMPLib/DataContainers/DataContainerArray.h
@@ -710,8 +710,7 @@ class SIMPLib_EXPORT DataContainerArray : public QObject
      * @param dca
      * @return
      */
-    DataContainerArray::Pointer deepCopy();
-
+    DataContainerArray::Pointer deepCopy(bool forceNoAllocate);
 
   protected:
     DataContainerArray();

--- a/Source/SIMPLib/Geometry/EdgeGeom.cpp
+++ b/Source/SIMPLib/Geometry/EdgeGeom.cpp
@@ -650,17 +650,25 @@ int EdgeGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IGeometry::Pointer EdgeGeom::deepCopy()
+IGeometry::Pointer EdgeGeom::deepCopy(bool forceNoAllocate)
 {
-  EdgeGeom::Pointer edgeCopy = EdgeGeom::CreateGeometry(getEdges(), getVertices(), getName());
+  SharedVertexList::Pointer verts = std::dynamic_pointer_cast<SharedVertexList>((getVertices().get() == nullptr) ? nullptr : getVertices()->deepCopy(forceNoAllocate));
+  SharedEdgeList::Pointer edges = std::dynamic_pointer_cast<SharedEdgeList>((getEdges().get() == nullptr) ? nullptr : getEdges()->deepCopy(forceNoAllocate));
+  ElementDynamicList::Pointer elementsContainingVert =
+      std::dynamic_pointer_cast<ElementDynamicList>((getElementsContainingVert().get() == nullptr) ? nullptr : getElementsContainingVert()->deepCopy(forceNoAllocate));
+  ElementDynamicList::Pointer elementNeighbors = std::dynamic_pointer_cast<ElementDynamicList>((getElementNeighbors().get() == nullptr) ? nullptr : getElementNeighbors()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer elementCentroids = std::dynamic_pointer_cast<FloatArrayType>((getElementCentroids().get() == nullptr) ? nullptr : getElementCentroids()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer elementSizes = std::dynamic_pointer_cast<FloatArrayType>((getElementSizes().get() == nullptr) ? nullptr : getElementSizes()->deepCopy(forceNoAllocate));
 
-  edgeCopy->setElementsContainingVert(getElementsContainingVert());
-  edgeCopy->setElementNeighbors(getElementNeighbors());
-  edgeCopy->setElementCentroids(getElementCentroids());
-  edgeCopy->setElementSizes(getElementSizes());
-  edgeCopy->setSpatialDimensionality(getSpatialDimensionality());
+  EdgeGeom::Pointer copy = EdgeGeom::CreateGeometry(edges, verts, getName());
 
-  return edgeCopy;
+  copy->setElementsContainingVert(elementsContainingVert);
+  copy->setElementNeighbors(elementNeighbors);
+  copy->setElementCentroids(elementCentroids);
+  copy->setElementSizes(elementSizes);
+  copy->setSpatialDimensionality(getSpatialDimensionality());
+
+  return copy;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/Geometry/EdgeGeom.h
+++ b/Source/SIMPLib/Geometry/EdgeGeom.h
@@ -329,7 +329,7 @@ class SIMPLib_EXPORT EdgeGeom : public IGeometry
      * @brief deepCopy
      * @return
      */
-    virtual IGeometry::Pointer deepCopy();
+    virtual IGeometry::Pointer deepCopy(bool forceNoAllocate = false) override;
 
     /**
      * @brief addAttributeMatrix

--- a/Source/SIMPLib/Geometry/IGeometry.h
+++ b/Source/SIMPLib/Geometry/IGeometry.h
@@ -327,7 +327,7 @@ class SIMPLib_EXPORT IGeometry : public Observable
      * @brief deepCopy
      * @return
      */
-    virtual Pointer deepCopy() = 0;
+    virtual Pointer deepCopy(bool forceNoAllocate = false) = 0;
 
     /**
      * @brief initializeWithZeros

--- a/Source/SIMPLib/Geometry/ImageGeom.cpp
+++ b/Source/SIMPLib/Geometry/ImageGeom.cpp
@@ -1002,7 +1002,7 @@ int ImageGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IGeometry::Pointer ImageGeom::deepCopy()
+IGeometry::Pointer ImageGeom::deepCopy(bool forceNoAllocate)
 {
   ImageGeom::Pointer imageCopy = ImageGeom::CreateGeometry(getName());
 
@@ -1015,7 +1015,8 @@ IGeometry::Pointer ImageGeom::deepCopy()
   imageCopy->setDimensions(volDims);
   imageCopy->setResolution(spacing);
   imageCopy->setOrigin(origin);
-  imageCopy->setElementSizes(getElementSizes());
+  FloatArrayType::Pointer elementSizes = std::dynamic_pointer_cast<FloatArrayType>((getElementSizes().get() == nullptr) ? nullptr : getElementSizes()->deepCopy(forceNoAllocate));
+  imageCopy->setElementSizes(elementSizes);
   imageCopy->setSpatialDimensionality(getSpatialDimensionality());
 
   return imageCopy;

--- a/Source/SIMPLib/Geometry/ImageGeom.h
+++ b/Source/SIMPLib/Geometry/ImageGeom.h
@@ -224,7 +224,7 @@ class SIMPLib_EXPORT ImageGeom : public IGeometryGrid
      * @brief deepCopy
      * @return
      */
-    virtual IGeometry::Pointer deepCopy();
+    virtual IGeometry::Pointer deepCopy(bool forceNoAllocate = false) override;
 
     /**
      * @brief addAttributeMatrix

--- a/Source/SIMPLib/Geometry/QuadGeom.cpp
+++ b/Source/SIMPLib/Geometry/QuadGeom.cpp
@@ -746,19 +746,29 @@ int QuadGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IGeometry::Pointer QuadGeom::deepCopy()
+IGeometry::Pointer QuadGeom::deepCopy(bool forceNoAllocate)
 {
-  QuadGeom::Pointer quadCopy = QuadGeom::CreateGeometry(getQuads(), getVertices(), getName());
+  SharedQuadList::Pointer quads = std::dynamic_pointer_cast<SharedQuadList>((getQuads().get() == nullptr) ? nullptr : getQuads()->deepCopy(forceNoAllocate));
+  SharedVertexList::Pointer verts = std::dynamic_pointer_cast<SharedVertexList>((getVertices().get() == nullptr) ? nullptr : getVertices()->deepCopy(forceNoAllocate));
+  SharedEdgeList::Pointer edges = std::dynamic_pointer_cast<SharedEdgeList>((getEdges().get() == nullptr) ? nullptr : getEdges()->deepCopy(forceNoAllocate));
+  SharedEdgeList::Pointer unsharedEdges = std::dynamic_pointer_cast<SharedEdgeList>((getUnsharedEdges().get() == nullptr) ? nullptr : getUnsharedEdges()->deepCopy(forceNoAllocate));
+  ElementDynamicList::Pointer elementsContainingVert =
+      std::dynamic_pointer_cast<ElementDynamicList>((getElementsContainingVert().get() == nullptr) ? nullptr : getElementsContainingVert()->deepCopy(forceNoAllocate));
+  ElementDynamicList::Pointer elementNeighbors = std::dynamic_pointer_cast<ElementDynamicList>((getElementNeighbors().get() == nullptr) ? nullptr : getElementNeighbors()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer elementCentroids = std::dynamic_pointer_cast<FloatArrayType>((getElementCentroids().get() == nullptr) ? nullptr : getElementCentroids()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer elementSizes = std::dynamic_pointer_cast<FloatArrayType>((getElementSizes().get() == nullptr) ? nullptr : getElementSizes()->deepCopy(forceNoAllocate));
 
-  quadCopy->setEdges(getEdges());
-  quadCopy->setUnsharedEdges(getUnsharedEdges());
-  quadCopy->setElementsContainingVert(getElementsContainingVert());
-  quadCopy->setElementNeighbors(getElementNeighbors());
-  quadCopy->setElementCentroids(getElementCentroids());
-  quadCopy->setElementSizes(getElementSizes());
-  quadCopy->setSpatialDimensionality(getSpatialDimensionality());
+  QuadGeom::Pointer copy = QuadGeom::CreateGeometry(quads, verts, getName());
 
-  return quadCopy;
+  copy->setEdges(edges);
+  copy->setUnsharedEdges(unsharedEdges);
+  copy->setElementsContainingVert(elementsContainingVert);
+  copy->setElementNeighbors(elementNeighbors);
+  copy->setElementCentroids(elementCentroids);
+  copy->setElementSizes(elementSizes);
+  copy->setSpatialDimensionality(getSpatialDimensionality());
+
+  return copy;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/Geometry/QuadGeom.h
+++ b/Source/SIMPLib/Geometry/QuadGeom.h
@@ -297,7 +297,7 @@ class SIMPLib_EXPORT QuadGeom : public IGeometry2D
      * @brief deepCopy
      * @return
      */
-    virtual IGeometry::Pointer deepCopy();
+    virtual IGeometry::Pointer deepCopy(bool forceNoAllocate = false) override;
 
     /**
      * @brief addAttributeMatrix

--- a/Source/SIMPLib/Geometry/RectGridGeom.cpp
+++ b/Source/SIMPLib/Geometry/RectGridGeom.cpp
@@ -1098,20 +1098,25 @@ int RectGridGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IGeometry::Pointer RectGridGeom::deepCopy()
+IGeometry::Pointer RectGridGeom::deepCopy(bool forceNoAllocate)
 {
-  RectGridGeom::Pointer rectGridCopy = RectGridGeom::CreateGeometry(getName());
+  FloatArrayType::Pointer xBounds = std::dynamic_pointer_cast<FloatArrayType>((getXBounds().get() == nullptr) ? nullptr : getXBounds()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer yBounds = std::dynamic_pointer_cast<FloatArrayType>((getYBounds().get() == nullptr) ? nullptr : getYBounds()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer zBounds = std::dynamic_pointer_cast<FloatArrayType>((getZBounds().get() == nullptr) ? nullptr : getZBounds()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer elementSizes = std::dynamic_pointer_cast<FloatArrayType>((getElementSizes().get() == nullptr) ? nullptr : getElementSizes()->deepCopy(forceNoAllocate));
+
+  RectGridGeom::Pointer copy = RectGridGeom::CreateGeometry(getName());
 
   size_t volDims[3] = { 0, 0, 0 };
   getDimensions(volDims);
-  rectGridCopy->setDimensions(volDims);
-  rectGridCopy->setXBounds(getXBounds());
-  rectGridCopy->setYBounds(getYBounds());
-  rectGridCopy->setZBounds(getZBounds());
-  rectGridCopy->setElementSizes(getElementSizes());
-  rectGridCopy->setSpatialDimensionality(getSpatialDimensionality());
+  copy->setDimensions(volDims);
+  copy->setXBounds(xBounds);
+  copy->setYBounds(yBounds);
+  copy->setZBounds(zBounds);
+  copy->setElementSizes(elementSizes);
+  copy->setSpatialDimensionality(getSpatialDimensionality());
 
-  return rectGridCopy;
+  return copy;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/Geometry/RectGridGeom.h
+++ b/Source/SIMPLib/Geometry/RectGridGeom.h
@@ -205,7 +205,7 @@ class SIMPLib_EXPORT RectGridGeom : public IGeometryGrid
      * @brief deepCopy
      * @return
      */
-    virtual IGeometry::Pointer deepCopy();
+    virtual IGeometry::Pointer deepCopy(bool forceNoAllocate = false) override;
 
     /**
      * @brief addAttributeMatrix

--- a/Source/SIMPLib/Geometry/TetrahedralGeom.cpp
+++ b/Source/SIMPLib/Geometry/TetrahedralGeom.cpp
@@ -850,21 +850,32 @@ int TetrahedralGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IGeometry::Pointer TetrahedralGeom::deepCopy()
+IGeometry::Pointer TetrahedralGeom::deepCopy(bool forceNoAllocate)
 {
-  TetrahedralGeom::Pointer tetCopy = TetrahedralGeom::CreateGeometry(getTetrahedra(), getVertices(), getName());
+  SharedTetList::Pointer tets = std::dynamic_pointer_cast<SharedTetList>((getTetrahedra().get() == nullptr) ? nullptr : getTetrahedra()->deepCopy(forceNoAllocate));
+  SharedVertexList::Pointer verts = std::dynamic_pointer_cast<SharedVertexList>((getVertices().get() == nullptr) ? nullptr : getVertices()->deepCopy(forceNoAllocate));
+  SharedTriList::Pointer tris = std::dynamic_pointer_cast<SharedTriList>((getTriangles().get() == nullptr) ? nullptr : getTriangles()->deepCopy(forceNoAllocate));
+  SharedEdgeList::Pointer edges = std::dynamic_pointer_cast<SharedEdgeList>((getEdges().get() == nullptr) ? nullptr : getEdges()->deepCopy(forceNoAllocate));
+  SharedEdgeList::Pointer unsharedEdges = std::dynamic_pointer_cast<SharedEdgeList>((getUnsharedEdges().get() == nullptr) ? nullptr : getUnsharedEdges()->deepCopy(forceNoAllocate));
+  ElementDynamicList::Pointer elementsContainingVert =
+      std::dynamic_pointer_cast<ElementDynamicList>((getElementsContainingVert().get() == nullptr) ? nullptr : getElementsContainingVert()->deepCopy(forceNoAllocate));
+  ElementDynamicList::Pointer elementNeighbors = std::dynamic_pointer_cast<ElementDynamicList>((getElementNeighbors().get() == nullptr) ? nullptr : getElementNeighbors()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer elementCentroids = std::dynamic_pointer_cast<FloatArrayType>((getElementCentroids().get() == nullptr) ? nullptr : getElementCentroids()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer elementSizes = std::dynamic_pointer_cast<FloatArrayType>((getElementSizes().get() == nullptr) ? nullptr : getElementSizes()->deepCopy(forceNoAllocate));
 
-  tetCopy->setEdges(getEdges());
-  tetCopy->setUnsharedEdges(getUnsharedEdges());
-  tetCopy->setTriangles(getTriangles());
-  tetCopy->setUnsharedFaces(getUnsharedFaces());
-  tetCopy->setElementsContainingVert(getElementsContainingVert());
-  tetCopy->setElementNeighbors(getElementNeighbors());
-  tetCopy->setElementCentroids(getElementCentroids());
-  tetCopy->setElementSizes(getElementSizes());
-  tetCopy->setSpatialDimensionality(getSpatialDimensionality());
+  TetrahedralGeom::Pointer copy = TetrahedralGeom::CreateGeometry(tets, verts, getName());
 
-  return tetCopy;
+  copy->setEdges(edges);
+  copy->setUnsharedEdges(unsharedEdges);
+  copy->setTriangles(tris);
+  copy->setUnsharedFaces(getUnsharedFaces());
+  copy->setElementsContainingVert(elementsContainingVert);
+  copy->setElementNeighbors(elementNeighbors);
+  copy->setElementCentroids(elementCentroids);
+  copy->setElementSizes(elementSizes);
+  copy->setSpatialDimensionality(getSpatialDimensionality());
+
+  return copy;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/Geometry/TetrahedralGeom.h
+++ b/Source/SIMPLib/Geometry/TetrahedralGeom.h
@@ -361,7 +361,7 @@ class SIMPLib_EXPORT TetrahedralGeom : public IGeometry3D
      * @brief deepCopy
      * @return
      */
-    virtual IGeometry::Pointer deepCopy();
+    virtual IGeometry::Pointer deepCopy(bool forceNoAllocate = false) override;
 
     /**
      * @brief addAttributeMatrix

--- a/Source/SIMPLib/Geometry/TriangleGeom.cpp
+++ b/Source/SIMPLib/Geometry/TriangleGeom.cpp
@@ -744,19 +744,29 @@ int TriangleGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IGeometry::Pointer TriangleGeom::deepCopy()
+IGeometry::Pointer TriangleGeom::deepCopy(bool forceNoAllocate)
 {
-  TriangleGeom::Pointer triCopy = TriangleGeom::CreateGeometry(getTriangles(), getVertices(), getName());
+  SharedTriList::Pointer tris = std::dynamic_pointer_cast<SharedTriList>((getTriangles().get() == nullptr) ? nullptr : getTriangles()->deepCopy(forceNoAllocate));
+  SharedVertexList::Pointer verts = std::dynamic_pointer_cast<SharedVertexList>((getVertices().get() == nullptr) ? nullptr : getVertices()->deepCopy(forceNoAllocate));
+  SharedEdgeList::Pointer edges = std::dynamic_pointer_cast<SharedEdgeList>((getEdges().get() == nullptr) ? nullptr : getEdges()->deepCopy(forceNoAllocate));
+  SharedEdgeList::Pointer unsharedEdges = std::dynamic_pointer_cast<SharedEdgeList>((getUnsharedEdges().get() == nullptr) ? nullptr : getUnsharedEdges()->deepCopy(forceNoAllocate));
+  ElementDynamicList::Pointer elementsContainingVert =
+      std::dynamic_pointer_cast<ElementDynamicList>((getElementsContainingVert().get() == nullptr) ? nullptr : getElementsContainingVert()->deepCopy(forceNoAllocate));
+  ElementDynamicList::Pointer elementNeighbors = std::dynamic_pointer_cast<ElementDynamicList>((getElementNeighbors().get() == nullptr) ? nullptr : getElementNeighbors()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer elementCentroids = std::dynamic_pointer_cast<FloatArrayType>((getElementCentroids().get() == nullptr) ? nullptr : getElementCentroids()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer elementSizes = std::dynamic_pointer_cast<FloatArrayType>((getElementSizes().get() == nullptr) ? nullptr : getElementSizes()->deepCopy(forceNoAllocate));
 
-  triCopy->setEdges(getEdges());
-  triCopy->setUnsharedEdges(getUnsharedEdges());
-  triCopy->setElementsContainingVert(getElementsContainingVert());
-  triCopy->setElementNeighbors(getElementNeighbors());
-  triCopy->setElementCentroids(getElementCentroids());
-  triCopy->setElementSizes(getElementSizes());
-  triCopy->setSpatialDimensionality(getSpatialDimensionality());
+  TriangleGeom::Pointer copy = TriangleGeom::CreateGeometry(tris, verts, getName());
 
-  return triCopy;
+  copy->setEdges(edges);
+  copy->setUnsharedEdges(unsharedEdges);
+  copy->setElementsContainingVert(elementsContainingVert);
+  copy->setElementNeighbors(elementNeighbors);
+  copy->setElementCentroids(elementCentroids);
+  copy->setElementSizes(elementSizes);
+  copy->setSpatialDimensionality(getSpatialDimensionality());
+
+  return copy;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/Geometry/TriangleGeom.h
+++ b/Source/SIMPLib/Geometry/TriangleGeom.h
@@ -296,7 +296,7 @@ class SIMPLib_EXPORT TriangleGeom : public IGeometry2D
      * @brief deepCopy
      * @return
      */
-    virtual IGeometry::Pointer deepCopy();
+    virtual IGeometry::Pointer deepCopy(bool forceNoAllocate = false) override;
 
     /**
      * @brief addAttributeMatrix

--- a/Source/SIMPLib/Geometry/VertexGeom.cpp
+++ b/Source/SIMPLib/Geometry/VertexGeom.cpp
@@ -454,11 +454,13 @@ int VertexGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IGeometry::Pointer VertexGeom::deepCopy()
+IGeometry::Pointer VertexGeom::deepCopy(bool forceNoAllocate)
 {
-  VertexGeom::Pointer vertexCopy = VertexGeom::CreateGeometry(getVertices(), getName());
+  SharedVertexList::Pointer verts = std::dynamic_pointer_cast<SharedVertexList>((getVertices().get() == nullptr) ? nullptr : getVertices()->deepCopy(forceNoAllocate));
+  FloatArrayType::Pointer elementSizes = std::dynamic_pointer_cast<FloatArrayType>((getElementSizes().get() == nullptr) ? nullptr : getElementSizes()->deepCopy(forceNoAllocate));
 
-  vertexCopy->setElementSizes(getElementSizes());
+  VertexGeom::Pointer vertexCopy = VertexGeom::CreateGeometry(verts, getName());
+  vertexCopy->setElementSizes(elementSizes);
   vertexCopy->setSpatialDimensionality(getSpatialDimensionality());
 
   return vertexCopy;

--- a/Source/SIMPLib/Geometry/VertexGeom.h
+++ b/Source/SIMPLib/Geometry/VertexGeom.h
@@ -266,7 +266,7 @@ class SIMPLib_EXPORT VertexGeom : public IGeometry
      * @brief deepCopy
      * @return
      */
-    virtual IGeometry::Pointer deepCopy();
+    virtual IGeometry::Pointer deepCopy(bool forceNoAllocate = false) override;
 
     /**
      * @brief addAttributeMatrix

--- a/Source/SVWidgetsLib/Widgets/DataBrowserWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/DataBrowserWidget.cpp
@@ -96,7 +96,7 @@ void DataBrowserWidget::setupGui()
 // -----------------------------------------------------------------------------
 void DataBrowserWidget::updateDataContainerArray(DataContainerArray::Pointer dca)
 {
-  m_Dca = dca->deepCopy();
+  m_Dca = dca->deepCopy(true);
   refreshData();
 }
 
@@ -243,7 +243,7 @@ void DataBrowserWidget::filterObjectActivated(PipelineFilterObject* object)
       DataContainerArray::Pointer dca = filter->getDataContainerArray();
       if(dca.get())
       {
-        m_Dca = dca->deepCopy();
+        m_Dca = dca->deepCopy(true);
       }
     }
   }

--- a/Test/DataContainerBundleTest.cpp
+++ b/Test/DataContainerBundleTest.cpp
@@ -105,10 +105,10 @@ public:
     AttributeMatrix::Pointer metaAm = AttributeMatrix::New(tupleDims, DataContainerBundle::GetMetaDataName(), AttributeMatrix::Type::MetaData);
     dc0->addAttributeMatrix(metaAm->getName(), metaAm);
 
-    DataContainer::Pointer dc1 = dc0->deepCopy();
+    DataContainer::Pointer dc1 = dc0->deepCopy(false);
     dc1->setName("DC 1");
 
-    DataContainer::Pointer dc2 = dc0->deepCopy();
+    DataContainer::Pointer dc2 = dc0->deepCopy(false);
     dc2->setName("DC 2");
     // remove an array so that we have something different
     dc2->getAttributeMatrix("CellAttributeMatrix")->removeAttributeArray("Uint8 Array");


### PR DESCRIPTION
These methods appear in DataContainerArray, DataContainer, AttributeMatrix,
IDataArray and subclasses and IGeometry and subclasses. Update other areas
of the codes that use this method.

updates #48