### PR TITLE
Disabled operators <<, >> between QDataStream and PhaseType

### DIFF
--- a/Source/SIMPLib/Utilities/QMetaObjectUtilities.cpp
+++ b/Source/SIMPLib/Utilities/QMetaObjectUtilities.cpp
@@ -35,6 +35,8 @@
 
 #include "QMetaObjectUtilities.h"
 
+#include <cassert>
+
 #include <QtCore/QDataStream>
 #include <QtCore/QVector>
 
@@ -82,12 +84,17 @@ QDataStream& operator<<(QDataStream& out, const DataArrayPath& v)
 
 QDataStream& operator<<(QDataStream& out, const PhaseType::Type& v)
 {
-  out << static_cast<PhaseType::EnumType>(v);
+  assert(false);
+  PhaseType::EnumType temp = static_cast<PhaseType::EnumType>(v);
+  out << temp;
   return out;
 }
 QDataStream& operator>>(QDataStream& in, PhaseType::Type& v)
 {
-  in >> v;
+  assert(false);
+  PhaseType::EnumType temp;
+  in >> temp;
+  v = static_cast<PhaseType::Type>(temp);
   return in;
 }
 

--- a/Source/SIMPLib/Utilities/QMetaObjectUtilities.h
+++ b/Source/SIMPLib/Utilities/QMetaObjectUtilities.h
@@ -43,9 +43,6 @@
 
 
 
-
-
-
 class SIMPLib_EXPORT QMetaObjectUtilities
 {
   public:

--- a/Test/FilterParametersRWTest.cpp
+++ b/Test/FilterParametersRWTest.cpp
@@ -906,6 +906,56 @@ public:
     return EXIT_SUCCESS;
   }
 
+#if 0
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void TestRWPhaseType(PhaseType::Type type)
+  {
+    QByteArray data;
+    QDataStream is(&data, QIODevice::ReadOnly);
+    QDataStream os(&data, QIODevice::WriteOnly);
+
+    is << type;
+
+    PhaseType::Type read;
+    os >> read;
+
+    Q_ASSERT(type == read);
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  int TestPhaseTypeDataStream()
+  {
+    PhaseType::Type type;
+
+    type = PhaseType::Type::Any;
+    TestRWPhaseType(type);
+
+    type = PhaseType::Type::Boundary;
+    TestRWPhaseType(type);
+
+    type = PhaseType::Type::Matrix;
+    TestRWPhaseType(type);
+
+    type = PhaseType::Type::Precipitate;
+    TestRWPhaseType(type);
+
+    type = PhaseType::Type::Primary;
+    TestRWPhaseType(type);
+
+    type = PhaseType::Type::Transformation;
+    TestRWPhaseType(type);
+
+    type = PhaseType::Type::Unknown;
+    TestRWPhaseType(type);
+
+    return EXIT_SUCCESS;
+  }
+#endif
+
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixed compiler error for >> operator between QDataStream and PhaseType::Type.  A unit test was laid out in FilterParametersRWTest before adding an assert statement to prevent the operators from being used.