### PR TITLE
Implement a LinkedDataContainerSelectionWidget

### DIFF
--- a/Source/SIMPLib/FilterParameters/LinkedDataContainerSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/LinkedDataContainerSelectionFilterParameter.cpp
@@ -1,0 +1,105 @@
+/* ============================================================================
+* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-07-D-5800
+*    United States Air Force Prime Contract FA8650-10-D-5210
+*    United States Prime Contract Navy N00173-07-C-2068
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "LinkedDataContainerSelectionFilterParameter.h"
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+LinkedDataContainerSelectionFilterParameter::LinkedDataContainerSelectionFilterParameter()
+: FilterParameter()
+{
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+LinkedDataContainerSelectionFilterParameter::~LinkedDataContainerSelectionFilterParameter()
+{
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+LinkedDataContainerSelectionFilterParameter::Pointer LinkedDataContainerSelectionFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category,
+                                                                        SetterCallbackType setterCallback, GetterCallbackType getterCallback, const RequirementType req, QStringList linkedProperties,
+                                                                        int groupIndex)
+{
+  LinkedDataContainerSelectionFilterParameter::Pointer ptr = LinkedDataContainerSelectionFilterParameter::New();
+  ptr->setHumanLabel(humanLabel);
+  ptr->setPropertyName(propertyName);
+  QVariant v;
+  v.setValue(defaultValue);
+  ptr->setDefaultValue(v);
+  ptr->setCategory(category);
+  ptr->setDefaultGeometryTypes(req.dcGeometryTypes);
+  ptr->setLinkedProperties(linkedProperties);
+  ptr->setGroupIndex(groupIndex);
+  ptr->setSetterCallback(setterCallback);
+  ptr->setGetterCallback(getterCallback);
+
+  return ptr;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString LinkedDataContainerSelectionFilterParameter::getWidgetType()
+{
+  return QString("LinkedDataContainerSelectionWidget");
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionFilterParameter::readJson(const QJsonObject& json)
+{
+  QJsonValue jsonValue = json[getPropertyName()];
+  if(!jsonValue.isUndefined() && m_SetterCallback)
+  {
+    m_SetterCallback(jsonValue.toString(""));
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionFilterParameter::writeJson(QJsonObject& json)
+{
+  if(m_GetterCallback)
+  {
+    json[getPropertyName()] = m_GetterCallback();
+  }
+}

--- a/Source/SIMPLib/FilterParameters/LinkedDataContainerSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/LinkedDataContainerSelectionFilterParameter.h
@@ -1,0 +1,151 @@
+/* ============================================================================
+* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-07-D-5800
+*    United States Air Force Prime Contract FA8650-10-D-5210
+*    United States Prime Contract Navy N00173-07-C-2068
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#ifndef _linkeddatacontainerselectionfilterparameter_h_
+#define _linkeddatacontainerselectionfilterparameter_h_
+
+#include <QtCore/QJsonObject>
+
+#include "SIMPLib/FilterParameters/FilterParameter.h"
+#include "SIMPLib/Geometry/IGeometry.h"
+
+// FP: Documentation incomplete because there isn't currently a way to instantiate this filter parameter
+//     in one line.
+/**
+ * @brief SIMPL_NEW_LINKED_DC_SELECTION_FP This macro is a short-form way of instantiating an instance of
+ * LinkedChoicesFilterParameter. There are 6 required parameters and 1 optional parameter
+ * that are always passed to this macro in the following order: HumanLabel, PropertyName, Category,
+ * FilterName (class name), Choices, LinkedProperties, GroupIndex (optional).
+ */
+#define SIMPL_NEW_LINKED_DC_SELECTION_FP(...) \
+  SIMPL_EXPAND(_FP_GET_OVERRIDE(__VA_ARGS__, \
+  SIMPL_NEW_FP_9, SIMPL_NEW_FP_8, SIMPL_NEW_FP_7, SIMPL_NEW_FP_6, SIMPL_NEW_FP_5, SIMPL_NEW_FP_4)\
+  (LinkedDataContainerSelectionFilterParameter, __VA_ARGS__))
+
+/**
+ * @brief The LinkedDataContainerSelectionFilterParameter class is used by filters to instantiate a LinkedDataContainerSelectionWidget.  By instantiating an instance of
+ * this class in a filter's setupFilterParameters() method, a LinkedDataContainerSelectionWidget will appear in the filter's "filter input" section in the DREAM3D GUI.
+ */
+class SIMPLib_EXPORT LinkedDataContainerSelectionFilterParameter : public FilterParameter
+{
+  public:
+    SIMPL_SHARED_POINTERS(LinkedDataContainerSelectionFilterParameter)
+    SIMPL_STATIC_NEW_MACRO(LinkedDataContainerSelectionFilterParameter)
+    SIMPL_TYPE_MACRO_SUPER(LinkedDataContainerSelectionFilterParameter, FilterParameter)
+
+    typedef std::function<void(QString)> SetterCallbackType;
+    typedef std::function<QString(void)> GetterCallbackType;
+    
+    typedef struct
+    {
+      IGeometry::Types dcGeometryTypes;
+    } RequirementType;
+
+    /**
+     * @brief New This function instantiates an instance of the LinkedDataContainerSelectionFilterParameter. This function must be used to instantiate the class; the 
+     * SIMPL_NEW_LINKED_DC_SELECTION_FP macro does not properly instantiate the class, so this static New method must be used.
+     *
+     * @param humanLabel The name that the users of DREAM.3D see for this filter parameter
+     * @param propertyName The internal property name for this filter parameter.
+     * @param defaultValue The value that this filter parameter will be initialized to by default.
+     * @param category The category for the filter parameter in the DREAM.3D user interface.  There
+     * are three categories: Parameter, Required Arrays, and Created Arrays.
+     * @param setterCallback The method in the AbstractFilter subclass that <i>sets</i> the value of the property
+     * that this FilterParameter subclass represents.
+     * @param getterCallback The method in the AbstractFilter subclass that <i>gets</i> the value of the property
+     * that this FilterParameter subclass represents.
+     * @param choices The selections that appear in the LinkedChoicesWidget.
+     * @param linkedProperties The properties that appear/disappear when a selection is chosen.
+     * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
+     * @return
+     */
+    static Pointer New(const QString& humanLabel, const QString& propertyName,
+                       const QString& defaultValue, Category category,
+                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                       const RequirementType req, QStringList linkedProperties,
+                       int groupIndex = -1);
+
+    virtual ~LinkedDataContainerSelectionFilterParameter();
+
+    SIMPL_INSTANCE_PROPERTY(QStringList, LinkedProperties)
+    SIMPL_INSTANCE_PROPERTY(IGeometry::Types, DefaultGeometryTypes)
+
+    /**
+     * @brief getWidgetType Returns the type of widget that displays and controls
+     * this FilterParameter subclass
+     * @return
+     */
+    QString getWidgetType();
+
+    /**
+     * @brief readJson Reads this filter parameter's corresponding property out of a QJsonObject.
+     * @param json The QJsonObject that the filter parameter reads from.
+     */
+    void readJson(const QJsonObject &json);
+
+    /**
+     * @brief writeJson Writes this filter parameter's corresponding property to a QJsonObject.
+     * @param json The QJsonObject that the filter parameter writes to.
+     */
+    void writeJson(QJsonObject &json);
+
+    /**
+    * @param SetterCallback The method in the AbstractFilter subclass that <i>sets</i> the value of the property
+    * that this FilterParameter subclass represents.
+    * from the filter parameter.
+    */
+    SIMPL_INSTANCE_PROPERTY(SetterCallbackType, SetterCallback)
+
+    /**
+    * @param GetterCallback The method in the AbstractFilter subclass that <i>gets</i> the value of the property
+    * that this FilterParameter subclass represents.
+    * @return The GetterCallback
+    */
+    SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
+
+
+  protected:
+      /**
+       * @brief LinkedDataContainerSelectionFilterParameter The default constructor.  It is protected because this
+       * filter parameter should only be instantiated using its New(...) function or short-form macro.
+       */
+    LinkedDataContainerSelectionFilterParameter();
+
+  private:
+    LinkedDataContainerSelectionFilterParameter(const LinkedDataContainerSelectionFilterParameter&); // Copy Constructor Not Implemented
+    void operator=(const LinkedDataContainerSelectionFilterParameter&); // Operator '=' Not Implemented
+};
+
+#endif /* _linkeddatacontainerselectionfilterparameter_h_ */

