### PR TITLE
Fixed MultiDataArraySelectionWidget and MultiAttributeMatrixSelectionWidget not updating

### DIFF
--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiAttributeMatrixSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiAttributeMatrixSelectionWidget.cpp
@@ -547,13 +547,10 @@ void MultiAttributeMatrixSelectionWidget::beforePreflight()
   {
     return;
   }
-  if(m_DidCausePreflight == true)
+  if(m_DidCausePreflight == false)
   {
-    // std::cout << "***  MultiAttributeMatrixSelectionWidget already caused a preflight, just returning" << std::endl;
-    return;
+    createSelectionMenu();
   }
-
-  createSelectionMenu();
 
   // Previously in afterPreflight()
   DataContainerArray::Pointer dca = getFilter()->getDataContainerArray();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.cpp
@@ -569,13 +569,10 @@ void MultiDataArraySelectionWidget::beforePreflight()
   {
     return;
   }
-  if(m_DidCausePreflight == true)
+  if(m_DidCausePreflight == false)
   {
-    // std::cout << "***  MultiDataArraySelectionWidget already caused a preflight, just returning" << std::endl;
-    return;
+    createSelectionMenu();
   }
-
-  createSelectionMenu();
 
   // Previously in afterPreflight()
   DataContainerArray::Pointer dca = getFilter()->getDataContainerArray();


### PR DESCRIPTION
Removed the return on m_DidCausePreflight in beforePreflight() for both MultiDataArraySelectionWidget and MultiAttributeMatrixSelectionWidget.  This was preventing the data selection columns from being updated if those widgets were what caused preflight.  Instead, only createSelectionMenu() is effected m_DidCausePreflight.