### PR TITLE
Feature/rename paths

### DIFF
--- a/Source/SIMPLib/CoreFilters/ArrayCalculator.cpp
+++ b/Source/SIMPLib/CoreFilters/ArrayCalculator.cpp
@@ -213,6 +213,45 @@ void ArrayCalculator::initialize()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+void ArrayCalculator::renameDataArrayPath(DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  DataArrayPath amPath = getSelectedAttributeMatrix();
+
+  bool dcChanged = oldPath.getDataContainerName() != newPath.getDataContainerName();
+  bool amChanged = !dcChanged && oldPath.getAttributeMatrixName() != newPath.getAttributeMatrixName();
+  bool daChanged = !amChanged && oldPath.getDataArrayName() != newPath.getDataArrayName();
+
+  bool amConsistent = false == dcChanged && false == amChanged
+    && amPath.getDataContainerName() == oldPath.getDataContainerName()
+    && amPath.getAttributeMatrixName() == oldPath.getAttributeMatrixName();
+
+  for(FilterParameter::Pointer parameter : getFilterParameters())
+  {
+    // Only update the CalculatorFilterParameter when a DataArray changed
+    // This allows the parameter to run on the assumption that if this method gets called, 
+    // everything before the DataArray part of the path already matches because the parameter
+    // has no way of performing that check itself.
+    if(std::dynamic_pointer_cast<CalculatorFilterParameter>(parameter))
+    {
+      if(daChanged && amConsistent)
+      {
+        parameter->dataArrayPathRenamed(this, renamePath);
+      }
+    }
+    else
+    {
+      parameter->dataArrayPathRenamed(this, renamePath);
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void ArrayCalculator::dataCheck()
 {
   setErrorCondition(0);

--- a/Source/SIMPLib/CoreFilters/ArrayCalculator.cpp
+++ b/Source/SIMPLib/CoreFilters/ArrayCalculator.cpp
@@ -213,45 +213,6 @@ void ArrayCalculator::initialize()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void ArrayCalculator::renameDataArrayPath(DataArrayPath::RenameType renamePath)
-{
-  DataArrayPath oldPath;
-  DataArrayPath newPath;
-  std::tie(oldPath, newPath) = renamePath;
-
-  DataArrayPath amPath = getSelectedAttributeMatrix();
-
-  bool dcChanged = oldPath.getDataContainerName() != newPath.getDataContainerName();
-  bool amChanged = !dcChanged && oldPath.getAttributeMatrixName() != newPath.getAttributeMatrixName();
-  bool daChanged = !amChanged && oldPath.getDataArrayName() != newPath.getDataArrayName();
-
-  bool amConsistent = false == dcChanged && false == amChanged
-    && amPath.getDataContainerName() == oldPath.getDataContainerName()
-    && amPath.getAttributeMatrixName() == oldPath.getAttributeMatrixName();
-
-  for(FilterParameter::Pointer parameter : getFilterParameters())
-  {
-    // Only update the CalculatorFilterParameter when a DataArray changed
-    // This allows the parameter to run on the assumption that if this method gets called, 
-    // everything before the DataArray part of the path already matches because the parameter
-    // has no way of performing that check itself.
-    if(std::dynamic_pointer_cast<CalculatorFilterParameter>(parameter))
-    {
-      if(daChanged && amConsistent)
-      {
-        parameter->dataArrayPathRenamed(this, renamePath);
-      }
-    }
-    else
-    {
-      parameter->dataArrayPathRenamed(this, renamePath);
-    }
-  }
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
 void ArrayCalculator::dataCheck()
 {
   setErrorCondition(0);

--- a/Source/SIMPLib/CoreFilters/ArrayCalculator.h
+++ b/Source/SIMPLib/CoreFilters/ArrayCalculator.h
@@ -157,13 +157,6 @@ class SIMPLib_EXPORT ArrayCalculator : public AbstractFilter
     */
     void preflight() override;
 
-    /**
-    * @brief Updates any DataArrayPath properties from the old path to a new path
-    * For DataArrayPaths longer than the given path, only the specified values are modified
-    * @param renamePath
-    */
-    void renameDataArrayPath(DataArrayPath::RenameType renamePath) override;
-
   signals:
     /**
      * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters

--- a/Source/SIMPLib/CoreFilters/ArrayCalculator.h
+++ b/Source/SIMPLib/CoreFilters/ArrayCalculator.h
@@ -157,6 +157,13 @@ class SIMPLib_EXPORT ArrayCalculator : public AbstractFilter
     */
     void preflight() override;
 
+    /**
+    * @brief Updates any DataArrayPath properties from the old path to a new path
+    * For DataArrayPaths longer than the given path, only the specified values are modified
+    * @param renamePath
+    */
+    void renameDataArrayPath(DataArrayPath::RenameType renamePath) override;
+
   signals:
     /**
      * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters

--- a/Source/SIMPLib/CoreFilters/ReadASCIIData.cpp
+++ b/Source/SIMPLib/CoreFilters/ReadASCIIData.cpp
@@ -216,6 +216,16 @@ void ReadASCIIData::writeFilterParameters(QJsonObject& obj)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+void ReadASCIIData::renameDataArrayPath(DataArrayPath::RenameType renamePath)
+{
+  getWizardData().updateDataArrayPath(renamePath);
+
+  AbstractFilter::renameDataArrayPath(renamePath);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void ReadASCIIData::initialize()
 {
   m_ASCIIArrayMap.clear();

--- a/Source/SIMPLib/CoreFilters/ReadASCIIData.h
+++ b/Source/SIMPLib/CoreFilters/ReadASCIIData.h
@@ -116,6 +116,13 @@ class ReadASCIIData : public AbstractFilter
     */
     void preflight() override;
 
+    /**
+    * @brief Updates any DataArrayPath properties from the old path to a new path
+    * For DataArrayPaths longer than the given path, only the specified values are modified
+    * @param renamePath
+    */
+    void renameDataArrayPath(DataArrayPath::RenameType renamePath) override;
+
   signals:
     /**
      * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters

--- a/Source/SIMPLib/CoreFilters/RenameAttributeArray.cpp
+++ b/Source/SIMPLib/CoreFilters/RenameAttributeArray.cpp
@@ -237,3 +237,18 @@ const QString RenameAttributeArray::getHumanLabel() const
 {
   return "Rename Attribute Array";
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+DataArrayPath::RenameContainer RenameAttributeArray::getRenamedPaths()
+{
+  DataArrayPath oldPath = getSelectedArrayPath();
+  DataArrayPath newPath = getSelectedArrayPath();
+  newPath.setDataArrayName(getNewArrayName());
+
+  DataArrayPath::RenameContainer container;
+  container.push_back(DataArrayPath::RenameType(oldPath, newPath));
+
+  return container;
+}

--- a/Source/SIMPLib/CoreFilters/RenameAttributeArray.h
+++ b/Source/SIMPLib/CoreFilters/RenameAttributeArray.h
@@ -125,6 +125,12 @@ class SIMPLib_EXPORT RenameAttributeArray : public AbstractFilter
     */
     void preflight() override;
 
+    /**
+     * @brief Returns a list of DataArrayPaths that have been renamed along with their corresponding renamed value
+     * @return
+     */
+    DataArrayPath::RenameContainer getRenamedPaths() override;
+
   signals:
     /**
      * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters

--- a/Source/SIMPLib/CoreFilters/RenameAttributeMatrix.cpp
+++ b/Source/SIMPLib/CoreFilters/RenameAttributeMatrix.cpp
@@ -224,3 +224,18 @@ const QString RenameAttributeMatrix::getHumanLabel() const
 {
   return "Rename Attribute Matrix";
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+DataArrayPath::RenameContainer RenameAttributeMatrix::getRenamedPaths()
+{
+  DataArrayPath oldPath = getSelectedAttributeMatrixPath();
+  DataArrayPath newPath = getSelectedAttributeMatrixPath();
+  newPath.setAttributeMatrixName(getNewAttributeMatrix());
+
+  DataArrayPath::RenameContainer container;
+  container.push_back(DataArrayPath::RenameType(oldPath, newPath));
+
+  return container;
+}

--- a/Source/SIMPLib/CoreFilters/RenameAttributeMatrix.h
+++ b/Source/SIMPLib/CoreFilters/RenameAttributeMatrix.h
@@ -125,6 +125,12 @@ class SIMPLib_EXPORT RenameAttributeMatrix : public AbstractFilter
     */
     void preflight() override;
 
+    /**
+    * @brief Returns a list of DataArrayPaths that have been renamed along with their corresponding renamed value
+    * @return
+    */
+    DataArrayPath::RenameContainer getRenamedPaths() override;
+
   signals:
     /**
      * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters

--- a/Source/SIMPLib/CoreFilters/RenameDataContainer.cpp
+++ b/Source/SIMPLib/CoreFilters/RenameDataContainer.cpp
@@ -220,3 +220,17 @@ const QString RenameDataContainer::getHumanLabel() const
 {
   return "Rename Data Container";
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+DataArrayPath::RenameContainer RenameDataContainer::getRenamedPaths()
+{
+  DataArrayPath oldPath(getSelectedDataContainerName(), "", "");
+  DataArrayPath newPath(getNewDataContainerName(), "", "");
+
+  DataArrayPath::RenameContainer container;
+  container.push_back(DataArrayPath::RenameType(oldPath, newPath));
+
+  return container;
+}

--- a/Source/SIMPLib/CoreFilters/RenameDataContainer.h
+++ b/Source/SIMPLib/CoreFilters/RenameDataContainer.h
@@ -125,6 +125,12 @@ class SIMPLib_EXPORT RenameDataContainer : public AbstractFilter
     */
     void preflight() override;
 
+    /**
+    * @brief Returns a list of DataArrayPaths that have been renamed along with their corresponding renamed value
+    * @return
+    */
+    DataArrayPath::RenameContainer getRenamedPaths() override;
+
   signals:
     /**
      * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters

--- a/Source/SIMPLib/CoreFilters/util/ASCIIWizardData.hpp
+++ b/Source/SIMPLib/CoreFilters/util/ASCIIWizardData.hpp
@@ -73,6 +73,31 @@ public:
   bool headerUsesDefaults = false; // The user just wants to use the automatically generated headers
 
 
+  void updateDataArrayPath(DataArrayPath::RenameType renamePath)
+  {
+    DataArrayPath oldPath;
+    DataArrayPath newPath;
+    std::tie(oldPath, newPath) = renamePath;
+
+    bool hasAM = false == oldPath.getAttributeMatrixName().isEmpty();
+
+    if(selectedPath.hasSameDataContainer(oldPath))
+    {
+      if(hasAM)
+      {
+        if(selectedPath.hasSameAttributeMatrix(oldPath))
+        {
+          selectedPath.setDataContainerName(newPath.getDataContainerName());
+          selectedPath.setAttributeMatrixName(newPath.getAttributeMatrixName());
+        }
+      }
+      else
+      {
+        selectedPath.setDataContainerName(newPath.getDataContainerName());
+      }
+    }
+  }
+
   bool isEmpty()
   {
     if (inputFilePath.isEmpty() && dataHeaders.isEmpty() && dataTypes.isEmpty() && tupleDims.isEmpty() && beginIndex < 0 && numberOfLines < 0 && selectedPath.isEmpty())

--- a/Source/SIMPLib/DataContainers/AttributeMatrixProxy.cpp
+++ b/Source/SIMPLib/DataContainers/AttributeMatrixProxy.cpp
@@ -268,3 +268,29 @@ void AttributeMatrixProxy::setFlags(uint8_t flag, DataArrayProxy::PrimitiveTypeF
     }
   }
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void AttributeMatrixProxy::updatePath(DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(oldPath.getAttributeMatrixName() != newPath.getAttributeMatrixName())
+  {
+    name = newPath.getAttributeMatrixName();
+  }
+
+  if(oldPath.getDataArrayName().isEmpty())
+  {
+    return;
+  }
+
+  DataArrayProxy daProxy = dataArrays[oldPath.getDataArrayName()];
+
+  if(oldPath.getDataArrayName() != newPath.getDataArrayName())
+  {
+    dataArrays.insert(newPath.getDataArrayName(), daProxy);
+    dataArrays.remove(oldPath.getDataArrayName());
+  }
+
+  daProxy.updatePath(oldPath, newPath);
+}

--- a/Source/SIMPLib/DataContainers/AttributeMatrixProxy.cpp
+++ b/Source/SIMPLib/DataContainers/AttributeMatrixProxy.cpp
@@ -288,13 +288,8 @@ void AttributeMatrixProxy::updatePath(DataArrayPath::RenameType renamePath)
     return;
   }
 
-  DataArrayProxy daProxy = dataArrays[oldPath.getDataArrayName()];
-
-  if(oldPath.getDataArrayName() != newPath.getDataArrayName())
-  {
-    dataArrays.insert(newPath.getDataArrayName(), daProxy);
-    dataArrays.remove(oldPath.getDataArrayName());
-  }
-
+  DataArrayProxy daProxy = dataArrays.take(oldPath.getDataArrayName());
   daProxy.updatePath(renamePath);
+
+  dataArrays.insert(newPath.getDataArrayName(), daProxy);
 }

--- a/Source/SIMPLib/DataContainers/AttributeMatrixProxy.cpp
+++ b/Source/SIMPLib/DataContainers/AttributeMatrixProxy.cpp
@@ -283,13 +283,10 @@ void AttributeMatrixProxy::updatePath(DataArrayPath::RenameType renamePath)
     name = newPath.getAttributeMatrixName();
   }
 
-  if(oldPath.getDataArrayName().isEmpty())
+  if(dataArrays.contains(oldPath.getDataArrayName()))
   {
-    return;
+    DataArrayProxy daProxy = dataArrays.take(oldPath.getDataArrayName());
+    daProxy.updatePath(renamePath);
+    dataArrays.insert(newPath.getDataArrayName(), daProxy);
   }
-
-  DataArrayProxy daProxy = dataArrays.take(oldPath.getDataArrayName());
-  daProxy.updatePath(renamePath);
-
-  dataArrays.insert(newPath.getDataArrayName(), daProxy);
 }

--- a/Source/SIMPLib/DataContainers/AttributeMatrixProxy.cpp
+++ b/Source/SIMPLib/DataContainers/AttributeMatrixProxy.cpp
@@ -272,8 +272,12 @@ void AttributeMatrixProxy::setFlags(uint8_t flag, DataArrayProxy::PrimitiveTypeF
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void AttributeMatrixProxy::updatePath(DataArrayPath oldPath, DataArrayPath newPath)
+void AttributeMatrixProxy::updatePath(DataArrayPath::RenameType renamePath)
 {
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
   if(oldPath.getAttributeMatrixName() != newPath.getAttributeMatrixName())
   {
     name = newPath.getAttributeMatrixName();
@@ -292,5 +296,5 @@ void AttributeMatrixProxy::updatePath(DataArrayPath oldPath, DataArrayPath newPa
     dataArrays.remove(oldPath.getDataArrayName());
   }
 
-  daProxy.updatePath(oldPath, newPath);
+  daProxy.updatePath(renamePath);
 }

--- a/Source/SIMPLib/DataContainers/AttributeMatrixProxy.h
+++ b/Source/SIMPLib/DataContainers/AttributeMatrixProxy.h
@@ -132,6 +132,13 @@ class SIMPLib_EXPORT AttributeMatrixProxy
      */
     void setFlags(uint8_t flag, DataArrayProxy::PrimitiveTypeFlags primitiveTypes = DataArrayProxy::Any_PType, DataArrayProxy::CompDimsVector compDimsVector = DataArrayProxy::CompDimsVector());
 
+    /**
+     * @brief Updates the proxy to match a renamed DataArrayPath
+     * @param oldPath
+     * @param newPath
+     */
+    void updatePath(DataArrayPath oldPath, DataArrayPath newPath);
+
     //----- Our variables, publicly available
     uint8_t flag;
     QString name;

--- a/Source/SIMPLib/DataContainers/AttributeMatrixProxy.h
+++ b/Source/SIMPLib/DataContainers/AttributeMatrixProxy.h
@@ -134,10 +134,9 @@ class SIMPLib_EXPORT AttributeMatrixProxy
 
     /**
      * @brief Updates the proxy to match a renamed DataArrayPath
-     * @param oldPath
-     * @param newPath
+     * @param renamePath
      */
-    void updatePath(DataArrayPath oldPath, DataArrayPath newPath);
+    void updatePath(DataArrayPath::RenameType renamePath);
 
     //----- Our variables, publicly available
     uint8_t flag;

--- a/Source/SIMPLib/DataContainers/DataArrayPath.cpp
+++ b/Source/SIMPLib/DataContainers/DataArrayPath.cpp
@@ -492,8 +492,12 @@ bool DataArrayPath::possibleRename(const DataArrayPath& updated) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-bool DataArrayPath::updatePath(const DataArrayPath& oldPath, const DataArrayPath& newPath)
+bool DataArrayPath::updatePath(const DataArrayPath::RenameType& renamePath)
 {
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
   // Check for differences with original path
   if(false == hasSameDataArray(oldPath) && false == oldPath.getDataArrayName().isEmpty())
   {

--- a/Source/SIMPLib/DataContainers/DataArrayPath.cpp
+++ b/Source/SIMPLib/DataContainers/DataArrayPath.cpp
@@ -38,6 +38,7 @@
 #include <QtCore/QJsonObject>
 
 #include "SIMPLib/Common/Constants.h"
+#include "SIMPLib/DataContainers/DataContainerArray.h"
 
 // -----------------------------------------------------------------------------
 //
@@ -203,6 +204,122 @@ DataArrayPath DataArrayPath::Deserialize(QString str, QString delimiter)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+bool DataArrayPath::CheckRenamePath(DataContainerArrayShPtr oldDca, DataContainerArrayShPtr newDca, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  // If the paths are not possible renames, return false
+  if(false == oldPath.possibleRename(newPath))
+  {
+    return false;
+  }
+
+  // Check that the DataArrayPath targets are compatibles
+  DataContainer::Pointer oldDc = oldDca->getDataContainer(oldPath.getDataContainerName());
+  DataContainer::Pointer newDc = newDca->getDataContainer(newPath.getDataContainerName());
+
+  // Data Container required
+  if(oldDc && newDc)
+  {
+    IGeometry::Pointer oldGeom = oldDc->getGeometry();
+    IGeometry::Pointer newGeom = newDc->getGeometry();
+
+    bool hasGeom = oldGeom && newGeom;
+    if(hasGeom && oldGeom->getGeometryType() == newGeom->getGeometryType() || false == hasGeom)
+    {
+      // No Attribute Matrix path
+      if(oldPath.getAttributeMatrixName().isEmpty() && newPath.getAttributeMatrixName().isEmpty())
+      {
+        return true;
+      }
+
+      AttributeMatrix::Pointer oldAm = oldDc->getAttributeMatrix(oldPath.getAttributeMatrixName());
+      AttributeMatrix::Pointer newAm = newDc->getAttributeMatrix(newPath.getAttributeMatrixName());
+
+      bool hasAttributeMatrix = oldAm && newAm;
+      if(hasAttributeMatrix && oldAm->getType() == newAm->getType() && oldAm->getNumberOfTuples() == newAm->getNumberOfTuples())
+      {
+        // No Data Array path
+        if(oldPath.getDataArrayName().isEmpty() && newPath.getDataArrayName().isEmpty())
+        {
+          return true;
+        }
+
+        IDataArray::Pointer oldDa = oldAm->getAttributeArray(oldPath.getDataArrayName());
+        IDataArray::Pointer newDa = newAm->getAttributeArray(newPath.getDataArrayName());
+
+        bool hasDataArray = oldDa && newDa;
+        if(hasDataArray && oldDa->getTypeAsString() == newDa->getTypeAsString() && oldDa->getComponentDimensions() == newDa->getComponentDimensions())
+        {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+DataArrayPath::RenameContainer DataArrayPath::CheckForRenamedPaths(DataContainerArrayShPtr oldDca, DataContainerArrayShPtr newDca, std::list<DataArrayPath> oldPaths, std::list<DataArrayPath> newPaths)
+{
+  RenameContainer container;
+  std::list<DataArrayPath> duplicatedPaths;
+  std::list<DataArrayPath> usedNewPaths;
+
+  // For each older path, check for any matching new paths.  If only one new path matches, add it as a possibility
+  for(DataArrayPath oldPath : oldPaths)
+  {
+    if(std::find(newPaths.begin(), newPaths.end(), oldPath) != newPaths.end())
+    {
+      continue;
+    }
+
+    std::list<DataArrayPath> matches;
+    for(DataArrayPath newPath : newPaths)
+    {
+      // Check that all geometries, AttributeMatrices, and DataArrays are compatible
+      if(CheckRenamePath(oldDca, newDca, oldPath, newPath))
+      {
+        matches.push_back(newPath);
+      }
+    }
+    // If this path was already used, mark it as duplicate and move on
+    if(matches.size() == 1)
+    {
+      DataArrayPath newPath = (*matches.begin());
+      if(usedNewPaths.end() != std::find(usedNewPaths.begin(), usedNewPaths.end(), newPath))
+      {
+        duplicatedPaths.push_back(newPath);
+      }
+      else
+      {
+        usedNewPaths.push_back(newPath);
+        container.push_back(RenameType(oldPath, newPath));
+      }
+    }
+  }
+
+  // Remove items with duplicated paths
+  for(auto iter = container.begin(); iter != container.end(); )
+  {
+    DataArrayPath checkPath = std::get<1>(*iter);
+    if(duplicatedPaths.end() != std::find(duplicatedPaths.begin(), duplicatedPaths.end(), checkPath))
+    {
+      iter = container.erase(iter);
+    }
+    else
+    {
+      iter++;
+    }
+  }
+
+  return container;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 QVector<QString> DataArrayPath::toQVector()
 {
   QVector<QString> v(3);
@@ -315,6 +432,87 @@ bool DataArrayPath::hasSameDataArray(const DataArrayPath& other) const
 bool DataArrayPath::hasSameAttributeMatrixPath(const DataArrayPath& other) const
 {
   return (hasSameDataContainer(other) && hasSameAttributeMatrix(other));
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+bool DataArrayPath::possibleRename(const DataArrayPath& updated) const
+{
+  // Empty DataArrayPaths are not considered renames
+  // Neither are DataArrayPaths of different lengths
+  if(updated.getDataContainerName().isEmpty() || getDataContainerName().isEmpty())
+  {
+    return false;
+  }
+  else if(updated.getAttributeMatrixName().isEmpty() != getAttributeMatrixName().isEmpty())
+  {
+    return false;
+  }
+  else if(updated.getDataArrayName().isEmpty() != getDataArrayName().isEmpty())
+  {
+    return false;
+  }
+
+  // Check number of differences
+  int differences = 0;
+  if(false == hasSameDataArray(updated))
+  {
+    differences++;
+  }
+  if(false == hasSameAttributeMatrix(updated))
+  {
+    differences++;
+  }
+  if(false == hasSameDataContainer(updated))
+  {
+    differences++;
+  }
+
+  if(1 == differences)
+  {
+    return true;
+  }
+
+  return false;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+bool DataArrayPath::updatePath(const DataArrayPath& oldPath, const DataArrayPath& newPath)
+{
+  // Check for differences with original path
+  if(false == hasSameDataArray(oldPath) && false == oldPath.getDataArrayName().isEmpty())
+  {
+    return false;
+  }
+  else if(false == hasSameAttributeMatrix(oldPath) && false == oldPath.getAttributeMatrixName().isEmpty())
+  {
+    return false;
+  }
+  else if(false == hasSameDataContainer(oldPath) && false == oldPath.getDataContainerName().isEmpty())
+  {
+    return false;
+  }
+  else if(oldPath.getDataContainerName().isEmpty() || newPath.getDataContainerName().isEmpty())
+  {
+    return false;
+  }
+
+  // Substitude in the new DataArrayPath
+  setDataContainerName(newPath.getDataContainerName());
+  if(false == newPath.getAttributeMatrixName().isEmpty())
+  {
+    setAttributeMatrixName(newPath.getAttributeMatrixName());
+
+    if(false == newPath.getDataArrayName().isEmpty())
+    {
+      setDataArrayName(newPath.getDataArrayName());
+    }
+  }
+
+  return true;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/DataContainers/DataArrayPath.cpp
+++ b/Source/SIMPLib/DataContainers/DataArrayPath.cpp
@@ -517,17 +517,21 @@ bool DataArrayPath::updatePath(const DataArrayPath::RenameType& renamePath)
   }
 
   // Substitude in the new DataArrayPath
-  setDataContainerName(newPath.getDataContainerName());
-  if(false == newPath.getAttributeMatrixName().isEmpty())
+  if(hasSameDataContainer(oldPath))
   {
-    setAttributeMatrixName(newPath.getAttributeMatrixName());
+    setDataContainerName(newPath.getDataContainerName());
 
-    if(false == newPath.getDataArrayName().isEmpty())
+    if(hasSameAttributeMatrix(oldPath))
     {
-      setDataArrayName(newPath.getDataArrayName());
+      setAttributeMatrixName(newPath.getAttributeMatrixName());
+
+      if(hasSameDataArray(oldPath))
+      {
+        setDataArrayName(newPath.getDataArrayName());
+      }
     }
   }
-
+  
   return true;
 }
 

--- a/Source/SIMPLib/DataContainers/DataArrayPath.h
+++ b/Source/SIMPLib/DataContainers/DataArrayPath.h
@@ -41,9 +41,15 @@
 #include <QtCore/QString>
 #include <QtCore/QVector>
 
+#include <list>
+#include <set>
+#include <tuple>
+
 #include "SIMPLib/Common/SIMPLibDLLExport.h"     // for SIMPLib_EXPORT
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"  // for SIMPL_PIMPL_PROPERTY_DECL
 
+class DataContainerArray;
+using DataContainerArrayShPtr = std::shared_ptr<DataContainerArray>;
 
 /**
  * @brief The DataArrayPath class holds a complete or partial path to a data array starting at the DataContainer
@@ -54,6 +60,10 @@ class SIMPLib_EXPORT DataArrayPath : public QObject
     Q_OBJECT
 
   public:
+    // tuple <oldPath, newPath>
+    using RenameType = std::tuple<DataArrayPath, DataArrayPath>;
+    using RenameContainer = std::list<RenameType>;
+
     DataArrayPath();
 
     /**
@@ -113,6 +123,22 @@ class SIMPLib_EXPORT DataArrayPath : public QObject
     */
     static DataArrayPath Deserialize(QString str, QString delimiter);
 
+    /**
+     * @brief checks for and returns any updated DataArrayPaths between two sets
+     * @param oldPaths
+     * @param newPaths
+     * @return
+     */
+    static RenameContainer CheckForRenamedPaths(DataContainerArrayShPtr oldDca, DataContainerArrayShPtr newDca, std::list<DataArrayPath> oldPaths, std::list<DataArrayPath> newPaths);
+
+    /**
+     * @brief checks if the targets of the old DataArrayPath and new DataArrayPath are compatible in their given DataContainerArrays
+     * @param oldDca
+     * @param newDca
+     * @param oldPath
+     * @param newPath
+     */
+    static bool CheckRenamePath(DataContainerArrayShPtr oldDca, DataContainerArrayShPtr newDca, DataArrayPath oldPath, DataArrayPath newPath);
 
     SIMPL_INSTANCE_STRING_PROPERTY(DataContainerName)
     SIMPL_INSTANCE_STRING_PROPERTY(AttributeMatrixName)
@@ -201,6 +227,23 @@ class SIMPLib_EXPORT DataArrayPath : public QObject
      * @return true if the two paths share the same data array, false otherwise
      */
     bool hasSameDataArray(const DataArrayPath& other) const;
+
+    /**
+     * @brief checks if the given DataArrayPath could indicate a possible renamed path.
+     * This requires that the given path be no longer than the current path and only one value is changed.
+     * Returns true if this is a possible rename and returns false otherwise.
+     * @param updated
+     * @return
+     */
+    bool possibleRename(const DataArrayPath& updated) const;
+
+    /**
+     * @brief updates the current path based on the newPath if it matches the given previous value
+     * @param oldPath
+     * @param newPath
+     * return
+     */
+    bool updatePath(const DataArrayPath& oldPath, const DataArrayPath& newPath);
 
     /**
     * @brief Writes the contents of the proxy to the json object 'json'

--- a/Source/SIMPLib/DataContainers/DataArrayPath.h
+++ b/Source/SIMPLib/DataContainers/DataArrayPath.h
@@ -239,11 +239,10 @@ class SIMPLib_EXPORT DataArrayPath : public QObject
 
     /**
      * @brief updates the current path based on the newPath if it matches the given previous value
-     * @param oldPath
-     * @param newPath
+     * @param renamePath
      * return
      */
-    bool updatePath(const DataArrayPath& oldPath, const DataArrayPath& newPath);
+    bool updatePath(const DataArrayPath::RenameType& renamePath);
 
     /**
     * @brief Writes the contents of the proxy to the json object 'json'

--- a/Source/SIMPLib/DataContainers/DataArrayPath.h
+++ b/Source/SIMPLib/DataContainers/DataArrayPath.h
@@ -155,7 +155,7 @@ class SIMPLib_EXPORT DataArrayPath : public QObject
      * @param rhs
      * @return
      */
-    bool operator==(const DataArrayPath& rhs);
+    bool operator==(const DataArrayPath& rhs) const;
 
     /**
      * @brief serialize Returns the path using the '|' charater by default. This can be over ridden by the programmer

--- a/Source/SIMPLib/DataContainers/DataArrayProxy.cpp
+++ b/Source/SIMPLib/DataContainers/DataArrayProxy.cpp
@@ -312,8 +312,12 @@ DataArrayProxy::PrimitiveTypeFlag DataArrayProxy::PrimitiveTypeToFlag(const QStr
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataArrayProxy::updatePath(DataArrayPath oldPath, DataArrayPath newPath)
+void DataArrayProxy::updatePath(DataArrayPath::RenameType renamePath)
 {
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
   if(oldPath.getDataArrayName().isEmpty())
   {
     return;

--- a/Source/SIMPLib/DataContainers/DataArrayProxy.cpp
+++ b/Source/SIMPLib/DataContainers/DataArrayProxy.cpp
@@ -308,3 +308,20 @@ DataArrayProxy::PrimitiveTypeFlag DataArrayProxy::PrimitiveTypeToFlag(const QStr
 
   return None_PType;
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataArrayProxy::updatePath(DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(oldPath.getDataArrayName().isEmpty())
+  {
+    return;
+  }
+
+  if(oldPath.getDataArrayName() != newPath.getDataArrayName())
+  {
+    name = newPath.getDataArrayName();
+    path = newPath.serialize();
+  }
+}

--- a/Source/SIMPLib/DataContainers/DataArrayProxy.h
+++ b/Source/SIMPLib/DataContainers/DataArrayProxy.h
@@ -137,7 +137,7 @@ public:
   * @param oldPath
   * @param newPath
   */
-  void updatePath(DataArrayPath oldPath, DataArrayPath newPath);
+  void updatePath(DataArrayPath::RenameType renamePath);
 
   /**
   * @brief operator = method

--- a/Source/SIMPLib/DataContainers/DataArrayProxy.h
+++ b/Source/SIMPLib/DataContainers/DataArrayProxy.h
@@ -45,6 +45,7 @@
 #include <hdf5.h>
 
 #include "SIMPLib/Common/Constants.h"
+#include "SIMPLib/DataContainers/DataArrayPath.h"
 
 class SIMPLH5DataReaderRequirements;
 
@@ -130,6 +131,13 @@ public:
    * @param h5InternalPath
    */
   static void ReadDataArrayStructure(hid_t attrMatGid, QMap<QString, DataArrayProxy>& dataArrays, SIMPLH5DataReaderRequirements* req, QString h5InternalPath);
+
+  /**
+  * @brief Updates the proxy to match a renamed DataArrayPath
+  * @param oldPath
+  * @param newPath
+  */
+  void updatePath(DataArrayPath oldPath, DataArrayPath newPath);
 
   /**
   * @brief operator = method

--- a/Source/SIMPLib/DataContainers/DataContainerArray.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainerArray.cpp
@@ -539,3 +539,37 @@ DataContainerArray::Pointer DataContainerArray::deepCopy(bool forceNoAllocate)
 
   return dcaCopy;
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataContainerArray::renameDataArrayPaths(DataArrayPath::RenameContainer renamePaths)
+{
+  for(DataArrayPath::RenameType renameType : renamePaths)
+  {
+    DataArrayPath oldPath;
+    DataArrayPath newPath;
+    std::tie(oldPath, newPath) = renameType;
+
+    if(oldPath.getDataContainerName() != newPath.getDataContainerName())
+    {
+      renameDataContainer(oldPath.getDataContainerName(), newPath.getDataContainerName());
+    }
+    if(oldPath.getAttributeMatrixName() != newPath.getAttributeMatrixName())
+    {
+      DataContainer::Pointer dc = getDataContainer(newPath);
+      if(dc)
+      {
+        dc->renameAttributeMatrix(oldPath.getAttributeMatrixName(), newPath.getAttributeMatrixName());
+      }
+    }
+    if(oldPath.getDataArrayName() != newPath.getDataArrayName())
+    {
+      AttributeMatrix::Pointer am = getAttributeMatrix(newPath);
+      if(am)
+      {
+        am->renameAttributeArray(oldPath.getDataArrayName(), newPath.getDataArrayName());
+      }
+    }
+  }
+}

--- a/Source/SIMPLib/DataContainers/DataContainerArray.h
+++ b/Source/SIMPLib/DataContainers/DataContainerArray.h
@@ -237,6 +237,12 @@ class SIMPLib_EXPORT DataContainerArray : public QObject
     void removeDataContainerFromBundles(const QString& name);
 
     /**
+    * @brief renameDataArrayPaths
+    * @param renamePaths
+    */
+    void renameDataArrayPaths(DataArrayPath::RenameContainer renamePaths);
+
+    /**
      * @brief getPrereqDataContainer
      * @param name
      * @param createIfNotExists

--- a/Source/SIMPLib/DataContainers/DataContainerArrayProxy.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainerArrayProxy.cpp
@@ -494,10 +494,12 @@ void DataContainerArrayProxy::updatePath(DataArrayPath::RenameType renamePath)
   DataArrayPath newPath;
   std::tie(oldPath, newPath) = renamePath;
 
-  DataContainerProxy dcProxy = dataContainers.take(oldPath.getDataContainerName());
-  dcProxy.updatePath(renamePath);
-
-  dataContainers.insert(newPath.getDataContainerName(), dcProxy);
+  if(dataContainers.contains(oldPath.getDataContainerName()))
+  {
+    DataContainerProxy dcProxy = dataContainers.take(oldPath.getDataContainerName());
+    dcProxy.updatePath(renamePath);
+    dataContainers.insert(newPath.getDataContainerName(), dcProxy);
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/DataContainers/DataContainerArrayProxy.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainerArrayProxy.cpp
@@ -488,6 +488,22 @@ DataContainerProxy& DataContainerArrayProxy::getDataContainerProxy(const QString
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+void DataContainerArrayProxy::updatePath(DataArrayPath oldPath, DataArrayPath newPath)
+{
+  DataContainerProxy dcProxy = dataContainers[oldPath.getDataContainerName()];
+
+  if(oldPath.getDataContainerName() != newPath.getDataContainerName())
+  {
+    dataContainers.insert(newPath.getDataContainerName(), dcProxy);
+    dataContainers.remove(oldPath.getDataContainerName());
+  }
+
+  dcProxy.updatePath(oldPath, newPath);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void DataContainerArrayProxy::writeJson(QJsonObject& json) const
 {
   json["Data Containers"] = writeMap(dataContainers);

--- a/Source/SIMPLib/DataContainers/DataContainerArrayProxy.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainerArrayProxy.cpp
@@ -494,15 +494,10 @@ void DataContainerArrayProxy::updatePath(DataArrayPath::RenameType renamePath)
   DataArrayPath newPath;
   std::tie(oldPath, newPath) = renamePath;
 
-  DataContainerProxy dcProxy = dataContainers[oldPath.getDataContainerName()];
-
-  if(oldPath.getDataContainerName() != newPath.getDataContainerName())
-  {
-    dataContainers.insert(newPath.getDataContainerName(), dcProxy);
-    dataContainers.remove(oldPath.getDataContainerName());
-  }
-
+  DataContainerProxy dcProxy = dataContainers.take(oldPath.getDataContainerName());
   dcProxy.updatePath(renamePath);
+
+  dataContainers.insert(newPath.getDataContainerName(), dcProxy);
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/DataContainers/DataContainerArrayProxy.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainerArrayProxy.cpp
@@ -488,8 +488,12 @@ DataContainerProxy& DataContainerArrayProxy::getDataContainerProxy(const QString
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataContainerArrayProxy::updatePath(DataArrayPath oldPath, DataArrayPath newPath)
+void DataContainerArrayProxy::updatePath(DataArrayPath::RenameType renamePath)
 {
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
   DataContainerProxy dcProxy = dataContainers[oldPath.getDataContainerName()];
 
   if(oldPath.getDataContainerName() != newPath.getDataContainerName())
@@ -498,7 +502,7 @@ void DataContainerArrayProxy::updatePath(DataArrayPath oldPath, DataArrayPath ne
     dataContainers.remove(oldPath.getDataContainerName());
   }
 
-  dcProxy.updatePath(oldPath, newPath);
+  dcProxy.updatePath(renamePath);
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/DataContainers/DataContainerArrayProxy.h
+++ b/Source/SIMPLib/DataContainers/DataContainerArrayProxy.h
@@ -166,10 +166,9 @@ class SIMPLib_EXPORT DataContainerArrayProxy
 
     /**
      * @brief Updates the proxy to match a renamed DataArrayPath
-     * @param oldPath
-     * @param newPath
+     * @param renamePath
      */
-    void updatePath(DataArrayPath oldPath, DataArrayPath newPath);
+    void updatePath(DataArrayPath::RenameType renamePath);
 
     /**
     * @brief Writes the contents of the proxy to the json object 'json'

--- a/Source/SIMPLib/DataContainers/DataContainerArrayProxy.h
+++ b/Source/SIMPLib/DataContainers/DataContainerArrayProxy.h
@@ -165,6 +165,13 @@ class SIMPLib_EXPORT DataContainerArrayProxy
     DataContainerProxy& getDataContainerProxy(const QString& name);
 
     /**
+     * @brief Updates the proxy to match a renamed DataArrayPath
+     * @param oldPath
+     * @param newPath
+     */
+    void updatePath(DataArrayPath oldPath, DataArrayPath newPath);
+
+    /**
     * @brief Writes the contents of the proxy to the json object 'json'
     * @param json
     * @return

--- a/Source/SIMPLib/DataContainers/DataContainerProxy.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainerProxy.cpp
@@ -91,6 +91,32 @@ bool DataContainerProxy::operator==(const DataContainerProxy& amp) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+void DataContainerProxy::updatePath(DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(oldPath.getDataContainerName() != newPath.getDataContainerName())
+  {
+    name = newPath.getDataContainerName();
+  }
+
+  if(oldPath.getAttributeMatrixName().isEmpty())
+  {
+    return;
+  }
+
+  AttributeMatrixProxy amProxy = attributeMatricies[oldPath.getAttributeMatrixName()];
+
+  if(oldPath.getAttributeMatrixName() != newPath.getAttributeMatrixName())
+  {
+    attributeMatricies.insert(newPath.getAttributeMatrixName(), amProxy);
+    attributeMatricies.remove(oldPath.getAttributeMatrixName());
+  }
+
+  amProxy.updatePath(oldPath, newPath);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void DataContainerProxy::writeJson(QJsonObject& json)
 {
   json["Flag"] = static_cast<double>(flag);

--- a/Source/SIMPLib/DataContainers/DataContainerProxy.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainerProxy.cpp
@@ -41,7 +41,7 @@
 DataContainerProxy::DataContainerProxy() :
   flag(Qt::Unchecked),
   name(""),
-  dcType(0)
+  dcType(static_cast<unsigned int>(IGeometry::Type::Any))
 {}
 
 // -----------------------------------------------------------------------------
@@ -107,15 +107,10 @@ void DataContainerProxy::updatePath(DataArrayPath::RenameType renamePath)
     return;
   }
 
-  AttributeMatrixProxy amProxy = attributeMatricies[oldPath.getAttributeMatrixName()];
-
-  if(oldPath.getAttributeMatrixName() != newPath.getAttributeMatrixName())
-  {
-    attributeMatricies.insert(newPath.getAttributeMatrixName(), amProxy);
-    attributeMatricies.remove(oldPath.getAttributeMatrixName());
-  }
-
+  AttributeMatrixProxy amProxy = attributeMatricies.take(oldPath.getAttributeMatrixName());
   amProxy.updatePath(renamePath);
+
+  attributeMatricies.insert(newPath.getAttributeMatrixName(), amProxy);
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/DataContainers/DataContainerProxy.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainerProxy.cpp
@@ -102,15 +102,12 @@ void DataContainerProxy::updatePath(DataArrayPath::RenameType renamePath)
     name = newPath.getDataContainerName();
   }
 
-  if(oldPath.getAttributeMatrixName().isEmpty())
+  if(attributeMatricies.contains(oldPath.getAttributeMatrixName()))
   {
-    return;
+    AttributeMatrixProxy amProxy = attributeMatricies.take(oldPath.getAttributeMatrixName());
+    amProxy.updatePath(renamePath);
+    attributeMatricies.insert(newPath.getAttributeMatrixName(), amProxy);
   }
-
-  AttributeMatrixProxy amProxy = attributeMatricies.take(oldPath.getAttributeMatrixName());
-  amProxy.updatePath(renamePath);
-
-  attributeMatricies.insert(newPath.getAttributeMatrixName(), amProxy);
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/DataContainers/DataContainerProxy.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainerProxy.cpp
@@ -91,8 +91,12 @@ bool DataContainerProxy::operator==(const DataContainerProxy& amp) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataContainerProxy::updatePath(DataArrayPath oldPath, DataArrayPath newPath)
+void DataContainerProxy::updatePath(DataArrayPath::RenameType renamePath)
 {
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
   if(oldPath.getDataContainerName() != newPath.getDataContainerName())
   {
     name = newPath.getDataContainerName();
@@ -111,7 +115,7 @@ void DataContainerProxy::updatePath(DataArrayPath oldPath, DataArrayPath newPath
     attributeMatricies.remove(oldPath.getAttributeMatrixName());
   }
 
-  amProxy.updatePath(oldPath, newPath);
+  amProxy.updatePath(renamePath);
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/DataContainers/DataContainerProxy.h
+++ b/Source/SIMPLib/DataContainers/DataContainerProxy.h
@@ -133,10 +133,9 @@ class SIMPLib_EXPORT DataContainerProxy
 
     /**
      * @brief Updates the proxy to match a renamed DataArrayPath
-     * @param oldPath
-     * @param newPath
+     * @param renamePath
      */
-    void updatePath(DataArrayPath oldPath, DataArrayPath newPath);
+    void updatePath(DataArrayPath::RenameType renamePath);
 
     //----- Our variables, publicly available
     uint8_t flag;

--- a/Source/SIMPLib/DataContainers/DataContainerProxy.h
+++ b/Source/SIMPLib/DataContainers/DataContainerProxy.h
@@ -131,6 +131,13 @@ class SIMPLib_EXPORT DataContainerProxy
     void setFlags(uint8_t flag, AttributeMatrixProxy::AMTypeFlags amTypes = AttributeMatrixProxy::Any_AMType,
                   DataArrayProxy::PrimitiveTypeFlags primitiveTypes = DataArrayProxy::Any_PType, DataArrayProxy::CompDimsVector compDimsVector = DataArrayProxy::CompDimsVector());
 
+    /**
+     * @brief Updates the proxy to match a renamed DataArrayPath
+     * @param oldPath
+     * @param newPath
+     */
+    void updatePath(DataArrayPath oldPath, DataArrayPath newPath);
+
     //----- Our variables, publicly available
     uint8_t flag;
     QString name;

--- a/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.cpp
@@ -166,11 +166,15 @@ void AttributeMatrixSelectionFilterParameter::writeJson(QJsonObject& json)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void AttributeMatrixSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath)
+void AttributeMatrixSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
 {
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
   if(m_GetterCallback() == oldPath)
   {
     m_SetterCallback(newPath);
-    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
   }
 }

--- a/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.cpp
@@ -37,6 +37,7 @@
 
 #include "SIMPLib/Common/Constants.h"
 #include "SIMPLib/DataContainers/AttributeMatrix.h"
+#include "SIMPLib/Filtering/AbstractFilter.h"
 
 // -----------------------------------------------------------------------------
 //
@@ -159,5 +160,17 @@ void AttributeMatrixSelectionFilterParameter::writeJson(QJsonObject& json)
     QJsonObject obj;
     dap.writeJson(obj);
     json[getPropertyName()] = obj;
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void AttributeMatrixSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(m_GetterCallback() == oldPath)
+  {
+    m_SetterCallback(newPath);
+    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
   }
 }

--- a/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.cpp
@@ -162,19 +162,3 @@ void AttributeMatrixSelectionFilterParameter::writeJson(QJsonObject& json)
     json[getPropertyName()] = obj;
   }
 }
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void AttributeMatrixSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
-{
-  DataArrayPath oldPath;
-  DataArrayPath newPath;
-  std::tie(oldPath, newPath) = renamePath;
-
-  if(m_GetterCallback() == oldPath)
-  {
-    m_SetterCallback(newPath);
-    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
-  }
-}

--- a/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.h
@@ -169,13 +169,6 @@ class SIMPLib_EXPORT AttributeMatrixSelectionFilterParameter : public FilterPara
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
-    /**
-     * @brief Handle DataArrayPath changes if necessary
-     * @param filter
-     * @param renamePath
-     */
-    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
-
   protected:
       /**
        * @brief AttributeMatrixSelectionFilterParameter The default constructor.  It is protected because this

--- a/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.h
@@ -171,8 +171,10 @@ class SIMPLib_EXPORT AttributeMatrixSelectionFilterParameter : public FilterPara
 
     /**
      * @brief Handle DataArrayPath changes if necessary
+     * @param filter
+     * @param renamePath
      */
-    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath) override;
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
 
   protected:
       /**

--- a/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.h
@@ -169,6 +169,11 @@ class SIMPLib_EXPORT AttributeMatrixSelectionFilterParameter : public FilterPara
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
+    /**
+     * @brief Handle DataArrayPath changes if necessary
+     */
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath) override;
+
   protected:
       /**
        * @brief AttributeMatrixSelectionFilterParameter The default constructor.  It is protected because this

--- a/Source/SIMPLib/FilterParameters/CalculatorFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/CalculatorFilterParameter.cpp
@@ -35,6 +35,8 @@
 
 #include "CalculatorFilterParameter.h"
 
+#include "SIMPLib/Filtering/AbstractFilter.h"
+
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -96,4 +98,20 @@ void CalculatorFilterParameter::writeJson(QJsonObject& json)
   {
     json[getPropertyName()] = m_GetterCallback();
   }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void CalculatorFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  QString inputStr = m_GetterCallback();
+  inputStr.replace(oldPath.getDataArrayName(), newPath.getDataArrayName());
+  m_SetterCallback(inputStr);
+
+  emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
 }

--- a/Source/SIMPLib/FilterParameters/CalculatorFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/CalculatorFilterParameter.h
@@ -126,6 +126,13 @@ public:
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
+    /**
+     * @brief Handles DataArrayPath changes wwith the assumption that the DataContainer and AttributeMatrix both match the input
+     * @param filter
+     * @param renamePath
+     */
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
+
   protected:
     /**
      * @brief CalculatorFilterParameter The default constructor.  It is protected because this

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionAdvancedFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionAdvancedFilterParameter.h
@@ -40,6 +40,7 @@
 
 #include "SIMPLib/DataContainers/AttributeMatrix.h"
 #include "SIMPLib/FilterParameters/FilterParameter.h"
+#include "SIMPLib/Filtering/AbstractComparison.h"
 #include "SIMPLib/Filtering/ComparisonInputsAdvanced.h"
 #include "SIMPLib/Geometry/IGeometry.h"
 
@@ -138,11 +139,18 @@ class SIMPLib_EXPORT ComparisonSelectionAdvancedFilterParameter : public FilterP
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
+    /**
+     * @brief Handle DataArrayPath changes if necessary
+     * @param filter
+     * @param renamePath
+     */
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
+
   protected:
-      /**
-       * @brief ComparisonSelectionAdvancedFilterParameter The default constructor.  It is protected because this
-       * filter parameter should only be instantiated using its New(...) function or short-form macro.
-       */
+    /**
+     * @brief ComparisonSelectionAdvancedFilterParameter The default constructor.  It is protected because this
+     * filter parameter should only be instantiated using its New(...) function or short-form macro.
+     */
     ComparisonSelectionAdvancedFilterParameter();
 
   private:

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.cpp
@@ -143,8 +143,8 @@ void ComparisonSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* fi
   int count = inputs.size();
   for(int i = 0; i < count; i++)
   {
-    ComparisonInput_t input = inputs.getInput(i);
-    
+    ComparisonInput_t& input = inputs.getInput(i);
+
     bool hasAttributeMatrix = oldPath.getAttributeMatrixName().isEmpty() == false;
     bool hasDataArray = oldPath.getDataArrayName().isEmpty() == false;
 
@@ -170,6 +170,7 @@ void ComparisonSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* fi
 
   if(hasChanges)
   {
+    m_SetterCallback(inputs);
     emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
   }
 }

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.cpp
@@ -131,8 +131,12 @@ void ComparisonSelectionFilterParameter::writeJson(QJsonObject& json)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void ComparisonSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath)
+void ComparisonSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
 {
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
   ComparisonInputs inputs = m_GetterCallback();
   bool hasChanges = false;
 
@@ -166,6 +170,6 @@ void ComparisonSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* fi
 
   if(hasChanges)
   {
-    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
   }
 }

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.cpp
@@ -37,6 +37,8 @@
 
 #include <QtCore/QJsonArray>
 
+#include "SIMPLib/Filtering/AbstractFilter.h"
+
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -123,5 +125,47 @@ void ComparisonSelectionFilterParameter::writeJson(QJsonObject& json)
     }
 
     json[getPropertyName()] = inputsArray;
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ComparisonSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  ComparisonInputs inputs = m_GetterCallback();
+  bool hasChanges = false;
+
+  int count = inputs.size();
+  for(int i = 0; i < count; i++)
+  {
+    ComparisonInput_t input = inputs.getInput(i);
+    
+    bool hasAttributeMatrix = oldPath.getAttributeMatrixName().isEmpty() == false;
+    bool hasDataArray = oldPath.getDataArrayName().isEmpty() == false;
+
+    bool sameDC = input.dataContainerName == oldPath.getDataContainerName();
+    bool sameAM = input.attributeMatrixName == oldPath.getAttributeMatrixName();
+    bool sameDA = input.attributeArrayName == oldPath.getDataArrayName();
+    if(sameDC && (!hasAttributeMatrix || (sameAM && (!hasDataArray || sameDA))))
+    {
+      input.dataContainerName = newPath.getDataContainerName();
+
+      if(hasAttributeMatrix)
+      {
+        input.attributeMatrixName = newPath.getAttributeMatrixName();
+        if(hasDataArray)
+        {
+          input.attributeArrayName = newPath.getDataArrayName();
+        }
+      }
+
+      hasChanges = true;
+    }
+  }
+
+  if(hasChanges)
+  {
+    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
   }
 }

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.h
@@ -141,10 +141,9 @@ class SIMPLib_EXPORT ComparisonSelectionFilterParameter : public FilterParameter
     /**
      * @brief Handle DataArrayPath changes if necessary
      * @param filter
-     * @param oldPath
-     * @param newPath
+     * @param renamePath
      */
-    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath) override;
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
 
   protected:
       /**

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.h
@@ -138,6 +138,14 @@ class SIMPLib_EXPORT ComparisonSelectionFilterParameter : public FilterParameter
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
+    /**
+     * @brief Handle DataArrayPath changes if necessary
+     * @param filter
+     * @param oldPath
+     * @param newPath
+     */
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath) override;
+
   protected:
       /**
        * @brief ComparisonSelectionFilterParameter The default constructor.  It is protected because this

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
@@ -198,11 +198,15 @@ void DataArraySelectionFilterParameter::writeJson(QJsonObject& json)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataArraySelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath)
+void DataArraySelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
 {
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
   if(m_GetterCallback() == oldPath)
   {
     m_SetterCallback(newPath);
-    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
   }
 }

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
@@ -35,6 +35,7 @@
 
 #include "DataArraySelectionFilterParameter.h"
 #include "SIMPLib/Common/Constants.h"
+#include "SIMPLib/Filtering/AbstractFilter.h"
 
 // -----------------------------------------------------------------------------
 //
@@ -191,5 +192,17 @@ void DataArraySelectionFilterParameter::writeJson(QJsonObject& json)
     QJsonObject obj;
     dap.writeJson(obj);
     json[getPropertyName()] = obj;
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataArraySelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(m_GetterCallback() == oldPath)
+  {
+    m_SetterCallback(newPath);
+    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
   }
 }

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
@@ -194,19 +194,3 @@ void DataArraySelectionFilterParameter::writeJson(QJsonObject& json)
     json[getPropertyName()] = obj;
   }
 }
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void DataArraySelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
-{
-  DataArrayPath oldPath;
-  DataArrayPath newPath;
-  std::tie(oldPath, newPath) = renamePath;
-
-  if(m_GetterCallback() == oldPath)
-  {
-    m_SetterCallback(newPath);
-    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
-  }
-}

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
@@ -192,13 +192,6 @@ class SIMPLib_EXPORT DataArraySelectionFilterParameter : public FilterParameter
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
-    /**
-     * @brief Handle DataArrayPath changes if necessary
-     * @param filter
-     * @param renamePath
-     */
-    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
-
   protected:
       /**
        * @brief DataArraySelectionFilterParameter The default constructor.  It is protected because this

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
@@ -194,8 +194,10 @@ class SIMPLib_EXPORT DataArraySelectionFilterParameter : public FilterParameter
 
     /**
      * @brief Handle DataArrayPath changes if necessary
+     * @param filter
+     * @param renamePath
      */
-    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath) override;
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
 
   protected:
       /**

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
@@ -192,6 +192,11 @@ class SIMPLib_EXPORT DataArraySelectionFilterParameter : public FilterParameter
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
+    /**
+     * @brief Handle DataArrayPath changes if necessary
+     */
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath) override;
+
   protected:
       /**
        * @brief DataArraySelectionFilterParameter The default constructor.  It is protected because this

--- a/Source/SIMPLib/FilterParameters/DataContainerArrayProxyFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataContainerArrayProxyFilterParameter.cpp
@@ -35,6 +35,8 @@
 
 #include "DataContainerArrayProxyFilterParameter.h"
 
+#include "SIMPLib/Filtering/AbstractFilter.h"
+
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -107,4 +109,17 @@ void DataContainerArrayProxyFilterParameter::writeJson(QJsonObject& json)
     proxy.writeJson(obj);
     json[getPropertyName()] = obj;
   }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataContainerArrayProxyFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
+{
+  QVariant var = filter->property(qPrintable(getPropertyName()));
+  DataContainerArrayProxy dcaProxy = var.value<DataContainerArrayProxy>();
+  dcaProxy.updatePath(renamePath);
+  var.setValue(dcaProxy);
+  filter->setProperty(qPrintable(getPropertyName()), var);
+  emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
 }

--- a/Source/SIMPLib/FilterParameters/DataContainerArrayProxyFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerArrayProxyFilterParameter.h
@@ -134,6 +134,10 @@ class SIMPLib_EXPORT DataContainerArrayProxyFilterParameter : public FilterParam
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
+    /**
+     * @brief Handle DataArrayPath changes if necessary
+     */
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
 
   protected:
       /**

--- a/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.cpp
@@ -106,11 +106,15 @@ void DataContainerSelectionFilterParameter::writeJson(QJsonObject& json)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataContainerSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath)
+void DataContainerSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
 {
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
   if(m_GetterCallback() == oldPath.getDataContainerName())
   {
     m_SetterCallback(newPath.getDataContainerName());
-    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
   }
 }

--- a/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.cpp
@@ -102,19 +102,3 @@ void DataContainerSelectionFilterParameter::writeJson(QJsonObject& json)
     json[getPropertyName()] = m_GetterCallback();
   }
 }
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void DataContainerSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
-{
-  DataArrayPath oldPath;
-  DataArrayPath newPath;
-  std::tie(oldPath, newPath) = renamePath;
-
-  if(m_GetterCallback() == oldPath.getDataContainerName())
-  {
-    m_SetterCallback(newPath.getDataContainerName());
-    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
-  }
-}

--- a/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.cpp
@@ -35,6 +35,8 @@
 
 #include "DataContainerSelectionFilterParameter.h"
 
+#include "SIMPLib/Filtering/AbstractFilter.h"
+
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -98,5 +100,17 @@ void DataContainerSelectionFilterParameter::writeJson(QJsonObject& json)
   if(m_GetterCallback)
   {
     json[getPropertyName()] = m_GetterCallback();
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataContainerSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(m_GetterCallback() == oldPath.getDataContainerName())
+  {
+    m_SetterCallback(newPath.getDataContainerName());
+    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
   }
 }

--- a/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.cpp
@@ -102,3 +102,19 @@ void DataContainerSelectionFilterParameter::writeJson(QJsonObject& json)
     json[getPropertyName()] = m_GetterCallback();
   }
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataContainerSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  if(oldPath.getDataContainerName() == m_GetterCallback() && oldPath.getDataContainerName() != newPath.getDataContainerName())
+  {
+    m_SetterCallback(newPath.getDataContainerName());
+    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
+  }
+}

--- a/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
@@ -140,6 +140,13 @@ class SIMPLib_EXPORT DataContainerSelectionFilterParameter : public FilterParame
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
+    /**
+     * @brief Handles changes to the DataArrayPath
+     * @param filter
+     * @param renamePath
+     */
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
+
   protected:
       /**
        * @brief DataContainerSelectionFilterParameter The default constructor.  It is protected because this

--- a/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
@@ -140,6 +140,14 @@ class SIMPLib_EXPORT DataContainerSelectionFilterParameter : public FilterParame
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
+    /**
+     * @brief Handle DataArrayPath changes if necessary
+     * @param filter
+     * @param oldPath
+     * @param newPath
+     */
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath) override;
+
   protected:
       /**
        * @brief DataContainerSelectionFilterParameter The default constructor.  It is protected because this

--- a/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
@@ -143,10 +143,9 @@ class SIMPLib_EXPORT DataContainerSelectionFilterParameter : public FilterParame
     /**
      * @brief Handle DataArrayPath changes if necessary
      * @param filter
-     * @param oldPath
-     * @param newPath
+     * @param renamePath
      */
-    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath) override;
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
 
   protected:
       /**

--- a/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
@@ -140,13 +140,6 @@ class SIMPLib_EXPORT DataContainerSelectionFilterParameter : public FilterParame
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
-    /**
-     * @brief Handle DataArrayPath changes if necessary
-     * @param filter
-     * @param renamePath
-     */
-    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
-
   protected:
       /**
        * @brief DataContainerSelectionFilterParameter The default constructor.  It is protected because this

--- a/Source/SIMPLib/FilterParameters/FilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/FilterParameter.cpp
@@ -76,49 +76,49 @@ void FilterParameter::writeJson(QJsonObject& json)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void FilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath)
+void FilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
 {
   QVariant var = filter->property(qPrintable(getPropertyName()));
   if(var.isValid() && var.canConvert<DataArrayPath>())
   {
     DataArrayPath path = var.value<DataArrayPath>();
-    if(path.updatePath(oldPath, newPath))
+    if(path.updatePath(renamePath))
     {
       var.setValue(path);
       filter->setProperty(qPrintable(getPropertyName()), var);
-      emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+      emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
     }
   }
   else if(var.isValid() && var.canConvert<DataContainerArrayProxy>())
   {
     DataContainerArrayProxy proxy = var.value<DataContainerArrayProxy>();
-    proxy.updatePath(oldPath, newPath);
+    proxy.updatePath(renamePath);
     var.setValue(proxy);
     filter->setProperty(qPrintable(getPropertyName()), var);
-    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
   }
   else if(var.isValid() && var.canConvert<DataContainerProxy>())
   {
     DataContainerProxy proxy = var.value<DataContainerProxy>();
-    proxy.updatePath(oldPath, newPath);
+    proxy.updatePath(renamePath);
     var.setValue(proxy);
     filter->setProperty(qPrintable(getPropertyName()), var);
-    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
   }
   else if(var.isValid() && var.canConvert<AttributeMatrixProxy>())
   {
     AttributeMatrixProxy proxy = var.value<AttributeMatrixProxy>();
-    proxy.updatePath(oldPath, newPath);
+    proxy.updatePath(renamePath);
     var.setValue(proxy);
     filter->setProperty(qPrintable(getPropertyName()), var);
-    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
   }
   else if(var.isValid() && var.canConvert<DataArrayProxy>())
   {
     DataArrayProxy proxy = var.value<DataArrayProxy>();
-    proxy.updatePath(oldPath, newPath);
+    proxy.updatePath(renamePath);
     var.setValue(proxy);
     filter->setProperty(qPrintable(getPropertyName()), var);
-    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+    emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
   }
 }

--- a/Source/SIMPLib/FilterParameters/FilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/FilterParameter.cpp
@@ -84,9 +84,6 @@ void FilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath
     DataArrayPath path = var.value<DataArrayPath>();
     if(path.updatePath(oldPath, newPath))
     {
-      //QString ss = QString("Updated property '%1' in %2").arg(name).arg(getHumanLabel());
-      //notifyStandardOutputMessage(getHumanLabel(), getPipelineIndex(), ss);
-      //notifyStatusMessage(getHumanLabel(), ss);
       var.setValue(path);
       filter->setProperty(qPrintable(getPropertyName()), var);
       emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);

--- a/Source/SIMPLib/FilterParameters/FilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/FilterParameter.cpp
@@ -37,6 +37,9 @@
 
 #include <QtCore/QJsonObject>
 
+#include "SIMPLib/Filtering/AbstractFilter.h"
+#include "SIMPLib/DataContainers/DataContainerArrayProxy.h"
+
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -68,4 +71,57 @@ void FilterParameter::readJson(const QJsonObject& json)
 void FilterParameter::writeJson(QJsonObject& json)
 {
   Q_UNUSED(json)
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void FilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  QVariant var = filter->property(qPrintable(getPropertyName()));
+  if(var.isValid() && var.canConvert<DataArrayPath>())
+  {
+    DataArrayPath path = var.value<DataArrayPath>();
+    if(path.updatePath(oldPath, newPath))
+    {
+      //QString ss = QString("Updated property '%1' in %2").arg(name).arg(getHumanLabel());
+      //notifyStandardOutputMessage(getHumanLabel(), getPipelineIndex(), ss);
+      //notifyStatusMessage(getHumanLabel(), ss);
+      var.setValue(path);
+      filter->setProperty(qPrintable(getPropertyName()), var);
+      emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+    }
+  }
+  else if(var.isValid() && var.canConvert<DataContainerArrayProxy>())
+  {
+    DataContainerArrayProxy proxy = var.value<DataContainerArrayProxy>();
+    proxy.updatePath(oldPath, newPath);
+    var.setValue(proxy);
+    filter->setProperty(qPrintable(getPropertyName()), var);
+    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+  }
+  else if(var.isValid() && var.canConvert<DataContainerProxy>())
+  {
+    DataContainerProxy proxy = var.value<DataContainerProxy>();
+    proxy.updatePath(oldPath, newPath);
+    var.setValue(proxy);
+    filter->setProperty(qPrintable(getPropertyName()), var);
+    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+  }
+  else if(var.isValid() && var.canConvert<AttributeMatrixProxy>())
+  {
+    AttributeMatrixProxy proxy = var.value<AttributeMatrixProxy>();
+    proxy.updatePath(oldPath, newPath);
+    var.setValue(proxy);
+    filter->setProperty(qPrintable(getPropertyName()), var);
+    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+  }
+  else if(var.isValid() && var.canConvert<DataArrayProxy>())
+  {
+    DataArrayProxy proxy = var.value<DataArrayProxy>();
+    proxy.updatePath(oldPath, newPath);
+    var.setValue(proxy);
+    filter->setProperty(qPrintable(getPropertyName()), var);
+    emit filter->dataArrayPathUpdated(getPropertyName(), oldPath, newPath);
+  }
 }

--- a/Source/SIMPLib/FilterParameters/FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FilterParameter.h
@@ -46,7 +46,9 @@
 
 #include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
+#include "SIMPLib/DataContainers/DataArrayPath.h"
 
+class AbstractFilter;
 
 /**
  * @class FilterParameter FilterParameter.h DREAM3DLib/FilterParameters/FilterParameter.h
@@ -98,6 +100,11 @@ class SIMPLib_EXPORT FilterParameter
      * @return
      */
     virtual void writeJson(QJsonObject &json);
+
+    /**
+    * @brief Handle DataArrayPath changes if necessary
+    */
+    virtual void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath);
 
   protected:
     FilterParameter();

