### PR TITLE
Fixed Enable Filter action and Disable button inconsistency

### DIFF
--- a/Source/SVWidgetsLib/Widgets/SVPipelineFilterWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/SVPipelineFilterWidget.cpp
@@ -417,6 +417,7 @@ void SVPipelineFilterWidget::on_deleteBtn_clicked()
 void SVPipelineFilterWidget::on_disableBtn_clicked()
 {
   setIsEnabled(!disableBtn->isChecked());
+  emit parametersChanged(QUuid());
 }
 
 // -----------------------------------------------------------------------------
@@ -532,6 +533,7 @@ void SVPipelineFilterWidget::toReadyState()
 {
   PipelineFilterObject::toReadyState();
   getFilterInputWidget()->toRunningState();
+  disableBtn->setChecked(false);
   changeStyle();
 }
 
@@ -560,6 +562,16 @@ void SVPipelineFilterWidget::toCompletedState()
   {
     setErrorState(ErrorState::Error);
   }
+  changeStyle();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void SVPipelineFilterWidget::toDisabledState()
+{
+  PipelineFilterObject::toDisabledState();
+  disableBtn->setChecked(true);
   changeStyle();
 }
 

--- a/Source/SVWidgetsLib/Widgets/SVPipelineFilterWidget.h
+++ b/Source/SVWidgetsLib/Widgets/SVPipelineFilterWidget.h
@@ -134,6 +134,10 @@ class SVWidgetsLib_EXPORT SVPipelineFilterWidget : public QFrame, public Pipelin
      */
     virtual void toCompletedState() override;
 
+    /**
+     * @brief toDisabledState
+     */
+    virtual void toDisabledState() override;
 
     /**
      * @brief toActiveState


### PR DESCRIPTION
SVPipelineFilterWidget updates the disable button when its state is changed to Disable or Ready.  Clicking the disable button also causes a preflight in order to update the DataContainerArray passed into other filters.