### PR TITLE
Combine Data Arrays should allow Copy or Move operations

### DIFF
--- a/Source/SIMPLib/CoreFilters/CombineAttributeArrays.cpp
+++ b/Source/SIMPLib/CoreFilters/CombineAttributeArrays.cpp
@@ -175,6 +175,7 @@ CombineAttributeArrays::CombineAttributeArrays()
 : m_SelectedDataArrayPaths(QVector<DataArrayPath>())
 , m_StackedDataArrayName(SIMPL::GeneralData::CombinedData)
 , m_NormalizeData(false)
+, m_MoveValues(false)
 {
 }
 
@@ -190,6 +191,7 @@ void CombineAttributeArrays::setupFilterParameters()
 {
   FilterParameterVector parameters;
   parameters.push_back(SIMPL_NEW_BOOL_FP("Normalize Data", NormalizeData, FilterParameter::Parameter, CombineAttributeArrays));
+  parameters.push_back(SIMPL_NEW_BOOL_FP("Move Data", MoveValues, FilterParameter::Parameter, CombineAttributeArrays));
   {
     MultiDataArraySelectionFilterParameter::RequirementType req =
         MultiDataArraySelectionFilterParameter::CreateRequirement(SIMPL::Defaults::AnyPrimitive, SIMPL::Defaults::AnyComponentSize, AttributeMatrix::Type::Any, IGeometry::Type::Any);
@@ -208,6 +210,7 @@ void CombineAttributeArrays::readFilterParameters(AbstractFilterParametersReader
   setSelectedDataArrayPaths(reader->readDataArrayPathVector("SelectedDataArrayPaths", getSelectedDataArrayPaths()));
   setStackedDataArrayName(reader->readString("StackedDataArrayName", getStackedDataArrayName()));
   setNormalizeData(reader->readValue("NormalizeData", getNormalizeData()));
+  setMoveValues(reader->readValue("MoveValues", getMoveValues()));
   reader->closeFilterGroup();
 }
 
@@ -287,6 +290,16 @@ void CombineAttributeArrays::dataCheck()
 
   DataArrayPath tempPath(getSelectedDataArrayPaths()[0].getDataContainerName(), getSelectedDataArrayPaths()[0].getAttributeMatrixName(), getStackedDataArrayName());
   m_StackedDataPtr = TemplateHelpers::CreateNonPrereqArrayFromArrayType()(this, tempPath, cDims, m_SelectedWeakPtrVector[0].lock());
+
+  if(getMoveValues() && getInPreflight())
+  {
+    QVector<DataArrayPath> paths = getSelectedDataArrayPaths();
+    for(DataArrayPath path : paths)
+    {
+      AttributeMatrix::Pointer attrMat = getDataContainerArray()->getAttributeMatrix(path);
+      attrMat->removeAttributeArray(path.getDataArrayName());
+    }
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -316,6 +329,16 @@ void CombineAttributeArrays::execute()
   }
 
   EXECUTE_TEMPLATE(this, CombineAttributeArraysTemplatePrivate, m_SelectedWeakPtrVector, this, m_SelectedWeakPtrVector, m_StackedDataPtr.lock())
+
+  if(getMoveValues())
+  {
+    QVector<DataArrayPath> paths = getSelectedDataArrayPaths();
+    for(DataArrayPath path : paths)
+    {
+      AttributeMatrix::Pointer attrMat = getDataContainerArray()->getAttributeMatrix(path);
+      attrMat->removeAttributeArray(path.getDataArrayName());
+    }
+  }
 
   /* Let the GUI know we are done with this filter */
   notifyStatusMessage(getHumanLabel(), "Complete");

--- a/Source/SIMPLib/CoreFilters/CombineAttributeArrays.h
+++ b/Source/SIMPLib/CoreFilters/CombineAttributeArrays.h
@@ -63,6 +63,9 @@ class SIMPLib_EXPORT CombineAttributeArrays : public AbstractFilter
     SIMPL_FILTER_PARAMETER(bool, NormalizeData)
     Q_PROPERTY(bool NormalizeData READ getNormalizeData WRITE setNormalizeData)
 
+    SIMPL_FILTER_PARAMETER(bool, MoveValues)
+    Q_PROPERTY(bool MoveValues READ getMoveValues WRITE setMoveValues)
+
     /**
      * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
      */

--- a/Source/SIMPLib/Documentation/SIMPLibFilters/CoreFilters/CombineAttributeArrays.md
+++ b/Source/SIMPLib/Documentation/SIMPLibFilters/CoreFilters/CombineAttributeArrays.md
@@ -7,7 +7,7 @@ Core (Memory/Management)
 
 ## Description ##
 
-This **Filter** will "stack" any number of user-chosen **Attribute Arrays** into a single attribute array. The arrays must all share the same primitive type and number of tuples, but may have differing component dimensions. The resulting combined array will have a total number of components equal to the sum of the number of components for each stacked array. The order in which the components are placed in the combined array is the same as the ordering chosen by the user when selecting the arrays. For example, consider two arrays, one that is a 3-vector and one that is a scalar. The values in memory appear as follows:
+This **Filter** will "stack" any number of user-chosen **Attribute Arrays** into a single attribute array and allows the option to remove the original **Attribute Arrays** once this operation is completed. The arrays must all share the same primitive type and number of tuples, but may have differing component dimensions. The resulting combined array will have a total number of components equal to the sum of the number of components for each stacked array. The order in which the components are placed in the combined array is the same as the ordering chosen by the user when selecting the arrays. For example, consider two arrays, one that is a 3-vector and one that is a scalar. The values in memory appear as follows:
 
 _Vector_: tuple 1 - { v1 v2 v3 } ; tuple 2 - { v1 v2 v3 } ; tuple 3 - { v1 v2 v3 } ...
 
@@ -45,6 +45,7 @@ The user may also select to normalize the resulting combined array. The normaliz
 | Name             | Type | Description |
 |------------------|------|-------------|
 | Standardize Data | bool | Whether to standardize the combine data on the interval [0, 1] |
+| Move Data        | bool | Whether to remove the original arrays after combining the data |
 
 ## Required Geometry ##
 


### PR DESCRIPTION
Added the MoveValues filter parameter that controls the removal of any arrays combined to create the output.  These arrays are only deleted in dataCheck or execute when MoveValues is true.  If MoveValues is false, the original arrays remain as they were and the previous functionality continues.

fixes BlueQuartzSoftware/DREAM3D#782. Closes BlueQuartzSoftware/DREAM3D#782