--- a/Source/SIMPLib/FilterParameters/FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FilterParameter.h
@@ -102,8 +102,10 @@ class SIMPLib_EXPORT FilterParameter
     virtual void writeJson(QJsonObject &json);
 
     /**
-    * @brief Handle DataArrayPath changes if necessary
-    */
+     * @brief Handle DataArrayPath changes if necessary
+     * @param filter
+     * @param renamePath
+     */
     virtual void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath);
 
   protected:

--- a/Source/SIMPLib/FilterParameters/FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FilterParameter.h
@@ -104,7 +104,7 @@ class SIMPLib_EXPORT FilterParameter
     /**
     * @brief Handle DataArrayPath changes if necessary
     */
-    virtual void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath oldPath, DataArrayPath newPath);
+    virtual void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath);
 
   protected:
     FilterParameter();

--- a/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.cpp
@@ -38,6 +38,7 @@
 #include <QtCore/QJsonArray>
 
 #include "SIMPLib/Common/Constants.h"
+#include "SIMPLib/Filtering/AbstractFilter.h"
 
 // -----------------------------------------------------------------------------
 //
@@ -203,4 +204,30 @@ void MultiAttributeMatrixSelectionFilterParameter::writeJson(QJsonObject& json)
 
     json[getPropertyName()] = arrayObj;
   }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void MultiAttributeMatrixSelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  QVector<DataArrayPath> paths = m_GetterCallback();
