### PR TITLE
Fixed unchecked boxes during the .dream3d import process

### DIFF
--- a/Source/SIMPLib/CoreFilters/DataContainerReader.cpp
+++ b/Source/SIMPLib/CoreFilters/DataContainerReader.cpp
@@ -418,8 +418,7 @@ int DataContainerReader::writeExistingPipelineToFile(QJsonObject& rootJson, int 
 // -----------------------------------------------------------------------------
 bool DataContainerReader::syncProxies()
 {
-//  SIMPLH5DataReaderRequirements req(SIMPL::Defaults::AnyPrimitive, SIMPL::Defaults::AnyComponentSize, AttributeMatrix::Type::Any, IGeometry::Type::Any);
-  SIMPLH5DataReaderRequirements req(SIMPL::Defaults::AnyPrimitive, 1, AttributeMatrix::Type::Any, IGeometry::Type::Image);
+  SIMPLH5DataReaderRequirements req(SIMPL::Defaults::AnyPrimitive, SIMPL::Defaults::AnyComponentSize, AttributeMatrix::Type::Any, IGeometry::Type::Any);
 
   SIMPLH5DataReader::Pointer simplReader = SIMPLH5DataReader::New();
   connect(simplReader.get(), &SIMPLH5DataReader::errorGenerated, [=] (const QString &msg, const int &code) {


### PR DESCRIPTION
Fixed a bug where importing a .dream3d file did not automatically select anything that was not an image geometry or 1 component array but gave no indication that this was the case without expanding the entire tree.

Fixes #164