### PR TITLE
Created notifyMissingProperty(FilterParameter*) to prepare for Python bridging

### DIFF
--- a/Source/SIMPLib/Common/AbstractFilter.cpp
+++ b/Source/SIMPLib/Common/AbstractFilter.cpp
@@ -457,3 +457,18 @@ void AbstractFilter::notifyProgressMessage(const QString& prefix, const QString&
   pm.setPipelineIndex(getPipelineIndex());
   emit filterGeneratedMessage(pm);
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void AbstractFilter::notifyMissingProperty(FilterParameter* filterParameter)
+{
+  QString ss =
+    QString("Error occurred transferring the Filter Parameter '%1' in Filter '%2' to the filter instance. The pipeline may run but the underlying filter will NOT be using the values from the GUI."
+      " Please report this issue to the developers of this filter.")
+    .arg(filterParameter->getPropertyName())
+    .arg(getHumanLabel());
+
+  setWarningCondition(-1);
+  notifyWarningMessage(getHumanLabel(), ss, getWarningCondition());
+}

--- a/Source/SIMPLib/Common/AbstractFilter.h
+++ b/Source/SIMPLib/Common/AbstractFilter.h
@@ -304,6 +304,12 @@ class SIMPLib_EXPORT AbstractFilter : public Observable
      */
     void notifyProgressMessage(const QString& prefix, const QString& humanLabel, const QString& str, int progress) override;
 
+    /**
+     * @brief notifyMissingProperty
+     * @param filterParameter
+    */
+    void notifyMissingProperty(FilterParameter* filterParameter);
+
     //---------------
     // Other convenicen methods
     // --------------

--- a/Source/SIMPLib/TestFilters/ErrorWarningFilter.cpp
+++ b/Source/SIMPLib/TestFilters/ErrorWarningFilter.cpp
@@ -47,6 +47,7 @@ ErrorWarningFilter::ErrorWarningFilter()
 , m_PreflightError(false)
 , m_ExecuteWarning(false)
 , m_ExecuteError(false)
+, m_PropertyError(false)
 {
   initialize();
   setupFilterParameters();
@@ -80,6 +81,7 @@ void ErrorWarningFilter::setupFilterParameters()
   parameters.push_back(SIMPL_NEW_BOOL_FP("Preflight Error", PreflightError, FilterParameter::Parameter, ErrorWarningFilter));
   parameters.push_back(SIMPL_NEW_BOOL_FP("Execute Warning", ExecuteWarning, FilterParameter::Parameter, ErrorWarningFilter));
   parameters.push_back(SIMPL_NEW_BOOL_FP("Execute Error", ExecuteError, FilterParameter::Parameter, ErrorWarningFilter));
+  parameters.push_back(SIMPL_NEW_BOOL_FP("Property Error", PropertyError, FilterParameter::Parameter, ErrorWarningFilter));
 
   setFilterParameters(parameters);
 }
@@ -101,6 +103,10 @@ void ErrorWarningFilter::dataCheck()
     QString ss = QObject::tr("Intentional preflight error generated");
     setErrorCondition(-666000);
     notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
+  }
+  if(getPropertyError())
+  {
+    notifyMissingProperty(getFilterParameters()[4].get());
   }
 }
 

--- a/Source/SIMPLib/TestFilters/ErrorWarningFilter.h
+++ b/Source/SIMPLib/TestFilters/ErrorWarningFilter.h
@@ -62,6 +62,9 @@ public:
   SIMPL_FILTER_PARAMETER(bool, ExecuteError)
   Q_PROPERTY(bool ExecuteError READ getExecuteError WRITE setExecuteError)
 
+  SIMPL_FILTER_PARAMETER(bool, PropertyError)
+  Q_PROPERTY(bool PropertyError READ getPropertyError WRITE setPropertyError)
+
   /**
    * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
    */

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.cpp
@@ -263,7 +263,7 @@ void AbstractIOFileWidget::filterNeedsInputParameters(AbstractFilter* filter)
   bool ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, text);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.cpp