+  int count = paths.size();
+  bool updated = false;
+
+  for(int i = 0; i < count; i++)
+  {
+    if(paths[i] == oldPath)
+    {
+      paths[i] = newPath;
+      updated = true;
+    }
+  }
+
+  m_SetterCallback(paths);
+  emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
 }

--- a/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.h
@@ -174,6 +174,13 @@ class SIMPLib_EXPORT MultiAttributeMatrixSelectionFilterParameter : public Filte
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
+    /**
+     * @brief Handle DataArrayPath changes if necessary
+     * @param filter
+     * @param renamePath
+     */
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
+
   protected:
       /**
        * @brief MultiAttributeMatrixSelectionFilterParameter The default constructor.  It is protected because this

--- a/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.cpp
@@ -38,6 +38,7 @@
 #include <QtCore/QJsonArray>
 
 #include "SIMPLib/Common/Constants.h"
+#include "SIMPLib/Filtering/AbstractFilter.h"
 
 // -----------------------------------------------------------------------------
 //
@@ -203,4 +204,30 @@ void MultiDataArraySelectionFilterParameter::writeJson(QJsonObject& json)
 
     json[getPropertyName()] = arrayObj;
   }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void MultiDataArraySelectionFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  QVector<DataArrayPath> paths = m_GetterCallback();
+  int count = paths.size();
+  bool updated = false;
+
+  for(int i = 0; i < count; i++)
+  {
+    if(paths[i] == oldPath)
+    {
+      paths[i] = newPath;
+      updated = true;
+    }
+  }
+
+  m_SetterCallback(paths);
+  emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
 }

--- a/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.h
@@ -174,6 +174,13 @@ class SIMPLib_EXPORT MultiDataArraySelectionFilterParameter : public FilterParam
     */
     SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
 
