### PR TITLE
Fix formatting of numbers so they are easier to read in the HTML summary

### DIFF
--- a/Source/SIMPLib/DataArrays/NeighborList.hpp
+++ b/Source/SIMPLib/DataArrays/NeighborList.hpp
@@ -758,18 +758,9 @@ class NeighborList : public IDataArray
         ss << "<tr bgcolor=\"#E9E7D6\"><th align=\"right\">Name:</th><td>" << getName() << "</td></tr>";
 
         ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Type:</th><td>" << getTypeAsString() << "</td></tr>";
-        ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Number of Tuples:</th><td>" << getNumberOfTuples() << "</td></tr>";
-
-//        QString compDimStr = "(";
-//        for(int i = 0; i < m_CompDims.size(); i++)
-//        {
-//          compDimStr = compDimStr + QString::number(m_CompDims[i]);
-//          if(i < m_CompDims.size() - 1) {
-//             compDimStr = compDimStr + QString(", ");
-//          }
-//        }
-//        compDimStr = compDimStr + ")";
-//        ss << "<tr bgcolor=\"#C3C8D0\"><th align=\"right\">Component Dimensions:</th><td>" << compDimStr << "</td></tr>";
+        QLocale usa(QLocale::English, QLocale::UnitedStates);
+        QString numStr = usa.toString(static_cast<qlonglong>(getNumberOfTuples()));
+        ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Number of Tuples:</th><td>" << numStr << "</td></tr>";
         ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Number of Lists:</th><td>" << getNumberOfLists() << "</td></tr>";
 
         ss << "</tbody></table>\n";

--- a/Source/SIMPLib/DataArrays/StatsDataArray.cpp
+++ b/Source/SIMPLib/DataArrays/StatsDataArray.cpp
@@ -699,7 +699,9 @@ QString StatsDataArray::getInfoString(SIMPL::InfoStringFormat format)
     ss << "<tr bgcolor=\"#E9E7D6\"><th align=\"right\">Name:</th><td>" << getName() << "</td></tr>";
 
     ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Type:</th><td>" << getTypeAsString() << "</td></tr>";
-    ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Number of Tuples:</th><td>" << getNumberOfTuples() << "</td></tr>";
+    QLocale usa(QLocale::English, QLocale::UnitedStates);
+    QString numStr = usa.toString(static_cast<qlonglong>(getNumberOfTuples()));
+    ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Number of Tuples:</th><td>" << numStr << "</td></tr>";
 
     ss << "</tbody></table>\n";
     ss << "<br/>";

--- a/Source/SIMPLib/DataArrays/StringDataArray.hpp
+++ b/Source/SIMPLib/DataArrays/StringDataArray.hpp
@@ -548,7 +548,9 @@ class StringDataArray : public IDataArray
         ss << "<tr bgcolor=\"#FFFCEA\"><th colspan=2>Attribute Array Info</th></tr>";
         ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Name:</th><td>" << getName() << "</td></tr>";
         ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Type:</th><td>" << getTypeAsString() << "</td></tr>";
-        ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Number of Tuples:</th><td>" << getNumberOfTuples() << "</td></tr>";
+        QLocale usa(QLocale::English, QLocale::UnitedStates);
+        QString numStr = usa.toString(static_cast<qlonglong>(getNumberOfTuples()));
+        ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Number of Tuples:</th><td>" << numStr << "</td></tr>";
         ss << "</tbody></table>\n";
         ss << "<br/>";
         ss << "</body></html>";

--- a/Source/SIMPLib/DataArrays/StructArray.hpp
+++ b/Source/SIMPLib/DataArrays/StructArray.hpp
@@ -674,7 +674,9 @@ class StructArray : public IDataArray
         ss << "<tr bgcolor=\"#FFFCEA\"><th colspan=2>Attribute Array Info</th></tr>";
         ss << "<tr bgcolor=\"#E9E7D6\"><th align=\"right\">Name:</th><td>" << getName() << "</td></tr>";
         ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Type:</th><td>" << getTypeAsString() << "</td></tr>";
-        ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Number of Tuples:</th><td>" << getNumberOfTuples() << "</td></tr>";
+        QLocale usa(QLocale::English, QLocale::UnitedStates);
+        QString numStr = usa.toString(static_cast<qlonglong>(getNumberOfTuples()));
+        ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Number of Tuples:</th><td>" << numStr << "</td></tr>";
         ss << "</tbody></table>\n";
         ss << "<br/>";
         ss << "</body></html>";

--- a/Source/SIMPLib/DataContainers/AttributeMatrix.cpp
+++ b/Source/SIMPLib/DataContainers/AttributeMatrix.cpp
@@ -791,11 +791,13 @@ QString AttributeMatrix::getInfoString(SIMPL::InfoStringFormat format)
       break;
     }
 
+    QLocale usa(QLocale::English, QLocale::UnitedStates);
     ss << "<tr bgcolor=\"#FFFCEA\"><th align=\"right\">Type:</th><td>" << typeString << "</td></tr>";
     QString tupleStr = "(";
     for(int i = 0; i < m_TupleDims.size(); i++)
     {
-      tupleStr = tupleStr + QString::number(m_TupleDims[i]);
+      QString numStr = usa.toString(static_cast<qlonglong>(m_TupleDims[i]));
+      tupleStr = tupleStr + numStr;
       if(i < m_TupleDims.size() - 1)
       {
         tupleStr = tupleStr + QString(", ");


### PR DESCRIPTION
The current formatting is set to US Locale by default.

Updates #94. Closes #94.