@@ -354,6 +354,6 @@ void AttributeMatrixCreationWidget::filterNeedsInputParameters(AbstractFilter* f
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.cpp
@@ -363,6 +363,6 @@ void AttributeMatrixSelectionWidget::filterNeedsInputParameters(AbstractFilter* 
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AxisAngleWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AxisAngleWidget.cpp
@@ -136,7 +136,7 @@ void AxisAngleWidget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/BooleanWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/BooleanWidget.cpp
@@ -117,7 +117,7 @@ void BooleanWidget::filterNeedsInputParameters(AbstractFilter* filter)
   bool ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/CalculatorWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/CalculatorWidget.cpp
@@ -403,7 +403,7 @@ void CalculatorWidget::filterNeedsInputParameters(AbstractFilter* filter)
   bool ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, equation->text());
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 
   ArrayCalculator* calculatorFilter = dynamic_cast<ArrayCalculator*>(filter);

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ChoiceWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ChoiceWidget.cpp
@@ -145,7 +145,7 @@ void ChoiceWidget::filterNeedsInputParameters(AbstractFilter* filter)
 
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionAdvancedWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionAdvancedWidget.cpp
@@ -298,7 +298,7 @@ void ComparisonSelectionAdvancedWidget::filterNeedsInputParameters(AbstractFilte
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if (false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.cpp
@@ -351,7 +351,7 @@ void ComparisonSelectionWidget::filterNeedsInputParameters(AbstractFilter* filte
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ConstrainedDoubleWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ConstrainedDoubleWidget.cpp
@@ -114,7 +114,7 @@ void ConstrainedDoubleWidget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if (false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ConstrainedIntWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ConstrainedIntWidget.cpp
@@ -114,7 +114,7 @@ void ConstrainedIntWidget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if (false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.cpp
@@ -388,6 +388,6 @@ void DataArrayCreationWidget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.cpp
@@ -419,7 +419,7 @@ void DataArraySelectionWidget::filterNeedsInputParameters(AbstractFilter* filter
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
@@ -362,7 +362,7 @@ void DataContainerArrayProxyWidget::filterNeedsInputParameters(AbstractFilter* f
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 
   //  if(getFilterParameter()->isConditional() )

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.cpp
@@ -122,6 +122,6 @@ void DataContainerCreationWidget::filterNeedsInputParameters(AbstractFilter* fil
   bool ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, stringEdit->getText());
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.cpp
@@ -334,6 +334,6 @@ void DataContainerSelectionWidget::filterNeedsInputParameters(AbstractFilter* fi
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DoubleWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DoubleWidget.cpp
@@ -150,7 +150,7 @@ void DoubleWidget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FileListInfoWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FileListInfoWidget.cpp
@@ -589,7 +589,7 @@ void FileListInfoWidget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FloatVec2Widget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FloatVec2Widget.cpp
@@ -173,7 +173,7 @@ void FloatVec2Widget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FloatVec3Widget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FloatVec3Widget.cpp
@@ -188,7 +188,7 @@ void FloatVec3Widget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FloatWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FloatWidget.cpp
@@ -150,7 +150,7 @@ void FloatWidget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FourthOrderPolynomialWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FourthOrderPolynomialWidget.cpp
@@ -184,7 +184,7 @@ void FourthOrderPolynomialWidget::filterNeedsInputParameters(AbstractFilter* fil
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/IntVec3Widget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/IntVec3Widget.cpp
@@ -126,7 +126,7 @@ void IntVec3Widget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/IntWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/IntWidget.cpp
@@ -142,7 +142,7 @@ void IntWidget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/LinkedBooleanWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/LinkedBooleanWidget.cpp
@@ -137,7 +137,7 @@ void LinkedBooleanWidget::filterNeedsInputParameters(AbstractFilter* filter)
   bool ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/LinkedDataContainerSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/LinkedDataContainerSelectionWidget.cpp
@@ -350,6 +350,6 @@ void LinkedDataContainerSelectionWidget::filterNeedsInputParameters(AbstractFilt
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiAttributeMatrixSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiAttributeMatrixSelectionWidget.cpp
@@ -635,6 +635,6 @@ void MultiAttributeMatrixSelectionWidget::filterNeedsInputParameters(AbstractFil
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.cpp
@@ -660,6 +660,6 @@ void MultiDataArraySelectionWidget::filterNeedsInputParameters(AbstractFilter* f
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/NumericTypeWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/NumericTypeWidget.cpp
@@ -130,7 +130,7 @@ void NumericTypeWidget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/PhaseTypeSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/PhaseTypeSelectionWidget.cpp
@@ -426,7 +426,7 @@ void PhaseTypeSelectionWidget::filterNeedsInputParameters(AbstractFilter* filter
   ok = filter->setProperty(m_FilterParameter->getPhaseTypeDataProperty().toLatin1().constData(), var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 
   DataArrayPath path = DataArrayPath::Deserialize(m_SelectedAttributeMatrixPath->text(), Detail::Delimiter);
@@ -437,6 +437,6 @@ void PhaseTypeSelectionWidget::filterNeedsInputParameters(AbstractFilter* filter
   ok = filter->setProperty(m_FilterParameter->getAttributeMatrixPathProperty().toLatin1().constData(), var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/RangeWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/RangeWidget.cpp
@@ -140,6 +140,6 @@ void RangeWidget::filterNeedsInputParameters(AbstractFilter* filter)
   bool ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ReadASCIIDataWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ReadASCIIDataWidget.cpp
@@ -463,7 +463,7 @@ void ReadASCIIDataWidget::filterNeedsInputParameters(AbstractFilter* filter)
   bool ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    // FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    // getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ScalarTypeWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ScalarTypeWidget.cpp
@@ -130,7 +130,7 @@ void ScalarTypeWidget::filterNeedsInputParameters(AbstractFilter* filter)
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/SecondOrderPolynomialWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/SecondOrderPolynomialWidget.cpp
@@ -155,7 +155,7 @@ void SecondOrderPolynomialWidget::filterNeedsInputParameters(AbstractFilter* fil
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ShapeTypeSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ShapeTypeSelectionWidget.cpp
@@ -306,6 +306,6 @@ void ShapeTypeSelectionWidget::filterNeedsInputParameters(AbstractFilter* filter
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, var);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/StringWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/StringWidget.cpp
@@ -118,6 +118,6 @@ void StringWidget::filterNeedsInputParameters(AbstractFilter* filter)
   bool ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, stringEdit->getText());
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ThirdOrderPolynomialWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ThirdOrderPolynomialWidget.cpp
@@ -163,7 +163,7 @@ void ThirdOrderPolynomialWidget::filterNeedsInputParameters(AbstractFilter* filt
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
   if(false == ok)
   {
-    FilterParameterWidgetsDialogs::ShowCouldNotSetFilterParameter(getFilter(), getFilterParameter());
+    getFilter()->notifyMissingProperty(getFilterParameter());
   }
 }
 


### PR DESCRIPTION
void FilterParameterWidgetsDialog::ShowCouldNotSetFilterParameter(AbstractFilter*, FilterParameter*) was replaced with void AbstractFilter::notifyMissingProperty(FilterParameter*) in existing FilterParameterWidgets.  Instead of creating a QMessageBox each time a property cannot be set, notifyMissingProperty sets a warning condition instead.