+    /**
+     * @brief Handle DataArrayPath changes if necessary
+     * @param filter
+     * @param renamePath
+     */
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
+
   protected:
       /**
        * @brief MultiDataArraySelectionFilterParameter The default constructor.  It is protected because this

--- a/Source/SIMPLib/FilterParameters/ReadASCIIDataFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ReadASCIIDataFilterParameter.cpp
@@ -36,6 +36,7 @@
 #include "ReadASCIIDataFilterParameter.h"
 
 #include "SIMPLib/CoreFilters/util/ASCIIWizardData.hpp"
+#include "SIMPLib/Filtering/AbstractFilter.h"
 
 // -----------------------------------------------------------------------------
 //
@@ -71,4 +72,16 @@ ReadASCIIDataFilterParameter::Pointer ReadASCIIDataFilterParameter::New(const QS
 QString ReadASCIIDataFilterParameter::getWidgetType() const
 {
   return QString("ReadASCIIDataWidget");
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ReadASCIIDataFilterParameter::dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  emit filter->dataArrayPathUpdated(getPropertyName(), renamePath);
 }

--- a/Source/SIMPLib/FilterParameters/ReadASCIIDataFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ReadASCIIDataFilterParameter.h
@@ -53,6 +53,13 @@ public:
 
     QString getWidgetType() const override;
 
+    /**
+     * @brief Handle DataArrayPath changes if necessary
+     * @param filter
+     * @param renamePath
+     */
+    void dataArrayPathRenamed(AbstractFilter* filter, DataArrayPath::RenameType renamePath) override;
+
   protected:
     ReadASCIIDataFilterParameter();
 

