### PR TITLE
Fixed inconsistent type usage

### DIFF
--- a/Source/H5Support/H5Lite.h
+++ b/Source/H5Support/H5Lite.h
@@ -1599,7 +1599,7 @@ namespace H5Support_NAMESPACE
        * @param attrName The name of the attribute
        * @param rank (out) Number of dimensions is store into this variable
        */
-      static H5Support_EXPORT hid_t getAttributeNDims(hid_t loc_id, const std::string& objName, const std::string& attrName, hid_t& rank);
+      static H5Support_EXPORT herr_t getAttributeNDims(hid_t loc_id, const std::string& objName, const std::string& attrName, hid_t& rank);
 
       /**
        * @brief Returns the number of dimensions for a given dataset
@@ -1607,7 +1607,7 @@ namespace H5Support_NAMESPACE
        * @param objName The name of the dataset
        * @param rank (out) Number of dimensions is store into this variable
        */
-      static H5Support_EXPORT hid_t getDatasetNDims(hid_t loc_id, const std::string& objName, hid_t& rank);
+      static H5Support_EXPORT herr_t getDatasetNDims(hid_t loc_id, const std::string& objName, hid_t& rank);
 
       /**
        * @brief Returns the H5T value for a given dataset.

--- a/Source/H5Support/H5Utilities.cpp
+++ b/Source/H5Support/H5Utilities.cpp
@@ -527,7 +527,7 @@ bool H5Utilities::probeForAttribute(hid_t loc_id, const std::string& obj_name, c
   H5SUPPORT_MUTEX_LOCK()
 
   herr_t err = 0;
-  int32_t rank;
+  hid_t rank;
   HDF_ERROR_HANDLER_OFF
   err = H5Lite::getAttributeNDims(loc_id, obj_name, attr_name, rank);
   HDF_ERROR_HANDLER_ON

--- a/Source/H5Support/Test/H5UtilitiesTest.cpp
+++ b/Source/H5Support/Test/H5UtilitiesTest.cpp
@@ -326,7 +326,7 @@ public:
     int32_t err = QH5Utilities::objectNameAtIndex(file_id, 0, objName);
     DREAM3D_REQUIRE(objName.compare("Pointer2DArrayDataset<H5T_NATIVE_INT32>") == 0);
 
-    hid_t objType = -1;
+    int32_t objType = -1;
     err = QH5Utilities::getObjectType(file_id, "Pointer2DArrayDataset<H5T_NATIVE_INT32>", &objType);
     DREAM3D_REQUIRE(objType == H5O_TYPE_DATASET);
     DREAM3D_REQUIRE(err >= 0);


### PR DESCRIPTION
Fixed four cases of inconsistent type usage.  H5Lite.h declared getAttributeNDims and getDatasetNDims methods as returning an hid_t but they were defined as returning herr_t.  H5Utilities created a rank variable as int32_t when the method that used it expected an hid_t.  H5UtilitiesTest created an objType variable of type hid_t when methods using it expected an int32_t.

updates #122 