### PR TITLE
FilterPipeline now returns the DataContainerArray after execution

### DIFF
--- a/Source/SIMPLib/Common/FilterPipeline.cpp
+++ b/Source/SIMPLib/Common/FilterPipeline.cpp
@@ -290,10 +290,12 @@ void FilterPipeline::cancelPipeline()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void FilterPipeline::run()
+DataContainerArray::Pointer FilterPipeline::run()
 {
-  execute();
+  DataContainerArray::Pointer dca = execute();
   pipelineFinished();
+
+  return dca;
 }
 
 // -----------------------------------------------------------------------------
@@ -516,7 +518,7 @@ int FilterPipeline::preflightPipeline()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void FilterPipeline::execute()
+DataContainerArray::Pointer FilterPipeline::execute()
 {
   int err = 0;
 
@@ -573,7 +575,7 @@ void FilterPipeline::execute()
       emit pipelineFinished();
       disconnectSignalsSlots();
 
-      return;
+      return dca;
     }
     if(this->getCancel() == true)
     {
@@ -589,6 +591,8 @@ void FilterPipeline::execute()
 
   PipelineMessage completMessage("", "Pipeline Complete", 0, PipelineMessage::MessageType::StatusMessage, -1);
   emit pipelineGeneratedMessage(completMessage);
+
+  return dca;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/Common/FilterPipeline.cpp
+++ b/Source/SIMPLib/Common/FilterPipeline.cpp
@@ -589,8 +589,8 @@ DataContainerArray::Pointer FilterPipeline::execute()
 
   disconnectSignalsSlots();
 
-  PipelineMessage completMessage("", "Pipeline Complete", 0, PipelineMessage::MessageType::StatusMessage, -1);
-  emit pipelineGeneratedMessage(completMessage);
+  PipelineMessage completeMessage("", "Pipeline Complete", 0, PipelineMessage::MessageType::StatusMessage, -1);
+  emit pipelineGeneratedMessage(completeMessage);
 
   return dca;
 }

--- a/Source/SIMPLib/Common/FilterPipeline.h
+++ b/Source/SIMPLib/Common/FilterPipeline.h
@@ -87,7 +87,7 @@ class SIMPLib_EXPORT FilterPipeline : public QObject
      * @brief A pure virtual function that gets called from the "run()" method. Subclasses
      * are expected to create a concrete implementation of this method.
      */
-    virtual void execute();
+    virtual DataContainerArray::Pointer execute();
 
     /**
      * @brief This will preflight the pipeline and report any errors that would occur during
@@ -161,7 +161,7 @@ class SIMPLib_EXPORT FilterPipeline : public QObject
     /**
      * @brief This method is called to start the pipeline for a plugin
      */
-    virtual void run();
+    virtual DataContainerArray::Pointer run();
 
     /**
      * @brief cancelPipeline


### PR DESCRIPTION
Running a pipeline now returns the DataContainerArray as a std::shared_ptr as it was at the end of execution.  Doing so allows the results to be returned in a way that DREAM3D plugins can more easily use without the need to save to and read from a file every time a pipeline is run.