--- a/Source/SIMPLib/Filtering/AbstractComparison.h
+++ b/Source/SIMPLib/Filtering/AbstractComparison.h
@@ -37,6 +37,7 @@
 #define _AbstractComparison_h_
 
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
+#include "SIMPLib/DataContainers/DataArrayPath.h"
 #include "SIMPLib/SIMPLib.h"
 
 #include <QtCore/QJsonObject>
@@ -64,6 +65,7 @@ public:
   * @return
   */
   int getUnionOperator();
+
   /**
   * @brief Sets the union operator for the comparison
   * @param unionOperator
@@ -80,6 +82,12 @@ public:
   * @param json
   */
   virtual bool readJson(QJsonObject& json) = 0;
+
+  /**
+  * @brief Updates the comparison's DataArray options based on the renamed path
+  * @param renamePath
+  */
+  virtual bool renameDataArrayPath(DataArrayPath::RenameType renamePath) = 0;
 
 protected:
   int m_unionOperator;

--- a/Source/SIMPLib/Filtering/AbstractFilter.cpp
+++ b/Source/SIMPLib/Filtering/AbstractFilter.cpp
@@ -111,7 +111,7 @@ void AbstractFilter::setCancel(bool value)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void AbstractFilter::renameDataArrayPath(DataArrayPath oldPath, DataArrayPath newPath)
+void AbstractFilter::renameDataArrayPath(DataArrayPath::RenameType renamePath)
 {
   // Updates any DataArrayPath or proxy property assigned to this filter.
   // A signal is emitted if a change was required stating the property name, old path, and new path.
@@ -184,7 +184,7 @@ void AbstractFilter::renameDataArrayPath(DataArrayPath oldPath, DataArrayPath ne
   FilterParameterVector filterParams = getFilterParameters();
   for(FilterParameter::Pointer filterParam : filterParams)
   {
-    filterParam->dataArrayPathRenamed(this, oldPath, newPath);
+    filterParam->dataArrayPathRenamed(this, renamePath);
   }
 }
 
@@ -195,9 +195,7 @@ void AbstractFilter::renameDataArrayPaths(DataArrayPath::RenameContainer renamed
 {
   for(DataArrayPath::RenameType rename : renamedPaths)
   {
-    DataArrayPath first, second;
-    std::tie(first, second) = rename;
-    renameDataArrayPath(first, second);
+    renameDataArrayPath(rename);
   }
 }
 

--- a/Source/SIMPLib/Filtering/AbstractFilter.cpp
+++ b/Source/SIMPLib/Filtering/AbstractFilter.cpp
@@ -35,6 +35,8 @@
 
 #include "AbstractFilter.h"
 
+#include <QtCore/QMetaProperty>
+
 #include "SIMPLib/Common/PipelineMessage.h"
 #include "SIMPLib/Filtering/FilterManager.h"
 #include "SIMPLib/Filtering/IFilterFactory.hpp"
@@ -109,6 +111,99 @@ void AbstractFilter::setCancel(bool value)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+void AbstractFilter::renameDataArrayPath(DataArrayPath oldPath, DataArrayPath newPath)
+{
+  // Updates any DataArrayPath or proxy property assigned to this filter.
+  // A signal is emitted if a change was required stating the property name, old path, and new path.
+  // No additional methods are required aside from a connecting slot in filter parameter widgets to update their UI.
+  // If all filters stored their data paths as DataArrayPaths instead of QString without delimiters,
+  // this would handle all required updates.  This was moved to FilterParameter::dataArrayRenamed.
+  // However, moving this to FilterParameter does not update any private properties that do not 
+  // have a FilterParameter assigned.
+#if 0
+  const QMetaObject* metaobject = metaObject();
+  int count = metaobject->propertyCount();
+  for(int i = 0; i < count; i++)
+  {
+    QMetaProperty metaproperty = metaobject->property(i);
+    const char* name = metaproperty.name();
+    QVariant var = property(name);
+    if(var.isValid() && var.canConvert<DataArrayPath>())
+    {
+      DataArrayPath path = var.value<DataArrayPath>();
+      if(path.updatePath(oldPath, newPath))
+      {
+        //QString ss = QString("Updated property '%1' in %2").arg(name).arg(getHumanLabel());
+        //notifyStandardOutputMessage(getHumanLabel(), getPipelineIndex(), ss);
+        //notifyStatusMessage(getHumanLabel(), ss);
+        var.setValue(path);
+        this->setProperty(name, var);
+        emit dataArrayPathUpdated(name, oldPath, newPath);
+      }
+    }
+    else if(var.isValid() && var.canConvert<DataContainerArrayProxy>())
+    {
+      DataContainerArrayProxy proxy = var.value<DataContainerArrayProxy>();
+      proxy.updatePath(oldPath, newPath);
+      var.setValue(proxy);
+      this->setProperty(name, var);
+      emit dataArrayPathUpdated(name, oldPath, newPath);
+    }
+    else if(var.isValid() && var.canConvert<DataContainerProxy>())
+    {
+      DataContainerProxy proxy = var.value<DataContainerProxy>();
+      proxy.updatePath(oldPath, newPath);
+      var.setValue(proxy);
+      this->setProperty(name, var);
+      emit dataArrayPathUpdated(name, oldPath, newPath);
+    }
+    else if(var.isValid() && var.canConvert<AttributeMatrixProxy>())
+    {
+      AttributeMatrixProxy proxy = var.value<AttributeMatrixProxy>();
+      proxy.updatePath(oldPath, newPath);
+      var.setValue(proxy);
+      this->setProperty(name, var);
+      emit dataArrayPathUpdated(name, oldPath, newPath);
+    }
+    else if(var.isValid() && var.canConvert<DataArrayProxy>())
+    {
+      DataArrayProxy proxy = var.value<DataArrayProxy>();
+      proxy.updatePath(oldPath, newPath);
+      var.setValue(proxy);
+      this->setProperty(name, var);
+      emit dataArrayPathUpdated(name, oldPath, newPath);
+    }
+  }
+#endif
+
+  // Some filter parameters handle paths as nothing but a QString (i.e. DataContainerSelectionFilterParameter)
+  // This does not store data in a way that represents what is stored or in a consistent manner with anything else.
+  // Because this format cannot be quieried nicely like the above code, filter parameters have to be able to update
+  // their own paths in these cases.  In cases where private properties need to be updated but do not have
+  // assigned filter parameters, although this should not be the case, this code, unlike the above snippet, will not update them.
+  FilterParameterVector filterParams = getFilterParameters();
+  for(FilterParameter::Pointer filterParam : filterParams)
+  {
+    filterParam->dataArrayPathRenamed(this, oldPath, newPath);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void AbstractFilter::renameDataArrayPaths(DataArrayPath::RenameContainer renamedPaths)
+{
+  for(DataArrayPath::RenameType rename : renamedPaths)
+  {
+    DataArrayPath first, second;
+    std::tie(first, second) = rename;
+    renameDataArrayPath(first, second);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void AbstractFilter::setupFilterParameters()
 {
 }
@@ -170,6 +265,102 @@ bool AbstractFilter::doesPipelineContainFilterAfterThis(const QString& name)
     next = next->getNextFilter().lock();
   }
   return contains;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void insertAttributeMatrixPaths(DataContainer::Pointer dc, AttributeMatrix::Pointer am, std::list<DataArrayPath>& paths)
+{
+  paths.push_back(DataArrayPath(dc->getName(), am->getName(), ""));
+  // Insert all DataArrayPaths
+  for(QString daName : am->getAttributeArrayNames())
+  {
+    DataArrayPath daPath(dc->getName(), am->getName(), daName);
+    paths.push_back(daPath);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void insertDataContainerPaths(DataContainer::Pointer dc, std::list<DataArrayPath>& paths)
+{
+  paths.push_back(DataArrayPath(dc->getName(), "", ""));
+  // Insert all AttributeMatrix paths
+  for(AttributeMatrix::Pointer am : dc->getAttributeMatrices())
+  {
+    insertAttributeMatrixPaths(dc, am, paths);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+std::list<DataArrayPath> AbstractFilter::getCreatedPaths()
+{
+  std::list<DataArrayPath> createdPaths;
+  // Check if the DataContainerArray is valid
+  if(nullptr == getDataContainerArray())
+  {
+    return createdPaths;
+  }
+
+  AbstractFilter::Pointer previousFilter = getPreviousFilter().lock();
+  if(previousFilter && nullptr != previousFilter->getDataContainerArray())
+  {
+    DataContainerArray::Pointer prevDca = previousFilter->getDataContainerArray();
+    DataContainerArray::Pointer dca = getDataContainerArray();
+
+    // Check DataContainers
+    for(DataContainer::Pointer dc : dca->getDataContainers())
+    {
+      if(false == prevDca->doesDataContainerExist(dc->getName()))
+      {
+        insertDataContainerPaths(dc, createdPaths);
+      }
+      else
+      {
+        // Check AttributeMatrices
+        for(AttributeMatrix::Pointer am : dc->getAttributeMatrices())
+        {
+          DataArrayPath amPath(dc->getName(), am->getName(), "");
+          if(false == prevDca->doesAttributeMatrixExist(amPath))
+          {
+            insertAttributeMatrixPaths(dc, am, createdPaths);
+          }
+          else
+          {
+            // Check DataArrays
+            for(QString daName : am->getAttributeArrayNames())
+            {
+              DataArrayPath daPath(dc->getName(), am->getName(), daName);
+              if(false == prevDca->doesAttributeArrayExist(daPath))
+              {
+                createdPaths.push_back(daPath);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  else
+  {
+    DataContainerArray::Pointer dca = getDataContainerArray();
+
+    // Check if the DataContainerArray is valid
+    if(dca)
+    {
+      // Add all paths if there is no previous filter to compare to
+      for(DataContainer::Pointer dc : dca->getDataContainers())
+      {
+        insertDataContainerPaths(dc, createdPaths);
+      }
+    }
+  }
+
+  return createdPaths;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/Filtering/AbstractFilter.cpp
+++ b/Source/SIMPLib/Filtering/AbstractFilter.cpp
@@ -366,6 +366,16 @@ std::list<DataArrayPath> AbstractFilter::getCreatedPaths()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+DataArrayPath::RenameContainer AbstractFilter::getRenamedPaths()
+{
+  // Implemented in filters that rename existing paths
+  DataArrayPath::RenameContainer container;
+  return container;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void AbstractFilter::readFilterParameters(AbstractFilterParametersReader* reader, int index)
 {
   Q_ASSERT(reader != nullptr);

--- a/Source/SIMPLib/Filtering/AbstractFilter.h
+++ b/Source/SIMPLib/Filtering/AbstractFilter.h
@@ -260,6 +260,10 @@ public:
    */
   virtual bool doesPipelineContainFilterAfterThis(const QString& name);
 
+  // ------------------------------
+  // These functions allow renaming DataArrayPaths to update proceeding filters in the pipeline
+  // ------------------------------
+
   /**
    * @brief Returns a set of DataArrayPaths created by this filter.
    * This method requires preflight() or execute() to have already run.

--- a/Source/SIMPLib/Filtering/AbstractFilter.h
+++ b/Source/SIMPLib/Filtering/AbstractFilter.h
@@ -267,6 +267,12 @@ public:
    */
   std::list<DataArrayPath> getCreatedPaths();
 
+  /**
+   * @brief Returns a list of DataArrayPaths that have been renamed along with their corresponding renamed value
+   * @return
+   */
+  virtual DataArrayPath::RenameContainer getRenamedPaths();
+
   // ------------------------------
   // These methods are over ridden from the superclass in order to add the
   // pipeline index to the PipelineMessage Object.

--- a/Source/SIMPLib/Filtering/AbstractFilter.h
+++ b/Source/SIMPLib/Filtering/AbstractFilter.h
@@ -366,9 +366,10 @@ signals:
 
   /**
   * @brief Signal is emitted when a DataArrayPath property is updated
-  * @param name
+  * @param propertyName
+  * @param renamePath
   */
-  void dataArrayPathUpdated(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+  void dataArrayPathUpdated(QString propertyName, DataArrayPath::RenameType renamePath);
 
 public slots:
 
@@ -380,10 +381,9 @@ public slots:
   /**
    * @brief Updates any DataArrayPath properties from the old path to a new path
    * For DataArrayPaths longer than the given path, only the specified values are modified
-   * @param oldPath
-   * @param newPath
+   * @param renamePath
    */
-  virtual void renameDataArrayPath(DataArrayPath oldPath, DataArrayPath newPath);
+  virtual void renameDataArrayPath(DataArrayPath::RenameType renamePath);
 
   /**
   * @brief Updates any DataArrayPath properties from the old paths to their corresponding new paths.

--- a/Source/SIMPLib/Filtering/AbstractFilter.h
+++ b/Source/SIMPLib/Filtering/AbstractFilter.h
@@ -260,6 +260,13 @@ public:
    */
   virtual bool doesPipelineContainFilterAfterThis(const QString& name);
 
+  /**
+   * @brief Returns a set of DataArrayPaths created by this filter.
+   * This method requires preflight() or execute() to have already run.
+   * @return
+   */
+  std::list<DataArrayPath> getCreatedPaths();
+
   // ------------------------------
   // These methods are over ridden from the superclass in order to add the
   // pipeline index to the PipelineMessage Object.
@@ -351,12 +358,33 @@ signals:
    */
   void filterInProgress();
 
+  /**
+  * @brief Signal is emitted when a DataArrayPath property is updated
+  * @param name
+  */
+  void dataArrayPathUpdated(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+
 public slots:
 
   /**
     * @brief Cancel the operation
     */
   virtual void setCancel(bool value);
+
+  /**
+   * @brief Updates any DataArrayPath properties from the old path to a new path
+   * For DataArrayPaths longer than the given path, only the specified values are modified
+   * @param oldPath
+   * @param newPath
+   */
+  virtual void renameDataArrayPath(DataArrayPath oldPath, DataArrayPath newPath);
+
+  /**
+  * @brief Updates any DataArrayPath properties from the old paths to their corresponding new paths.
+  * For DataArrayPaths longer than the new path, only the values provided by the new path are modified
+  * @param renamedPaths
+  */
+  virtual void renameDataArrayPaths(DataArrayPath::RenameContainer renamedPaths);
 
 protected:
   AbstractFilter();

--- a/Source/SIMPLib/Filtering/ComparisonInputsAdvanced.cpp
+++ b/Source/SIMPLib/Filtering/ComparisonInputsAdvanced.cpp
@@ -65,14 +65,6 @@ ComparisonInputsAdvanced::ComparisonInputsAdvanced(const ComparisonInputsAdvance
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-// ComparisonInputs::ComparisonInputs(ComparisonInputs& rhs)
-//{
-//  m_Inputs = rhs.m_Inputs;
-//}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
 ComparisonInputsAdvanced::~ComparisonInputsAdvanced() = default;
 
 // -----------------------------------------------------------------------------
@@ -244,7 +236,9 @@ void ComparisonInputsAdvanced::operator=(const ComparisonInputsAdvanced& rhs)
 bool ComparisonInputsAdvanced::hasComparisonValue()
 {
   if(m_Inputs.size() == 0)
+  {
     return false;
+  }
 
   for(int i = 0; i < m_Inputs.size(); i++)
   {

--- a/Source/SIMPLib/Filtering/ComparisonInputsAdvanced.cpp
+++ b/Source/SIMPLib/Filtering/ComparisonInputsAdvanced.cpp
@@ -205,6 +205,14 @@ QString ComparisonInputsAdvanced::getAttributeMatrixName()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+DataArrayPath ComparisonInputsAdvanced::getAttributeMatrixPath()
+{
+  return DataArrayPath(m_dataContainerName, m_attributeMatrixName, "");
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void ComparisonInputsAdvanced::setDataContainerName(QString dcName)
 {
   m_dataContainerName = dcName;

--- a/Source/SIMPLib/Filtering/ComparisonInputsAdvanced.h
+++ b/Source/SIMPLib/Filtering/ComparisonInputsAdvanced.h
@@ -127,6 +127,11 @@ public:
   QString getAttributeMatrixName();
 
   /**
+  * @brief Returns the DataArrayPath to the selected AttributeMatrix
+  */
+  DataArrayPath getAttributeMatrixPath();
+
+  /**
    * @brief Sets the DataContainer name used by the group of comparisons
    * @param dcName
    */

--- a/Source/SIMPLib/Filtering/ComparisonInputsAdvanced.h
+++ b/Source/SIMPLib/Filtering/ComparisonInputsAdvanced.h
@@ -63,38 +63,128 @@ class SIMPLib_EXPORT ComparisonInputsAdvanced : public QObject
 public:
   ComparisonInputsAdvanced();
   ComparisonInputsAdvanced(const ComparisonInputsAdvanced& rhs);
-  // explicit ComparisonInputsAdvanced(ComparisonInputsAdvanced& rhs);
 
   virtual ~ComparisonInputsAdvanced();
 
+  /**
+   * @brief size
+   * @return
+   */
   int size();
 
+  /**
+    * @brief Adds a new input to the list of comparisons
+    * @param unionOperator
+    * @param arrayName
+    * @param compOperator
+    * @param compValue
+    */
   void addInput(int unionOperator, const QString arrayName, int compOperator, double compValue);
+
+  /**
+   * @brief Adds a new input to the list of comparisons
+   * @param unionOperator
+   * @param invertComparison
+   * @param comparisons
+   */
   void addInput(int unionOperator, bool invertComparison, QVector<AbstractComparison::Pointer> comparisons);
+
+  /**
+   * @brief Adds new inputs to the list of comparisons
+   * @param input
+   */
   void addInput(const AbstractComparison::Pointer input);
 
+  /**
+   * @brief Returns the nth comparison
+   * @param index
+   * @return
+   */
   AbstractComparison::Pointer getInput(int index);
+
+  /**
+   * @brief Returns the vector of comparisons
+   * @return
+   */
   QVector<AbstractComparison::Pointer>& getInputs();
 
+  /**
+   * @brief Sets the comparisons to be used
+   * @param comparisons
+   */
   void setInputs(QVector<AbstractComparison::Pointer> comparisons);
 
+  /**
+   * @brief Returns the DataContainer name used by the group
+   * @return
+   */
   QString getDataContainerName();
+
+  /**
+   * @brief Returns the AttributeMatrix name used by the group
+   * @return
+   */
   QString getAttributeMatrixName();
 
+  /**
+   * @brief Sets the DataContainer name used by the group of comparisons
+   * @param dcName
+   */
   void setDataContainerName(QString dcName);
+
+  /**
+   * @brief Sets the AttributeMatrix name used by the group of comparisons
+   * @brief amName
+   */
   void setAttributeMatrixName(QString amName);
 
+  /**
+   * @brief Assignment operator
+   * @param
+   */
   void operator=(const ComparisonInputsAdvanced&);
 
+  /**
+   * @brief operator overload[]
+   * @param index
+   * @return
+   */
   AbstractComparison::Pointer operator[](int index);
 
+  /**
+   * @brief Returns true if there exists at least one comparison value
+   * @return
+   */
   bool hasComparisonValue();
+
+  /**
+   * @brief Returns a vector of comparisons for the group
+   * @return
+   */
   QVector<AbstractComparison::Pointer> getComparisonValues();
 
+  /**
+   * @brief Returns true if the resulting comparison should be inverted
+   * @return
+   */
   bool shouldInvert();
+
+  /**
+   * @brief Sets whether or not the resulting comparison should be inverted
+   * @param invert
+   */
   void setInvert(bool invert);
 
+  /**
+   * @brief Loads data from json 
+   * @param obj
+   */
   void readJson(QJsonObject obj);
+
+  /**
+   * @brief Writes data to json
+   * @param obj
+   */
   void writeJson(QJsonObject& obj);
 
 private:

--- a/Source/SIMPLib/Filtering/ComparisonSet.cpp
+++ b/Source/SIMPLib/Filtering/ComparisonSet.cpp
@@ -44,8 +44,8 @@
 // -----------------------------------------------------------------------------
 ComparisonSet::ComparisonSet()
 : AbstractComparison()
+, m_invertComparison(false)
 {
-  m_invertComparison = false;
 }
 
 // -----------------------------------------------------------------------------
@@ -225,4 +225,28 @@ QVector<AbstractComparison::Pointer> ComparisonSet::getComparisonValues()
   }
 
   return comparisonValues;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+bool ComparisonSet::renameDataArrayPath(DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  if(oldPath.getDataArrayName().isEmpty() || oldPath.getDataArrayName() == newPath.getDataArrayName())
+  {
+    return false;
+  }
+
+  bool updated = false;
+  QVector<AbstractComparison::Pointer> comparisons = getComparisonValues();
+  for(AbstractComparison::Pointer comparison : comparisons)
+  {
+    updated |= comparison->renameDataArrayPath(renamePath);
+  }
+
+  return updated;
 }

--- a/Source/SIMPLib/Filtering/ComparisonSet.h
+++ b/Source/SIMPLib/Filtering/ComparisonSet.h
@@ -109,6 +109,13 @@ public:
   */
   QVector<AbstractComparison::Pointer> getComparisonValues();
 
+  /**
+  * @brief Checks the comparison's DataArray options based on the renamed path. Returns true if the comparison was changed
+  * @param renamePath
+  * @return
+  */
+  bool renameDataArrayPath(DataArrayPath::RenameType renamePath) override;
+
 protected:
   bool m_invertComparison;
   QVector<AbstractComparison::Pointer> m_comparisons;

--- a/Source/SIMPLib/Filtering/ComparisonValue.cpp
+++ b/Source/SIMPLib/Filtering/ComparisonValue.cpp
@@ -152,3 +152,26 @@ void ComparisonValue::setParentSet(ComparisonSet::Pointer parentSet)
 {
   m_parentSet = parentSet;
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+bool ComparisonValue::renameDataArrayPath(DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  if(oldPath.getDataArrayName().isEmpty() || newPath.getDataArrayName().isEmpty() || oldPath.getDataArrayName() == newPath.getDataArrayName())
+  {
+    return false;
+  }
+
+  if(oldPath.getDataArrayName() == m_attributeArrayName)
+  {
+    m_attributeArrayName = newPath.getDataArrayName();
+    return true;
+  }
+
+  return false;
+}

--- a/Source/SIMPLib/Filtering/ComparisonValue.h
+++ b/Source/SIMPLib/Filtering/ComparisonValue.h
@@ -59,6 +59,7 @@ public:
   * @param json
   */
   void writeJson(QJsonObject& json);
+
   /**
   * @brief Reads the ComparisonValue from JSon
   * @param json
@@ -70,11 +71,13 @@ public:
   * @return
   */
   QString getAttributeArrayName();
+
   /**
   * @brief Returns the comparison operator used
   * @return
   */
   int getCompOperator();
+
   /**
   * @brief Returns the value used by the ComparisonValue
   */
@@ -85,11 +88,13 @@ public:
   * @param name
   */
   void setAttributeArrayName(QString name);
+
   /**
   * @brief Sets the comparison operator used
   * @param compOperator
   */
   void setCompOperator(int compOperator);
+
   /**
   * @brief Sets the value used by the comparison
   * @param value
@@ -101,11 +106,19 @@ public:
   * @return
   */
   ComparisonSet::Pointer getParentSet();
+
   /**
   * @brief Changes the parent ComparisonSet
   * @param parentSet
   */
   void setParentSet(ComparisonSet::Pointer parentSet);
+
+  /**
+  * @brief Checks the comparison's DataArray options based on the renamed path. Returns true if the comparison was changed
+  * @param renamePath
+  * @return
+  */
+  bool renameDataArrayPath(DataArrayPath::RenameType renamePath) override;
 
 protected:
   QString m_attributeArrayName;

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.cpp
@@ -135,6 +135,10 @@ void AttributeMatrixCreationWidget::setupGui()
   // Catch when the filter wants its values updated
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
+  // If the DataArrayPath is updated in the filter, update the widget
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+
   connect(stringEdit, SIGNAL(valueChanged(const QString&)), this, SIGNAL(parametersChanged()));
 
   m_SelectedDataContainerPath->blockSignals(true);
@@ -247,6 +251,25 @@ bool AttributeMatrixCreationWidget::eventFilter(QObject* obj, QEvent* event)
     return true;
   }
   return false;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void AttributeMatrixCreationWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(propertyName.compare(PROPERTY_NAME_AS_CHAR) == 0)
+  {
+    QVariant var = getFilter()->property(PROPERTY_NAME_AS_CHAR);
+    DataArrayPath updatedPath = var.value<DataArrayPath>();
+    QString amName = updatedPath.getAttributeMatrixName();
+    updatedPath.setAttributeMatrixName("");
+
+    blockSignals(true);
+    setSelectedPath(updatedPath);
+    stringEdit->setText(amName);
+    blockSignals(false);
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.cpp
@@ -136,8 +136,8 @@ void AttributeMatrixCreationWidget::setupGui()
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
   // If the DataArrayPath is updated in the filter, update the widget
-  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)),
-    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath::RenameType)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath::RenameType)));
 
   connect(stringEdit, SIGNAL(valueChanged(const QString&)), this, SIGNAL(parametersChanged()));
 
@@ -256,7 +256,7 @@ bool AttributeMatrixCreationWidget::eventFilter(QObject* obj, QEvent* event)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void AttributeMatrixCreationWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+void AttributeMatrixCreationWidget::updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath)
 {
   if(propertyName.compare(PROPERTY_NAME_AS_CHAR) == 0)
   {

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.h
@@ -129,7 +129,7 @@ protected:
   void setSelectedPath(QString dcName, QString attrMatName, QString attrArrName);
 
   protected slots:
-    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
 
 signals:
   void errorSettingFilterParameter(const QString& msg);

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.h
@@ -128,6 +128,9 @@ protected:
    */
   void setSelectedPath(QString dcName, QString attrMatName, QString attrArrName);
 
+  protected slots:
+    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+
 signals:
   void errorSettingFilterParameter(const QString& msg);
   void parametersChanged();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.cpp
@@ -118,8 +118,8 @@ void AttributeMatrixSelectionWidget::setupGui()
           this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
   // If the DataArrayPath is updated in the filter, update the widget
-  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)), 
-    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath::RenameType)), 
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath::RenameType)));
 
   DataArrayPath defaultPath = getFilter()->property(PROPERTY_NAME_AS_CHAR).value<DataArrayPath>();
   m_SelectedAttributeMatrixPath->setText(defaultPath.serialize(Detail::Delimiter));
@@ -266,7 +266,7 @@ bool AttributeMatrixSelectionWidget::eventFilter(QObject* obj, QEvent* event)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void AttributeMatrixSelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+void AttributeMatrixSelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath)
 {
   if(propertyName.compare(PROPERTY_NAME_AS_CHAR) == 0)
   {

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.cpp
@@ -117,6 +117,10 @@ void AttributeMatrixSelectionWidget::setupGui()
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)),
           this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
+  // If the DataArrayPath is updated in the filter, update the widget
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)), 
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+
   DataArrayPath defaultPath = getFilter()->property(PROPERTY_NAME_AS_CHAR).value<DataArrayPath>();
   m_SelectedAttributeMatrixPath->setText(defaultPath.serialize(Detail::Delimiter));
 
@@ -257,6 +261,22 @@ bool AttributeMatrixSelectionWidget::eventFilter(QObject* obj, QEvent* event)
     return true;
   }
   return false;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void AttributeMatrixSelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(propertyName.compare(PROPERTY_NAME_AS_CHAR) == 0)
+  {
+    QVariant var = getFilter()->property(PROPERTY_NAME_AS_CHAR);
+    DataArrayPath updatedPath = var.value<DataArrayPath>();
+
+    blockSignals(true);
+    setSelectedPath(updatedPath);
+    blockSignals(false);
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.cpp
@@ -322,6 +322,15 @@ void AttributeMatrixSelectionWidget::setSelectedPath(DataArrayPath amPath)
     QString html = am->getInfoString(SIMPL::HtmlFormat);
     m_SelectedAttributeMatrixPath->setToolTip(html);
     m_SelectedAttributeMatrixPath->setText(amPath.serialize(Detail::Delimiter));
+    changeStyleSheet(Style::FS_STANDARD_STYLE);
+  }
+  else
+  {
+    m_SelectedAttributeMatrixPath->setText(amPath.serialize(Detail::Delimiter));
+    //
+    m_SelectedAttributeMatrixPath->setToolTip(wrapStringInHtml("DataArrayPath does not exist."));
+    m_SelectedAttributeMatrixPath->setStyleSheet(QtSStyles::QToolSelectionButtonStyle(false));
+    changeStyleSheet(Style::FS_DOESNOTEXIST_STYLE);
   }
 }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.h
@@ -109,7 +109,7 @@ class SVWidgetsLib_EXPORT AttributeMatrixSelectionWidget : public FilterParamete
     void createSelectionMenu();
 
   protected slots:
-    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
 
   signals:
     void errorSettingFilterParameter(const QString& msg);

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.h
@@ -108,6 +108,9 @@ class SVWidgetsLib_EXPORT AttributeMatrixSelectionWidget : public FilterParamete
      */
     void createSelectionMenu();
 
+  protected slots:
+    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+
   signals:
     void errorSettingFilterParameter(const QString& msg);
     void parametersChanged();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/CalculatorWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/CalculatorWidget.cpp
@@ -92,6 +92,10 @@ void CalculatorWidget::setupGui()
   // Catch when the filter wants its values updated
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
+  // If the DataArrayPath is updated in the filter, update the widget
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath::RenameType)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath::RenameType)));
+
   connect(equation, SIGNAL(textChanged(const QString&)), this, SLOT(widgetChanged(const QString&)));
 
   connect(equation, SIGNAL(selectionChanged()), this, SLOT(updateSelection()));
@@ -441,4 +445,21 @@ void CalculatorWidget::on_applyChangesBtn_clicked()
   faderWidget->setFadeOut();
   connect(faderWidget, SIGNAL(animationComplete()), this, SLOT(hideButton()));
   faderWidget->start();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void CalculatorWidget::updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  if(propertyName.compare(getFilterParameter()->getPropertyName()) == 0)
+  {
+    QString inputStr = equation->text();
+    inputStr.replace(oldPath.getDataArrayName(), newPath.getDataArrayName());
+    equation->setText(inputStr);
+  }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/CalculatorWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/CalculatorWidget.h
@@ -92,7 +92,7 @@ class SVWidgetsLib_EXPORT CalculatorWidget : public FilterParameterWidget, priva
 
     void hideButton();
 
-    protected slots:
+  protected slots:
     void printUnaryButtonName();
     void printButtonName();
     void printActionName();
@@ -108,6 +108,8 @@ class SVWidgetsLib_EXPORT CalculatorWidget : public FilterParameterWidget, priva
     void on_scalarsBtn_clicked();
     void on_vectorsBtn_clicked();
     void on_piBtn_clicked();
+
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
 
   signals:
     void errorSettingFilterParameter(const QString& msg);

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionAdvancedWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionAdvancedWidget.h
@@ -135,11 +135,6 @@ class ComparisonSelectionAdvancedWidget : public FilterParameterWidget, private 
     void createSelectionMenu();
 
     /**
-    * @brief populateAttributeMatrixList
-    */
-    //void populateAttributeMatrixList();
-
-    /**
     * @brief generateAttributeArrayList
     * @param currentDCName
     * @param currentAttrMatName
@@ -171,16 +166,25 @@ class ComparisonSelectionAdvancedWidget : public FilterParameterWidget, private 
     * @param text
     */
     void widgetChanged(const QString& text);
+
     /**
     * @brief setSelectedPath
     * @param path
     */
     void setSelectedPath(QString path);
+
     /**
     * @brief setSelectedPath
     * @param amPath
     */
     void setSelectedPath(DataArrayPath amPath);
+
+    /**
+    * @brief Handles changes to an affected DataArrayPath
+    * @param propertyName
+    * @param renamePath
+    */
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
 
   private:
     DataContainerArrayProxy m_DcaProxy;

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionTableModel.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionTableModel.cpp
@@ -534,3 +534,25 @@ QStringList ComparisonSelectionTableModel::getPossibleFeatures()
 {
   return m_PossibleFeatures;
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ComparisonSelectionTableModel::updateFeatureName(QString oldName, QString newName)
+{
+  QVector<QString> featureNames;
+  QVector<float> featureValues;
+  QVector<int> featureOperators;
+
+  getTableData(featureNames, featureValues, featureOperators);
+
+  for(int i = 0; i < m_RowCount; i++)
+  {
+    if(featureNames[i] == oldName)
+    {
+      featureNames[i] = newName;
+    }
+  }
+
+  setTableData(featureNames, featureValues, featureOperators);
+}

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionTableModel.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionTableModel.h
@@ -166,6 +166,7 @@ class SVWidgetsLib_EXPORT ComparisonSelectionTableModel : public QAbstractTableM
 
     void setNumberOfPhases(int n);
 
+    void updateFeatureName(QString oldName, QString newName);
 
   private:
     int m_ColumnCount;

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.cpp
@@ -646,9 +646,9 @@ void ComparisonSelectionWidget::updateDataArrayPath(QString propertyName, DataAr
     std::tie(oldPath, newPath) = renamePath;
 
     QVariant var = getFilter()->property(PROPERTY_NAME_AS_CHAR);
-    DataArrayPath amPath = newPath;
-    QString dataArrayName = amPath.getDataArrayName();
-    amPath.setDataArrayName("");
+    ComparisonInputs inputs = var.value<ComparisonInputs>();
+    ComparisonInput_t input = inputs.getInput(0);
+    DataArrayPath amPath(input.dataContainerName, input.attributeMatrixName, "");
 
     blockSignals(true);
     // Update the AttributeMatrix path
@@ -665,6 +665,11 @@ void ComparisonSelectionWidget::updateDataArrayPath(QString propertyName, DataAr
         QString html = am->getInfoString(SIMPL::HtmlFormat);
         m_SelectedAttributeMatrixPath->setToolTip(html);
         m_SelectedAttributeMatrixPath->setText(amPath.serialize(Detail::Delimiter));
+      }
+      else
+      {
+        m_SelectedAttributeMatrixPath->setText(amPath.serialize(Detail::Delimiter));
+        //
       }
     }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.cpp
@@ -122,8 +122,8 @@ void ComparisonSelectionWidget::setupGui()
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
   // If the DataArrayPath is updated in the filter, update the widget
-  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)),
-    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath::RenameType)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath::RenameType)));
 
   // Create the table model
   m_ComparisonSelectionTableModel = createComparisonModel();
