### PR TITLE
Feature/83 proxy select all

### DIFF
--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
@@ -266,39 +266,6 @@ void DataContainerArrayProxyWidget::updateProxyChecked(QListWidgetItem* item, bo
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-bool DataContainerArrayProxyWidget::shouldStrikeOutItem(QCheckBox* item)
-{
-  bool dcChecked = false;
-  bool amChecked = false;
-
-  if(false == m_DcName.isEmpty())
-  {
-    dcChecked = (getDataContainerProxy().flag == Qt::Checked);
-  }
-  if(false == m_AmName.isEmpty())
-  {
-    amChecked = (getAttributeMatrixProxy().flag == Qt::Checked);
-  }
-
-  if(item == selectAllDataContainer)
-  {
-    return item->checkState() == Qt::Checked;
-  }
-  else if(item == selectAllAttributeMatrix)
-  {
-    return dcChecked || item->checkState() == Qt::Checked;
-  }
-  else if(item == selectAllDataArray)
-  {
-    return dcChecked || amChecked || item->checkState() == Qt::Checked;
-  }
-
-  return false;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
 bool DataContainerArrayProxyWidget::shouldStrikeOutItem(QListWidgetItem* item)
 {
   bool dcChecked = false;
@@ -376,29 +343,6 @@ void DataContainerArrayProxyWidget::toggleStrikeOutFont(QListWidgetItem* item, Q
   {
     font.setStrikeOut(false);
     item->setBackground(defaultBrush);
-  }
-
-  item->setFont(font);
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void DataContainerArrayProxyWidget::toggleStrikeOutFont(QCheckBox* item, Qt::CheckState state)
-{
-  QFont font = item->font();
-
-  QColor errorColor(255, 191, 193);
-
-  QColor defaultColor(Qt::white);
-
-  if(state == Qt::Checked)
-  {
-    font.setStrikeOut(true);
-  }
-  else if(item->checkState() == false)
-  {
-    font.setStrikeOut(false);
   }
 
   item->setFont(font);
@@ -604,9 +548,6 @@ Qt::CheckState DataContainerArrayProxyWidget::updateSelectAllState(QListWidget* 
   if(selectAll)
   {
     selectAll->setCheckState(state);
-
-    Qt::CheckState state = shouldStrikeOutItem(selectAll) ? Qt::Checked : Qt::Unchecked;
-    toggleStrikeOutFont(selectAll, state);
   }
 
   return state;

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
@@ -151,6 +151,7 @@ void DataContainerArrayProxyWidget::selectAllDataContainersClicked(bool checked)
 
   dataContainerList->blockSignals(true);
   checkAllItems(dataContainerList, selectAllDataContainer->checkState());
+  applyDataContainerArrayProxy(m_DcaProxy);
   dataContainerList->blockSignals(false);
 
   emit parametersChanged();
@@ -168,6 +169,7 @@ void DataContainerArrayProxyWidget::selectAllAttributeMatricesClicked(bool check
 
   attributeMatrixList->blockSignals(true);
   checkAllItems(attributeMatrixList, selectAllAttributeMatrix->checkState());
+  applyDataContainerProxy();
   attributeMatrixList->blockSignals(false);
 
   emit parametersChanged();
@@ -185,6 +187,7 @@ void DataContainerArrayProxyWidget::selectAllDataArraysClicked(bool checked)
 
   dataArrayList->blockSignals(true);
   checkAllItems(dataArrayList, selectAllDataArray->checkState());
+  applyAttributeMatrixProxy();
   dataArrayList->blockSignals(false);
 
   emit parametersChanged();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.h
@@ -122,7 +122,6 @@ class SVWidgetsLib_EXPORT DataContainerArrayProxyWidget : public FilterParameter
     void updateProxyChecked(QListWidgetItem* item, bool updateSelectAll = true);
     QList<QListWidgetItem*> getChildItems(QListWidgetItem* item, QList<QListWidgetItem*> otherItems);
 
-    bool shouldStrikeOutItem(QCheckBox* item);
     bool shouldStrikeOutItem(QListWidgetItem* item);
     Qt::CheckState updateSelectAllState(QListWidget* listWidget);
     QList<QListWidgetItem*> getAllItems(QListWidget* listWidget, bool ignoreSelectAll = true);
@@ -143,7 +142,6 @@ class SVWidgetsLib_EXPORT DataContainerArrayProxyWidget : public FilterParameter
     bool m_DidCausePreflight;
 
     void toggleStrikeOutFont(QListWidgetItem* item, Qt::CheckState state);
-    void toggleStrikeOutFont(QCheckBox* item, Qt::CheckState state);
 
     DataContainerArrayProxyWidget(const DataContainerArrayProxyWidget&); // Copy Constructor Not Implemented
     void operator=(const DataContainerArrayProxyWidget&); // Operator '=' Not Implemented


### PR DESCRIPTION
The Select All checkboxes in DataContainerArrayProxyWidget no longer have the strike-out effect, and clicking on the checkbox updates the corresponding proxy so that child proxies are correctly enabled or disabled.