### PR TITLE
Feature/DataArrayPath Style

### DIFF
--- a/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.cpp
@@ -1098,8 +1098,13 @@ void DataArrayPathSelectionWidget::changeStyleSheet(Style styleType)
   ss << " position: relative;\n";
   ss << "}\n";
 
+  QColor checkedColor = getColor(styleType);
+  int hue = checkedColor.hsvHue();
+  int saturation = 50;
+  int value = 255;
+  checkedColor.setHsv(hue, saturation, value);
   ss << "QToolButton:checked {\n";
-  ss << " border: 2px solid " << getColor(styleType) << ";\n";
+  ss << " background-color: " << checkedColor.name() << ";\n";
   ss << "}\n";
 
   ss << "QToolButton:flat {\n";
@@ -1136,11 +1141,6 @@ void DataArrayPathSelectionWidget::paintEvent(QPaintEvent* event)
 {
   QToolButton::paintEvent(event);
 
-  if(false == isEnabled())
-  {
-    return;
-  }
-
   int rectWidth = height();
   int penWidth = 2;
   int radius = 6;
@@ -1150,6 +1150,10 @@ void DataArrayPathSelectionWidget::paintEvent(QPaintEvent* event)
   if(m_Style == Style::NotFound)
   {
     penColor = getColor(Style::NotFound);
+  }
+  if(false == isEnabled())
+  {
+    fillColor = QColor("#DDDDDD");
   }
   
   QPen pen;

--- a/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.cpp
@@ -1099,7 +1099,7 @@ void DataArrayPathSelectionWidget::changeStyleSheet(Style styleType)
   ss << "}\n";
 
   ss << "QToolButton:checked {\n";
-  ss << " background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,\nstop: 0 " << getColor(Style::Active) << ", stop: 1 #FFFFFF);\n";
+  ss << " border: 2px solid " << getColor(styleType) << ";\n";
   ss << "}\n";
 
   ss << "QToolButton:flat {\n";
@@ -1135,6 +1135,11 @@ void DataArrayPathSelectionWidget::changeStyleSheet(Style styleType)
 void DataArrayPathSelectionWidget::paintEvent(QPaintEvent* event)
 {
   QToolButton::paintEvent(event);
+
+  if(false == isEnabled())
+  {
+    return;
+  }
 
   int rectWidth = height();
   int penWidth = 2;


### PR DESCRIPTION
Updated the style sheet and custom painting in DataArrayPathSelectionWidget to replace the gradient effect when the button is checked as well as draw outlines for the DataType box when the widget does not match the incoming DataArrayPath to filter by.