@@ -637,10 +637,14 @@ void ComparisonSelectionWidget::createSelectionMenu()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void ComparisonSelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+void ComparisonSelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath)
 {
   if(propertyName.compare(getFilterParameter()->getPropertyName()) == 0)
   {
+    DataArrayPath oldPath;
+    DataArrayPath newPath;
+    std::tie(oldPath, newPath) = renamePath;
+
     QVariant var = getFilter()->property(PROPERTY_NAME_AS_CHAR);
     DataArrayPath amPath = newPath;
     QString dataArrayName = amPath.getDataArrayName();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.h
@@ -214,10 +214,9 @@ class ComparisonSelectionWidget : public FilterParameterWidget, private Ui::Comp
     /**
      * @brief Handles changes to an affected DataArrayPath
      * @param propertyName
-     * @param oldPath
-     * @param newPath
+     * @param renamePath
      */
-    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
 
   private:
     DataContainerArrayProxy m_DcaProxy;

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.h
@@ -211,6 +211,14 @@ class ComparisonSelectionWidget : public FilterParameterWidget, private Ui::Comp
 
     void setSelectedPath(DataArrayPath amPath);
 
+    /**
+     * @brief Handles changes to an affected DataArrayPath
+     * @param propertyName
+     * @param oldPath
+     * @param newPath
+     */
+    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+
   private:
     DataContainerArrayProxy m_DcaProxy;
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSetWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSetWidget.cpp
@@ -446,3 +446,16 @@ void ComparisonSetWidget::setArrayNames(QStringList names)
 
   blockSignals(false);
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ComparisonSetWidget::renameDataArrayPath(DataArrayPath::RenameType renamePath)
+{
+  QVector<IComparisonWidget*> comparisonWidgets = getComparisonWidgets();
+  int count = comparisonWidgets.size();
+  for(int i = 0; i < count; i++)
+  {
+    comparisonWidgets[i]->renameDataArrayPath(renamePath);
+  }
+}

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSetWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSetWidget.h
@@ -44,6 +44,7 @@
 #include <vector>
 
 #include "SIMPLib/DataContainers/AttributeMatrix.h"
+#include "SIMPLib/DataContainers/DataArrayPath.h"
 #include "SIMPLib/Filtering/ComparisonSet.h"
 
 #include "SVWidgetsLib/FilterParameterWidgets/IComparisonWidget.h"
@@ -127,6 +128,12 @@ public:
   * @brief This method does additional GUI widget connections
   */
   void setupGui();
+
+  /**
+  * @brief Updates all comparisons contained in the set with the updated path
+  * @param renamePath
+  */
+  void renameDataArrayPath(DataArrayPath::RenameType renamePath) override;
   
 protected:
   /**

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonValueWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonValueWidget.cpp
@@ -149,3 +149,27 @@ void ComparisonValueWidget::setArrayNames(QStringList names)
     arrayNameComboBox->setCurrentIndex(-1);
   }
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ComparisonValueWidget::renameDataArrayPath(DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  if(oldPath.getDataArrayName().isEmpty())
+  {
+    return;
+  }
+
+  int index = arrayNameComboBox->findText(oldPath.getDataArrayName());
+  if(index >= 0)
+  {
+    arrayNameComboBox->setItemText(index, newPath.getDataArrayName());
+  }
+
+  arrayNameComboBox->update();
+  arrayNameComboBox->setCurrentText(getComparisonValue()->getAttributeArrayName());
+}

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonValueWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonValueWidget.h
@@ -89,6 +89,12 @@ public:
   */
   void setupGui();
 
+  /**
+  * @brief Updates the comparison array paths based on the renamed DataArrayPath
+  * @param renamePath
+  */
+  void renameDataArrayPath(DataArrayPath::RenameType renamePath) override;
+
 protected:
   /**
   * @brief Updates the DataArray combo box with names from the given AttributeMatrix

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.cpp
@@ -136,6 +136,10 @@ void DataArrayCreationWidget::setupGui()
 
   connect(stringEdit, SIGNAL(valueChanged(const QString&)), this, SIGNAL(parametersChanged()));
 
+  // If the DataArrayPath is updated in the filter, update the widget
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+
   DataArrayPath defaultPath = getFilter()->property(PROPERTY_NAME_AS_CHAR).value<DataArrayPath>();
   DataArrayPath amPath(defaultPath.getDataContainerName(), defaultPath.getAttributeMatrixName(), "");
   m_SelectedAttributeMatrixPath->setText(amPath.serialize(Detail::Delimiter));
@@ -281,6 +285,25 @@ bool DataArrayCreationWidget::eventFilter(QObject* obj, QEvent* event)
     return true;
   }
   return false;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataArrayCreationWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(propertyName.compare(getFilterParameter()->getPropertyName()) == 0)
+  {
+    QVariant var = getFilter()->property(PROPERTY_NAME_AS_CHAR);
+    DataArrayPath updatedPath = var.value<DataArrayPath>();
+    QString dataArrayName = updatedPath.getDataArrayName();
+    updatedPath.setDataArrayName("");
+
+    blockSignals(true);
+    setSelectedPath(updatedPath);
+    stringEdit->setText(dataArrayName);
+    blockSignals(false);
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.cpp
@@ -137,8 +137,8 @@ void DataArrayCreationWidget::setupGui()
   connect(stringEdit, SIGNAL(valueChanged(const QString&)), this, SIGNAL(parametersChanged()));
 
   // If the DataArrayPath is updated in the filter, update the widget
-  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)),
-    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath::RenameType)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath::RenameType)));
 
   DataArrayPath defaultPath = getFilter()->property(PROPERTY_NAME_AS_CHAR).value<DataArrayPath>();
   DataArrayPath amPath(defaultPath.getDataContainerName(), defaultPath.getAttributeMatrixName(), "");
@@ -290,7 +290,7 @@ bool DataArrayCreationWidget::eventFilter(QObject* obj, QEvent* event)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataArrayCreationWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+void DataArrayCreationWidget::updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath)
 {
   if(propertyName.compare(getFilterParameter()->getPropertyName()) == 0)
   {

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.h
@@ -116,7 +116,7 @@ class SVWidgetsLib_EXPORT DataArrayCreationWidget : public FilterParameterWidget
     void createSelectionMenu();
 
   protected slots:
-    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
 
   signals:
     void errorSettingFilterParameter(const QString& msg);

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.h
@@ -115,6 +115,9 @@ class SVWidgetsLib_EXPORT DataArrayCreationWidget : public FilterParameterWidget
      */
     void createSelectionMenu();
 
+  protected slots:
+    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+
   signals:
     void errorSettingFilterParameter(const QString& msg);
     void parametersChanged();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.cpp
@@ -360,6 +360,8 @@ void DataArraySelectionWidget::setSelectedPath(DataArrayPath daPath)
   }
   else
   {
+    m_SelectedDataArrayPath->setText(daPath.serialize(Detail::Delimiter));
+    //
     m_SelectedDataArrayPath->setToolTip(wrapStringInHtml("DataArrayPath does not exist."));
     m_SelectedDataArrayPath->setStyleSheet(QtSStyles::QToolSelectionButtonStyle(false));
     changeStyleSheet(Style::FS_DOESNOTEXIST_STYLE);

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.cpp
@@ -130,6 +130,10 @@ void DataArraySelectionWidget::setupGui()
   // Catch when the filter wants its values updated
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
+  // If the DataArrayPath is updated in the filter, update the widget
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)), 
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+
   DataArrayPath defaultPath = getFilter()->property(PROPERTY_NAME_AS_CHAR).value<DataArrayPath>();
   m_SelectedDataArrayPath->setText(defaultPath.serialize(Detail::Delimiter));
 