--- a/Source/SIMPLib/FilterParameters/SourceList.cmake
+++ b/Source/SIMPLib/FilterParameters/SourceList.cmake
@@ -86,6 +86,7 @@ set(SIMPLib_${SUBDIR_NAME}_HDRS
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/JsonFilterParametersWriter.h
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/LinkedBooleanFilterParameter.h
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/LinkedChoicesFilterParameter.h
+  ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/LinkedDataContainerSelectionFilterParameter.h
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/MultiDataArraySelectionFilterParameter.h
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/NumericTypeFilterParameter.h
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/OutputFileFilterParameter.h
@@ -143,6 +144,7 @@ set(SIMPLib_${SUBDIR_NAME}_SRCS
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/JsonFilterParametersWriter.cpp
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/LinkedBooleanFilterParameter.cpp
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/LinkedChoicesFilterParameter.cpp
+  ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/LinkedDataContainerSelectionFilterParameter.cpp
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/MultiDataArraySelectionFilterParameter.cpp
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/NumericTypeFilterParameter.cpp
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/OutputFileFilterParameter.cpp

--- a/Source/SVWidgetsLib/FilterParameterWidgets/LinkedDataContainerSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/LinkedDataContainerSelectionWidget.cpp
@@ -1,0 +1,355 @@
+/* ============================================================================
+* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-07-D-5800
+*    United States Air Force Prime Contract FA8650-10-D-5210
+*    United States Prime Contract Navy N00173-07-C-2068
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "LinkedDataContainerSelectionWidget.h"
+
+#include <QtCore/QList>
+#include <QtCore/QMetaProperty>
+#include <QtCore/QSignalMapper>
+
+#include <QtGui/QStandardItemModel>
+
+#include <QtWidgets/QListWidgetItem>
+#include <QtWidgets/QMenu>
+
+#include "SIMPLib/DataContainers/DataArrayPath.h"
+#include "SVWidgetsLib/Core/SVWidgetsLibConstants.h"
+#include "SVWidgetsLib/QtSupport/QtSStyles.h"
+
+#include "SVWidgetsLib/FilterParameterWidgets/FilterParameterWidgetUtils.hpp"
+#include "SVWidgetsLib/FilterParameterWidgets/FilterParameterWidgetsDialogs.h"
+
+// Include the MOC generated file for this class
+#include "moc_LinkedDataContainerSelectionWidget.cpp"
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+LinkedDataContainerSelectionWidget::LinkedDataContainerSelectionWidget(FilterParameter* parameter, AbstractFilter* filter, QWidget* parent)
+: FilterParameterWidget(parameter, filter, parent)
+, m_DidCausePreflight(false)
+{
+  m_FilterParameter = dynamic_cast<LinkedDataContainerSelectionFilterParameter*>(parameter);
+  Q_ASSERT_X(m_FilterParameter != nullptr, "NULL Pointer", "LinkedDataContainerSelectionWidget can ONLY be used with a LinkedDataContainerSelectionFilterParameter object");
+
+  setupUi(this);
+  setupGui();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+LinkedDataContainerSelectionWidget::LinkedDataContainerSelectionWidget(QWidget* parent)
+: FilterParameterWidget(nullptr, nullptr, parent)
+, m_DidCausePreflight(false)
+{
+  setupUi(this);
+  setupGui();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+LinkedDataContainerSelectionWidget::~LinkedDataContainerSelectionWidget()
+{
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionWidget::initializeWidget(FilterParameter* parameter, AbstractFilter* filter)
+{
+  setFilter(filter);
+  setFilterParameter(parameter);
+  setupGui();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionWidget::setupGui()
+{
+  if(getFilter() == nullptr)
+  {
+    return;
+  }
+  // Catch when the filter is about to execute the preflight
+  connect(getFilter(), SIGNAL(preflightAboutToExecute()), this, SLOT(beforePreflight()));
+
+  // Catch when the filter is finished running the preflight
+  connect(getFilter(), SIGNAL(preflightExecuted()), this, SLOT(afterPreflight()));
+
+  // Catch when the filter wants its values updated
+  connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
+
+  if(getFilterParameter() == nullptr)
+  {
+    return;
+  }
+  label->setText(getFilterParameter()->getHumanLabel());
+
+  m_SelectedDataContainerPath->setStyleSheet(QtSStyles::QToolSelectionButtonStyle(false));
+
+  m_MenuMapper = new QSignalMapper(this);
+  connect(m_MenuMapper, SIGNAL(mapped(QString)),
+            this, SLOT(dataContainerSelected(QString)));
+
+  QString dcName = getFilter()->property(PROPERTY_NAME_AS_CHAR).value<QString>();
+  m_SelectedDataContainerPath->setText(dcName);
+
+  changeStyleSheet(Style::FS_STANDARD_STYLE);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionWidget::widgetChanged()
+{
+  int index = 0;
+  DataContainerArray::Pointer dca = getFilter()->getDataContainerArray();
+  IGeometry::Pointer igeom = dca->getPrereqGeometryFromDataContainer<IGeometry, AbstractFilter>(nullptr, m_SelectedDataContainerPath->text());
+  
+  if(igeom)
+  {
+    index = static_cast<int32_t>(igeom->getGeometryType());
+  }
+
+  emit conditionalPropertyChanged(index);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString LinkedDataContainerSelectionWidget::checkStringValues(QString curDcName, QString filtDcName)
+{
+  if(curDcName.isEmpty() == true && filtDcName.isEmpty() == false)
+  {
+    return filtDcName;
+  }
+  else if(curDcName.isEmpty() == false && filtDcName.isEmpty() == true)
+  {
+    return curDcName;
+  }
+  else if(curDcName.isEmpty() == false && filtDcName.isEmpty() == false && m_DidCausePreflight == true)
+  {
+    return curDcName;
+  }
+
+  return filtDcName;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionWidget::createSelectionMenu()
+{
+  // Now get the DataContainerArray from the Filter instance
+  // We are going to use this to get all the current DataContainers
+  DataContainerArray::Pointer dca = getFilter()->getDataContainerArray();
+  if(nullptr == dca.get())
+  {
+    return;
+  }
+
+  // Get the menu and clear it out
+  QMenu* menu = m_SelectedDataContainerPath->menu();
+  if(!menu)
+  {
+    menu = new QMenu();
+    m_SelectedDataContainerPath->setMenu(menu);
+    menu->installEventFilter(this);
+  }
+  if(menu)
+  {
+    menu->clear();
+  }
+
+  // Get the DataContainerArray object
+  // Loop over the data containers until we find the proper data container
+  QList<DataContainer::Pointer> containers = dca->getDataContainers();
+  IGeometry::Types geomTypes = m_FilterParameter->getDefaultGeometryTypes();
+
+  QListIterator<DataContainer::Pointer> containerIter(containers);
+  while(containerIter.hasNext())
+  {
+    DataContainer::Pointer dc = containerIter.next();
+
+    IGeometry::Pointer geom = IGeometry::NullPointer();
+    IGeometry::Type geomType = IGeometry::Type::Unknown;
+    if(nullptr != dc.get())
+    {
+      geom = dc->getGeometry();
+    }
+    if(nullptr != geom.get())
+    {
+      geomType = geom->getGeometryType();
+    }
+
+    QString dcName = dc->getName();
+    QAction* action = new QAction(dcName, menu);
+    DataArrayPath dcPath(dcName, "", "");
+    QString path = dcPath.serialize(Detail::Delimiter);
+    action->setData(path);
+
+    connect(action, SIGNAL(triggered(bool)), m_MenuMapper, SLOT(map()));
+    m_MenuMapper->setMapping(action, path);
+    menu->addAction(action);
+
+    if(geomTypes.isEmpty() == false && geomTypes.contains(geomType) == false)
+    {
+      action->setDisabled(true);
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+bool LinkedDataContainerSelectionWidget::eventFilter(QObject* obj, QEvent* event)
+{
+  if(event->type() == QEvent::Show && obj == m_SelectedDataContainerPath->menu())
+  {
+    QPoint pos = adjustedMenuPosition(m_SelectedDataContainerPath);
+    m_SelectedDataContainerPath->menu()->move(pos);
+    return true;
+  }
+  return false;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionWidget::dataContainerSelected(QString path)
+{
+  setSelectedPath(path);
+
+  m_DidCausePreflight = true;
+  widgetChanged();
+  emit parametersChanged();
+  m_DidCausePreflight = false;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionWidget::setSelectedPath(QString path)
+{
+  DataArrayPath dcPath = DataArrayPath::Deserialize(path, Detail::Delimiter);
+  setSelectedPath(dcPath);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionWidget::setSelectedPath(DataArrayPath dcPath)
+{
+  if (dcPath.isEmpty()) { return; }
+
+  m_SelectedDataContainerPath->setText("");
+  m_SelectedDataContainerPath->setToolTip("");
+
+  DataContainerArray::Pointer dca = getFilter()->getDataContainerArray();
+  if(nullptr == dca.get())
+  {
+    return;
+  }
+
+  if (dca->doesDataContainerExist(dcPath.getDataContainerName()))
+  {
+    DataContainer::Pointer dc = dca->getDataContainer(dcPath.getDataContainerName());
+    QString html = dc->getInfoString(SIMPL::HtmlFormat);
+    m_SelectedDataContainerPath->setToolTip(html);
+    m_SelectedDataContainerPath->setText(dcPath.getDataContainerName());
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionWidget::beforePreflight()
+{
+  if(nullptr == getFilter())
+  {
+    return;
+  }
+  if(m_DidCausePreflight == true)
+  {
+    // std::cout << "***  DataContainerSelectionWidget already caused a preflight, just returning" << std::endl;
+    return;
+  }
+
+  createSelectionMenu();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionWidget::afterPreflight()
+{
+  DataContainerArray::Pointer dca = getFilter()->getDataContainerArray();
+  if (NULL == dca.get()) { return; }
+
+  if (dca->doesDataContainerExist(m_SelectedDataContainerPath->text()))
+  {
+    DataContainer::Pointer dc = dca->getDataContainer(m_SelectedDataContainerPath->text());
+    if (nullptr != dc.get()) {
+      QString html = dc->getInfoString(SIMPL::HtmlFormat);
+      m_SelectedDataContainerPath->setToolTip(html);
+      m_SelectedDataContainerPath->setStyleSheet(QtSStyles::QToolSelectionButtonStyle(true));
+    }
+  }
+  else
+  {
+    m_SelectedDataContainerPath->setStyleSheet(QtSStyles::QToolSelectionButtonStyle(false));
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void LinkedDataContainerSelectionWidget::filterNeedsInputParameters(AbstractFilter* filter)
+{
+  // Generate the path to the AttributeArray
+  // DataArrayPath path(dataContainerList->currentText(), attributeMatrixList->currentText(), attributeArrayList->currentText());
+  QVariant var(m_SelectedDataContainerPath->text());
+  // var.setValue(path);
+  bool ok = false;
+  // Set the value into the Filter
+  ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
+  if(false == ok)
+  {
+    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+  }
+}

--- a/Source/SVWidgetsLib/FilterParameterWidgets/LinkedDataContainerSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/LinkedDataContainerSelectionWidget.cpp
@@ -137,7 +137,7 @@ void LinkedDataContainerSelectionWidget::setupGui()
 // -----------------------------------------------------------------------------
 void LinkedDataContainerSelectionWidget::widgetChanged()
 {
-  int index = 0;
+  int index = -1;
   DataContainerArray::Pointer dca = getFilter()->getDataContainerArray();
   IGeometry::Pointer igeom = dca->getPrereqGeometryFromDataContainer<IGeometry, AbstractFilter>(nullptr, m_SelectedDataContainerPath->text());
   

--- a/Source/SVWidgetsLib/FilterParameterWidgets/LinkedDataContainerSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/LinkedDataContainerSelectionWidget.h
@@ -1,0 +1,136 @@
+/* ============================================================================
+* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-07-D-5800
+*    United States Air Force Prime Contract FA8650-10-D-5210
+*    United States Prime Contract Navy N00173-07-C-2068
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#ifndef _linkeddatacontainerselectionwidget_h_
+#define _linkeddatacontainerselectionwidget_h_
+
+#include <QtCore/QObject>
+#include <QtCore/QPointer>
+#include <QtWidgets/QWidget>
+
+#include "SIMPLib/Common/AbstractFilter.h"
+#include "SIMPLib/DataContainers/DataContainerArrayProxy.h"
+
+#include "SVWidgetsLib/QtSupport/QtSFaderWidget.h"
+#include "SVWidgetsLib/SVWidgetsLib.h"
+#include "SVWidgetsLib/FilterParameterWidgets/FilterParameterWidget.h"
+
+#include "SIMPLib/FilterParameters/LinkedDataContainerSelectionFilterParameter.h"
+
+#include "ui_LinkedDataContainerSelectionWidget.h"
+
+class QSignalMapper;
+
+/**
+* @brief
+* @author
+* @version
+*/
+class SVWidgetsLib_EXPORT LinkedDataContainerSelectionWidget : public FilterParameterWidget, private Ui::LinkedDataContainerSelectionWidget
+{
+    Q_OBJECT
+  public:
+    /**
+    * @brief Constructor
+    * @param parameter The FilterParameter object that this widget represents
+    * @param filter The instance of the filter that this parameter is a part of
+    * @param parent The parent QWidget for this Widget
+    */
+    LinkedDataContainerSelectionWidget(FilterParameter* parameter, AbstractFilter* filter = nullptr, QWidget* parent = nullptr);
+
+    LinkedDataContainerSelectionWidget(QWidget* parent = nullptr);
+
+    virtual ~LinkedDataContainerSelectionWidget();
+
+    /**
+    * @brief This method does additional GUI widget connections
+    */
+    void setupGui();
+
+    /**
+     * @brief checkStringValues
+     * @param current
+     * @param filt
+     * @return
+     */
+    QString checkStringValues(QString current, QString filtDcName);
+
+    /**
+     * @brief initializeWidget
+     * @param parameter
+     * @param filter
+     */
+    void initializeWidget(FilterParameter* parameter, AbstractFilter* filter);
+
+    /**
+     * @brief eventFilter
+     * @param obj
+     * @param event
+     * @return
+     */
+    bool eventFilter(QObject* obj, QEvent* event);
+
+  public slots:
+    void widgetChanged();
+    void beforePreflight();
+    void afterPreflight();
+    void filterNeedsInputParameters(AbstractFilter* filter);
+    void dataContainerSelected(QString path);
+
+  signals:
+    void errorSettingFilterParameter(const QString& msg);
+    void parametersChanged();
+    void conditionalPropertyChanged(int);
+
+  protected:
+    /**
+     * @brief createSelectionMenu
+     */
+    void createSelectionMenu();
+
+  private:
+    bool m_DidCausePreflight;
+    LinkedDataContainerSelectionFilterParameter* m_FilterParameter;
+    QPointer<QSignalMapper> m_MenuMapper;
+    void setSelectedPath(QString path);
+    void setSelectedPath(DataArrayPath dcPath);
+
+    LinkedDataContainerSelectionWidget(const LinkedDataContainerSelectionWidget&); // Copy Constructor Not Implemented
+    void operator=(const LinkedDataContainerSelectionWidget&); // Operator '=' Not Implemented
+};
+
+#endif /* _linkeddatacontainerselectionwidget_h_ */
+
+

--- a/Source/SVWidgetsLib/FilterParameterWidgets/SourceList.cmake
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/SourceList.cmake
@@ -53,6 +53,7 @@ set(SIMPLView_PARAMETER_WIDGETS_NO_UI
 set(SIMPLView_PARAMETER_WIDGETS_NO_CODEGEN
   AbstractIOFileWidget
   CalculatorWidget
+  LinkedDataContainerSelectionWidget
   PhaseTypeSelectionWidget
   ReadASCIIDataWidget
   ShapeTypeSelectionWidget

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/LinkedDataContainerSelectionWidget.ui
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/LinkedDataContainerSelectionWidget.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LinkedDataContainerSelectionWidget</class>
+ <widget class="QFrame" name="LinkedDataContainerSelectionWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>551</width>
+    <height>33</height>
+   </rect>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Property</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="m_SelectedDataContainerPath">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="popupMode">
+      <enum>QToolButton::InstantPopup</enum>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonTextBesideIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Source/SVWidgetsLib/Widgets/FilterInputWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/FilterInputWidget.cpp
@@ -53,12 +53,14 @@
 #include "SIMPLib/FilterParameters/InputPathFilterParameter.h"
 #include "SIMPLib/FilterParameters/LinkedBooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/LinkedChoicesFilterParameter.h"
+#include "SIMPLib/FilterParameters/LinkedDataContainerSelectionFilterParameter.h"
 
 #include "SVWidgetsLib/QtSupport/QtSHelpUrlGenerator.h"
 #include "SVWidgetsLib/QtSupport/QtSStyles.h"
 
 #include "SVWidgetsLib/FilterParameterWidgets/ChoiceWidget.h"
 #include "SVWidgetsLib/FilterParameterWidgets/LinkedBooleanWidget.h"
+#include "SVWidgetsLib/FilterParameterWidgets/LinkedDataContainerSelectionWidget.h"
 
 #include "SVWidgetsLib/Core/FilterWidgetManager.h"
 #include "SVWidgetsLib/Core/SVWidgetsLibConstants.h"
@@ -525,6 +527,32 @@ void FilterInputWidget::linkConditionalWidgets(QVector<FilterParameter::Pointer>
           if(choiceWidget)
           {
             choiceWidget->widgetChanged(choiceWidget->getCurrentIndex(), false);
+          }
+        }
+      }
+    }
+
+    LinkedDataContainerSelectionFilterParameter::Pointer optionPtr3 = std::dynamic_pointer_cast<LinkedDataContainerSelectionFilterParameter>(filterParameter);
+
+    if(nullptr != optionPtr3.get())
+    {
+      QStringList linkedProps = optionPtr3->getLinkedProperties();
+
+      QStringListIterator iter = QStringListIterator(linkedProps);
+      QWidget* checkboxSource = m_PropertyToWidget[optionPtr3->getPropertyName()];
+      while(iter.hasNext())
+      {
+        QString propName = iter.next();
+        QWidget* w = m_PropertyToWidget[propName];
+        if(w)
+        {
+          // qDebug() << "Connecting: " << optionPtr2->getPropertyName() << " to " << propName;
+          connect(checkboxSource, SIGNAL(conditionalPropertyChanged(int)), w, SLOT(setLinkedComboBoxState(int)));
+
+          LinkedDataContainerSelectionWidget* linkedDataContainerSelectionWidget = qobject_cast<LinkedDataContainerSelectionWidget*>(checkboxSource);
+          if(linkedDataContainerSelectionWidget)
+          {
+            linkedDataContainerSelectionWidget->widgetChanged();
           }
         }
       }


### PR DESCRIPTION
Example usage:

```
{
    LinkedDataContainerSelectionFilterParameter::Pointer parameter = LinkedDataContainerSelectionFilterParameter::New();
    parameter->setHumanLabel("Geometry");
    parameter->setPropertyName("DataContainerName");
    parameter->setSetterCallback(SIMPL_BIND_SETTER(ClassName, this, DataContainerName));
    parameter->setGetterCallback(SIMPL_BIND_GETTER(ClassName, this, DataContainerName));
    QStringList linkedProps = {"Foo"};
    parameter->setLinkedProperties(linkedProps);
    parameter->setCategory(FilterParameter::Parameter);
    IGeometry::Types geomTypes = {IGeometry::Type::RectGrid,
                                  IGeometry::Type::Image};
    parameter->setDefaultGeometryTypes(geomTypes);
    parameters.push_back(parameter);
}
{
    parameters.push_back(SIMPL_NEW_DA_CREATION_FP("Foo Array", Foo, FilterParameter::RequiredArray, ClassName, req, static_cast<int32_t>(IGeometry::Type::RectGrid)));
}
```

The `Foo` data array creation widget will now only appear if the geometry belonging to the data container selected by the LinkedDataContainerSelectionWidget is of type RectGrid.  The LinkedDataContainerSelectionWidget takes the same requirement type filters as the normal DataContainerSelectionWidget (in the above example, only RectGrid and Image geometries are selectable).

updates #76
closes #76 