### PR TITLE
Fixed hard-coded signal value where a variable was required

### DIFF
--- a/Source/SVWidgetsLib/Widgets/IssuesWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/IssuesWidget.cpp
@@ -141,7 +141,7 @@ void IssuesWidget::displayCachedMessages()
     }
   }
 
-  emit tableHasErrors(false, errCount, warnCount);
+  emit tableHasErrors(errCount > 0, errCount, warnCount);
 
   // Now create the correct number of table rows.
   ui->errorTableWidget->setRowCount(count);


### PR DESCRIPTION
Fixed a signal variable that was hardcoded to false and prevented a preference setting from being applied.  This relates to SIMPLView pull request 29