@@ -282,6 +286,22 @@ bool DataArraySelectionWidget::eventFilter(QObject* obj, QEvent* event)
     return true;
   }
   return false;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataArraySelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(propertyName.compare(PROPERTY_NAME_AS_CHAR) == 0)
+  {
+    QVariant var = getFilter()->property(PROPERTY_NAME_AS_CHAR);
+    DataArrayPath updatedPath = var.value<DataArrayPath>();
+
+    blockSignals(true);
+    setSelectedPath(updatedPath);
+    blockSignals(false);
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.cpp
@@ -131,8 +131,8 @@ void DataArraySelectionWidget::setupGui()
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
   // If the DataArrayPath is updated in the filter, update the widget
-  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)), 
-    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath::RenameType)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath::RenameType)));
 
   DataArrayPath defaultPath = getFilter()->property(PROPERTY_NAME_AS_CHAR).value<DataArrayPath>();
   m_SelectedDataArrayPath->setText(defaultPath.serialize(Detail::Delimiter));
@@ -291,7 +291,7 @@ bool DataArraySelectionWidget::eventFilter(QObject* obj, QEvent* event)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataArraySelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+void DataArraySelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath)
 {
   if(propertyName.compare(PROPERTY_NAME_AS_CHAR) == 0)
   {

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.h
@@ -122,6 +122,9 @@ class SVWidgetsLib_EXPORT DataArraySelectionWidget : public FilterParameterWidge
      */
     void createSelectionMenu();
 
+  protected slots:
+    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+
   signals:
     void errorSettingFilterParameter(const QString& msg);
     void parametersChanged();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.h
@@ -123,7 +123,7 @@ class SVWidgetsLib_EXPORT DataArraySelectionWidget : public FilterParameterWidge
     void createSelectionMenu();
 
   protected slots:
-    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
 
   signals:
     void errorSettingFilterParameter(const QString& msg);

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
@@ -106,8 +106,8 @@ void DataContainerArrayProxyWidget::setupGui()
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
   // If the DataArrayPath is updated in the filter, update the widget
-  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)),
-    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath::RenameType)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath::RenameType)));
 
   // setStyleSheet("QColumnView { text-decoration-color: red; }");
 
@@ -350,8 +350,12 @@ void DataContainerArrayProxyWidget::toggleStrikeOutFont(QListWidgetItem* item, Q
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataContainerArrayProxyWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+void DataContainerArrayProxyWidget::updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath)
 {
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
   blockSignals(true);
   
   // Attribute Matrix and Data Array lists are dependent on the current Data Container item

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
@@ -105,6 +105,10 @@ void DataContainerArrayProxyWidget::setupGui()
 
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
+  // If the DataArrayPath is updated in the filter, update the widget
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+
   // setStyleSheet("QColumnView { text-decoration-color: red; }");
 
   connect(dataContainerList, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(itemChanged(QListWidgetItem*)));
@@ -341,6 +345,45 @@ void DataContainerArrayProxyWidget::toggleStrikeOutFont(QListWidgetItem* item, Q
     item->setBackground(defaultBrush);
   }
   item->setFont(font);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataContainerArrayProxyWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  blockSignals(true);
+  
+  // Attribute Matrix and Data Array lists are dependent on the current Data Container item
+  if(dataContainerList->currentItem()->text() == oldPath.getDataContainerName())
+  {
+    // Data Array list is dependent on the current Attribute Matrix item
+    if(attributeMatrixList->currentItem()->text() == oldPath.getAttributeMatrixName())
+    {
+      // Data Array
+      QList<QListWidgetItem*> daItems = dataArrayList->findItems(oldPath.getDataArrayName(), Qt::MatchExactly);
+      for(QListWidgetItem* daItem : daItems)
+      {
+        daItem->setText(newPath.getDataContainerName());
+      }
+    }
+
+    // Attribute Matrix
+    QList<QListWidgetItem*> amItems = attributeMatrixList->findItems(oldPath.getAttributeMatrixName(), Qt::MatchExactly);
+    for(QListWidgetItem* amItem : amItems)
+    {
+      amItem->setText(newPath.getAttributeMatrixName());
+    }
+  }
+
+  // Data Container
+  QList<QListWidgetItem*> dcItems = dataContainerList->findItems(oldPath.getDataContainerName(), Qt::MatchExactly);
+  for(QListWidgetItem* dcItem : dcItems)
+  {
+    dcItem->setText(newPath.getDataContainerName());
+  }
+
+  blockSignals(false);
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.cpp
@@ -373,38 +373,40 @@ void DataContainerArrayProxyWidget::updateDataArrayPath(QString propertyName, Da
     }
   }
 
-  // Update widget values
-  bool oldDcSelected = dataContainerList->currentItem() && dataContainerList->currentItem()->text() == oldPath.getDataContainerName();
-  bool oldAmSelected = oldDcSelected && attributeMatrixList->currentItem() && attributeMatrixList->currentItem()->text() == oldPath.getAttributeMatrixName();
+  applyDataContainerArrayProxy(m_DcaProxy);
 
-  // Update DataContainer list names
-  QList<QListWidgetItem*> dcItems = dataContainerList->findItems(oldPath.getDataContainerName(), Qt::MatchFlag::MatchCaseSensitive);
-  for(QListWidgetItem* item : dcItems)
-  {
-    item->setText(newPath.getDataContainerName());
-  }
+  //// Update widget values
+  //bool oldDcSelected = dataContainerList->currentItem() && dataContainerList->currentItem()->text() == oldPath.getDataContainerName();
+  //bool oldAmSelected = oldDcSelected && attributeMatrixList->currentItem() && attributeMatrixList->currentItem()->text() == oldPath.getAttributeMatrixName();
 
-  // Selected DataContainer Renamed
-  if(oldDcSelected)
-  {
-    // Update AttributeMatrix list names
-    QList<QListWidgetItem*> amItems = dataContainerList->findItems(oldPath.getAttributeMatrixName(), Qt::MatchFlag::MatchCaseSensitive);
-    for(QListWidgetItem* item : amItems)
-    {
-      item->setText(newPath.getAttributeMatrixName());
-    }
+  //// Selected DataContainer Renamed
+  //if(oldDcSelected)
+  //{
+  //  // Selected AttributeMatrix Renamed
+  //  if(oldAmSelected)
+  //  {
+  //    // Update DataArray list names
+  //    QList<QListWidgetItem*> daItems = dataContainerList->findItems(oldPath.getDataArrayName(), Qt::MatchFlag::MatchCaseSensitive);
+  //    for(QListWidgetItem* item : daItems)
+  //    {
+  //      item->setText(newPath.getDataArrayName());
+  //    }
+  //  } // End DataArray
 
-    // Selected AttributeMatrix Renamed
-    if(oldAmSelected)
-    {
-      // Update DataArray list names
-      QList<QListWidgetItem*> daItems = dataContainerList->findItems(oldPath.getDataArrayName(), Qt::MatchFlag::MatchCaseSensitive);
-      for(QListWidgetItem* item : daItems)
-      {
-        item->setText(newPath.getDataArrayName());
-      }
-    }
-  }
+  //  // Update AttributeMatrix list names
+  //  QList<QListWidgetItem*> amItems = dataContainerList->findItems(oldPath.getAttributeMatrixName(), Qt::MatchFlag::MatchCaseSensitive);
+  //  for(QListWidgetItem* item : amItems)
+  //  {
+  //    item->setText(newPath.getAttributeMatrixName());
+  //  } // End AttributeMatrix
+  //}
+
+  //// Update DataContainer list names
+  //QList<QListWidgetItem*> dcItems = dataContainerList->findItems(oldPath.getDataContainerName(), Qt::MatchFlag::MatchCaseSensitive);
+  //for(QListWidgetItem* item : dcItems)
+  //{
+  //  item->setText(newPath.getDataContainerName());
+  //}
 
   blockSignals(false);
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.h
@@ -141,6 +141,8 @@ class SVWidgetsLib_EXPORT DataContainerArrayProxyWidget : public FilterParameter
     QString m_DcName;
     QString m_AmName;
     bool m_DidCausePreflight;
+    DataContainerProxy m_EmptyDcProxy;
+    AttributeMatrixProxy m_EmptyAmProxy;
 
     void toggleStrikeOutFont(QListWidgetItem* item, Qt::CheckState state);
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.h
@@ -132,6 +132,7 @@ class SVWidgetsLib_EXPORT DataContainerArrayProxyWidget : public FilterParameter
     void selectAllDataContainersClicked(bool checked);
     void selectAllAttributeMatricesClicked(bool checked);
     void selectAllDataArraysClicked(bool checked);
+    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
 
   private:
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.h
@@ -132,7 +132,7 @@ class SVWidgetsLib_EXPORT DataContainerArrayProxyWidget : public FilterParameter
     void selectAllDataContainersClicked(bool checked);
     void selectAllAttributeMatricesClicked(bool checked);
     void selectAllDataArraysClicked(bool checked);
-    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
 
   private:
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.cpp
@@ -91,8 +91,8 @@ void DataContainerCreationWidget::setupGui()
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
   // If the DataArrayPath is updated in the filter, update the widget
-  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)),
-    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath::RenameType)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath::RenameType)));
 
   connect(stringEdit, SIGNAL(valueChanged(const QString&)), this, SIGNAL(parametersChanged()));
   changeStyleSheet(Style::FS_STANDARD_STYLE);
@@ -128,7 +128,7 @@ void DataContainerCreationWidget::filterNeedsInputParameters(AbstractFilter* fil
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataContainerCreationWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+void DataContainerCreationWidget::updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath)
 {
   if(propertyName.compare(PROPERTY_NAME_AS_CHAR) == 0)
   {

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.cpp
@@ -90,6 +90,10 @@ void DataContainerCreationWidget::setupGui()
   // Catch when the filter wants its dataContainerNames updated
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
+  // If the DataArrayPath is updated in the filter, update the widget
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+
   connect(stringEdit, SIGNAL(valueChanged(const QString&)), this, SIGNAL(parametersChanged()));
   changeStyleSheet(Style::FS_STANDARD_STYLE);
 
@@ -118,5 +122,23 @@ void DataContainerCreationWidget::filterNeedsInputParameters(AbstractFilter* fil
   if(false == ok)
   {
     getFilter()->notifyMissingProperty(getFilterParameter());
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataContainerCreationWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(propertyName.compare(PROPERTY_NAME_AS_CHAR) == 0)
+  {
+    QVariant var = getFilter()->property(PROPERTY_NAME_AS_CHAR);
+    DataArrayPath updatedPath = var.value<DataArrayPath>();
+    QString dcName = updatedPath.getDataContainerName();
+    updatedPath.setDataContainerName("");
+
+    blockSignals(true);
+    stringEdit->setText(dcName);
+    blockSignals(false);
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.h
@@ -91,7 +91,7 @@ class SVWidgetsLib_EXPORT DataContainerCreationWidget : public FilterParameterWi
     void parametersChanged();
 
   protected slots:
-    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
 
   private:
     DataContainerCreationFilterParameter*                 m_FilterParameter;

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.h
@@ -90,6 +90,9 @@ class SVWidgetsLib_EXPORT DataContainerCreationWidget : public FilterParameterWi
     void errorSettingFilterParameter(const QString& msg);
     void parametersChanged();
 
+  protected slots:
+    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+
   private:
     DataContainerCreationFilterParameter*                 m_FilterParameter;
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.cpp
@@ -110,8 +110,8 @@ void DataContainerSelectionWidget::setupGui()
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
   // If the DataArrayPath is updated in the filter, update the widget
-  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)), 
-    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath::RenameType)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath::RenameType)));
 
   if(getFilterParameter() == nullptr)
   {
@@ -235,7 +235,7 @@ bool DataContainerSelectionWidget::eventFilter(QObject* obj, QEvent* event)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataContainerSelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+void DataContainerSelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath)
 {
   if(propertyName.compare(PROPERTY_NAME_AS_CHAR) == 0)
   {

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.cpp
@@ -109,6 +109,10 @@ void DataContainerSelectionWidget::setupGui()
   // Catch when the filter wants its values updated
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
+  // If the DataArrayPath is updated in the filter, update the widget
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath, DataArrayPath)), 
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath, DataArrayPath)));
+
   if(getFilterParameter() == nullptr)
   {
     return;
@@ -226,6 +230,22 @@ bool DataContainerSelectionWidget::eventFilter(QObject* obj, QEvent* event)
     return true;
   }
   return false;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataContainerSelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath)
+{
+  if(propertyName.compare(PROPERTY_NAME_AS_CHAR) == 0)
+  {
+    QVariant var = getFilter()->property(PROPERTY_NAME_AS_CHAR);
+    QString updatedPath = var.value<QString>();
+
+    blockSignals(true);
+    setSelectedPath(updatedPath);
+    blockSignals(false);
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.h
@@ -119,7 +119,7 @@ class SVWidgetsLib_EXPORT DataContainerSelectionWidget : public FilterParameterW
     void createSelectionMenu();
 
   protected slots:
-    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
 
   signals:
     void errorSettingFilterParameter(const QString& msg);

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.h
@@ -118,6 +118,9 @@ class SVWidgetsLib_EXPORT DataContainerSelectionWidget : public FilterParameterW
      */
     void createSelectionMenu();
 
+  protected slots:
+    void updateDataArrayPath(QString propertyName, DataArrayPath oldPath, DataArrayPath newPath);
+
   signals:
     void errorSettingFilterParameter(const QString& msg);
     void parametersChanged();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/IComparisonWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/IComparisonWidget.h
@@ -39,6 +39,7 @@
 #include <QtWidgets/QWidget>
 
 #include "SIMPLib/DataContainers/AttributeMatrix.h"
+#include "SIMPLib/DataContainers/DataArrayPath.h"
 #include "SIMPLib/Filtering/AbstractComparison.h"
 
 #include "SVWidgetsLib/SVWidgetsLib.h"
@@ -91,6 +92,12 @@ public:
   * @param am
   */
   virtual void setAttributeMatrix(AttributeMatrix::Pointer am);
+
+  /**
+  * @brief Updates the comparison's DataArray options based on the renamed path
+  * @param renamePath
+  */
+  virtual void renameDataArrayPath(DataArrayPath::RenameType renamePath) = 0;
 
 signals:
   /**

--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiAttributeMatrixSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiAttributeMatrixSelectionWidget.h
@@ -131,6 +131,8 @@ class SVWidgetsLib_EXPORT MultiAttributeMatrixSelectionWidget : public FilterPar
     void on_attributeMatricesSelectWidget_itemSelectionChanged();
     void on_attributeMatricesOrderWidget_itemSelectionChanged();
 
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
+
   signals:
     void errorSettingFilterParameter(const QString& msg);
     void parametersChanged();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.cpp
@@ -131,6 +131,10 @@ void MultiDataArraySelectionWidget::setupGui()
   // Catch when the filter wants its values updated
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
+  // If the DataArrayPath is updated in the filter, update the widget
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath::RenameType)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath::RenameType)));
+
   QVector<DataArrayPath> selectedPaths = getFilter()->property(PROPERTY_NAME_AS_CHAR).value<QVector<DataArrayPath>>();
   DataArrayPath amPath = DataArrayPath::GetAttributeMatrixPath(selectedPaths);
   m_SelectedAttributeMatrixPath->setText(amPath.serialize(Detail::Delimiter));
@@ -656,5 +660,67 @@ void MultiDataArraySelectionWidget::filterNeedsInputParameters(AbstractFilter* f
   if(false == ok)
   {
     getFilter()->notifyMissingProperty(getFilterParameter());
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void MultiDataArraySelectionWidget::updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  if(propertyName.compare(getFilterParameter()->getPropertyName()) == 0)
+  {
+    QVariant var = getFilter()->property(PROPERTY_NAME_AS_CHAR);
+    DataArrayPath updatedPath = var.value<DataArrayPath>();
+    QString dataArrayName = updatedPath.getDataArrayName();
+    updatedPath.setDataArrayName("");
+
+    blockSignals(true);
+    DataArrayPath currentPath = DataArrayPath::Deserialize(m_SelectedAttributeMatrixPath->text(), Detail::Delimiter);
+    if(currentPath.getDataContainerName() == oldPath.getDataContainerName())
+    {
+      if(oldPath.getDataContainerName() != newPath.getDataContainerName() || oldPath.getAttributeMatrixName() != newPath.getAttributeMatrixName())
+      {
+        DataArrayPath updatedPath(newPath.getDataContainerName(), newPath.getAttributeMatrixName(), "");
+        m_SelectedAttributeMatrixPath->setText(updatedPath.serialize(Detail::Delimiter));
+      }
+      else if(oldPath.getDataArrayName() != newPath.getDataArrayName())
+      {
+        // Unselected list widget
+        {
+          QList<QListWidgetItem*> renamedItems = availableArraysListWidget->findItems(oldPath.getDataArrayName(), Qt::MatchFlag::MatchCaseSensitive);
+
+          int renamedCount = renamedItems.size();
+          for(int i = 0; i < renamedCount; i++)
+          {
+            QListWidgetItem* item = renamedItems[i];
+            //availableArraysListWidget->removeItemWidget(item);
+            item->setText(newPath.getDataArrayName());
+          }
+        }
+
+        // Selected list widget
+        {
+          QList<QListWidgetItem*> renamedItems = selectedArraysListWidget->findItems(oldPath.getDataArrayName(), Qt::MatchFlag::MatchCaseSensitive);
+
+          int renamedCount = renamedItems.size();
+          for(int i = 0; i < renamedCount; i++)
+          {
+            QListWidgetItem* item = renamedItems[i];
+            if(item->text() == oldPath.getDataArrayName())
+            {
+              item->setText(newPath.getDataArrayName());
+            }
+          }
+        }
+        // End DataArray section
+      }
+    }
+
+    blockSignals(false);
   }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.cpp
@@ -681,14 +681,13 @@ void MultiDataArraySelectionWidget::updateDataArrayPath(QString propertyName, Da
 
     blockSignals(true);
     DataArrayPath currentPath = DataArrayPath::Deserialize(m_SelectedAttributeMatrixPath->text(), Detail::Delimiter);
-    if(currentPath.getDataContainerName() == oldPath.getDataContainerName())
+    if(currentPath.hasSameDataContainer(oldPath))
     {
-      if(oldPath.getDataContainerName() != newPath.getDataContainerName() || oldPath.getAttributeMatrixName() != newPath.getAttributeMatrixName())
-      {
-        DataArrayPath updatedPath(newPath.getDataContainerName(), newPath.getAttributeMatrixName(), "");
-        m_SelectedAttributeMatrixPath->setText(updatedPath.serialize(Detail::Delimiter));
-      }
-      else if(oldPath.getDataArrayName() != newPath.getDataArrayName())
+      bool hasAM = false == newPath.getAttributeMatrixName().isEmpty();
+      bool hasDA = false == newPath.getDataArrayName().isEmpty();
+
+      // Update the DataArray options
+      if(hasDA && currentPath.hasSameAttributeMatrix(oldPath))
       {
         // Unselected list widget
         {
@@ -717,7 +716,24 @@ void MultiDataArraySelectionWidget::updateDataArrayPath(QString propertyName, Da
             }
           }
         }
-        // End DataArray section
+      }// End DataArray section
+
+      // Update the AttributeMatrix Selection widget
+      if(false == hasDA)
+      {
+        if(false == hasAM)
+        {
+          DataArrayPath updatedPath(newPath.getDataContainerName(), currentPath.getAttributeMatrixName(), "");
+          m_SelectedAttributeMatrixPath->setText(updatedPath.serialize(Detail::Delimiter));
+        }
+        else
+        {
+          if(currentPath.hasSameAttributeMatrix(oldPath))
+          {
+            DataArrayPath updatedPath(newPath.getDataContainerName(), newPath.getAttributeMatrixName(), "");
+            m_SelectedAttributeMatrixPath->setText(updatedPath.serialize(Detail::Delimiter));
+          }
+        }
       }
     }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.h
@@ -134,6 +134,8 @@ class SVWidgetsLib_EXPORT MultiDataArraySelectionWidget : public FilterParameter
     void on_availableArraysListWidget_itemDoubleClicked(QListWidgetItem* item);
     void on_selectedArraysListWidget_itemDoubleClicked(QListWidgetItem* item);
 
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
+
   signals:
     void errorSettingFilterParameter(const QString& msg);
     void parametersChanged();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ReadASCIIDataWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ReadASCIIDataWidget.cpp
@@ -100,6 +100,10 @@ void ReadASCIIDataWidget::setupGui()
   // Catch when the filter wants its values updated
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
 
+  // If the DataArrayPath is updated in the filter, update the widget
+  connect(getFilter(), SIGNAL(dataArrayPathUpdated(QString, DataArrayPath::RenameType)),
+    this, SLOT(updateDataArrayPath(QString, DataArrayPath::RenameType)));
+
   // If the filter was loaded from a pipeline file, fill in the information in the widget
   if(m_Filter->getWizardData().isEmpty() == false)
   {
@@ -477,4 +481,19 @@ void ReadASCIIDataWidget::beforePreflight()
 // -----------------------------------------------------------------------------
 void ReadASCIIDataWidget::afterPreflight()
 {
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ReadASCIIDataWidget::updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  if(propertyName.compare(getFilterParameter()->getPropertyName()) == 0)
+  {
+    m_ImportWizard->updateDataArrayPath(renamePath);
+  }
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ReadASCIIDataWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ReadASCIIDataWidget.h
@@ -41,6 +41,8 @@
 
 #include <QtGui/QMovie>
 
+#include "SIMPLib/DataContainers/DataArrayPath.h"
+
 #include "SVWidgetsLib/FilterParameterWidgets/FilterParameterWidget.h"
 
 #include "ui_ReadASCIIDataWidget.h"
@@ -83,6 +85,8 @@ class SVWidgetsLib_EXPORT ReadASCIIDataWidget : public FilterParameterWidget, pr
 
     void lineCountDidFinish();
     void updateProgress(double percentage);
+
+    void updateDataArrayPath(QString propertyName, DataArrayPath::RenameType renamePath);
 
   signals:
     void errorSettingFilterParameter(const QString& msg);

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.cpp
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.cpp
@@ -1346,3 +1346,51 @@ int DataFormatPage::nextId() const
   // There is no "Next" page
   return -1;
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataFormatPage::updateDataArrayPath(DataArrayPath::RenameType renamePath)
+{
+  DataArrayPath oldPath;
+  DataArrayPath newPath;
+  std::tie(oldPath, newPath) = renamePath;
+
+  bool hasAm = false == oldPath.getAttributeMatrixName().isEmpty();
+
+  // Get current path
+  DataArrayPath currentPath;
+  if(createAMRadio->isChecked())
+  {
+    currentPath = DataArrayPath::Deserialize(selectedDCBtn->text(), Detail::Delimiter);
+    currentPath.setAttributeMatrixName(amName->text());
+  }
+  else
+  {
+    currentPath = DataArrayPath::Deserialize(selectedAMBtn->text(), Detail::Delimiter);
+  }
+
+  // Update current path
+  if(oldPath.getDataContainerName() == currentPath.getDataContainerName())
+  {
+    if(hasAm)
+    {
+      if(oldPath.getAttributeMatrixName() == currentPath.getAttributeMatrixName())
+      {
+        currentPath.setDataContainerName(newPath.getDataContainerName());
+        currentPath.setAttributeMatrixName(newPath.getAttributeMatrixName());
+      }
+    }
+  }
+
+  // Update the widget
+  if(createAMRadio->isChecked())
+  {
+    selectedDCBtn->setText(currentPath.getDataContainerName());
+    amName->setText(currentPath.getAttributeMatrixName());
+  }
+  else
+  {
+    selectedAMBtn->setText(currentPath.serialize(Detail::Delimiter));
+  }
+}

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.cpp
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.cpp
@@ -1381,6 +1381,10 @@ void DataFormatPage::updateDataArrayPath(DataArrayPath::RenameType renamePath)
         currentPath.setAttributeMatrixName(newPath.getAttributeMatrixName());
       }
     }
+    else
+    {
+      currentPath.setDataContainerName(newPath.getDataContainerName());
+    }
   }
 
   // Update the widget

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.h
@@ -194,6 +194,12 @@ class DataFormatPage : public AbstractWizardPage, private Ui::DataFormatPage
      */
     bool eventFilter(QObject* obj, QEvent* event);
 
+    /**
+    * @brief Handle DataArrayPath changes if necessary
+    * @param renamePath
+    */
+    void updateDataArrayPath(DataArrayPath::RenameType renamePath);
+
   public slots:
     /**
      * @brief dcaItemSelected

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ImportASCIIDataWizard.cpp
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ImportASCIIDataWizard.cpp
@@ -511,3 +511,15 @@ int ImportASCIIDataWizard::getAttributeMatrixType()
 
   return static_cast<int>(AttributeMatrix::Type::Generic);
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ImportASCIIDataWizard::updateDataArrayPath(DataArrayPath::RenameType renamePath)
+{
+  DataFormatPage* dfPage = dynamic_cast<DataFormatPage*>(page(DataFormat));
+  if(NULL != dfPage)
+  {
+    dfPage->updateDataArrayPath(renamePath);
+  }
+}

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ImportASCIIDataWizard.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ImportASCIIDataWizard.h
@@ -125,6 +125,12 @@ class ImportASCIIDataWizard : public QWizard
     */
     static void InsertLines(QStringList lines, int firstRowHeaderIndex, ASCIIDataModel* model);
 
+    /**
+    * @brief Updates the DataArrayPath used for importing data
+    * @param renamePath
+    */
+    void updateDataArrayPath(DataArrayPath::RenameType renamePath);
+
     QList<char> getDelimiters();
     bool getConsecutiveDelimiters();
     QStringList getHeaders();


### PR DESCRIPTION
Updated FilterPipeline, AbstractFilter, FilterParameter, as well several filter widgets to handle renaming DataArrayPaths.  Renaming a DataArrayPath will update filters and filter widgets further down the pipeline to reflect the new name.

This does not handle reordering filters where it relates to the RenameDataContainer, RenameAttributeMatrix, and RenameDataArray filters.  In this situation, moving these filters further down the pipeline will leave filters between its old and new position with the updated path.  Deleting these same filters also leave their changes intact, but disabling the filter reverses the renaming until it is re-enabled.