### PR TITLE
Add transforms to SIMPL

### DIFF
--- a/Source/SIMPLib/CMakeLists.txt
+++ b/Source/SIMPLib/CMakeLists.txt
@@ -87,7 +87,7 @@ endMacro()
 
 #------------------------------------------------------------------------------
 # Set up the directories that are used for each Group
-set(SIMPL_Group_BASE_MODULES Common DataArrays DataContainers Geometry HDF5 Math StatsData Utilities)
+set(SIMPL_Group_BASE_MODULES Common DataArrays DataContainers Geometry HDF5 Math StatsData Utilities ITK)
 set(SIMPL_Group_FILTERS_MODULES Filtering FilterParameters VTKUtils)
 set(SIMPL_Group_PLUGIN_MODULES Plugin)
 
@@ -160,7 +160,6 @@ cmpReplaceFileIfDifferent(OLD_FILE_PATH  ${SIMPLib_BINARY_DIR}/CoreFilters/SIMPL
                           NEW_FILE_PATH  ${AllFiltersHeaderFile} )
 cmpReplaceFileIfDifferent(OLD_FILE_PATH  ${SIMPLib_BINARY_DIR}/CoreFilters/RegisterKnownFilters.cpp
                           NEW_FILE_PATH  ${RegisterKnownFiltersFile} )
-
 
 
 set(${PROJECT_NAME}_LINK_LIBS Qt5::Core Qt5::Network H5Support)

--- a/Source/SIMPLib/Common/Constants.h
+++ b/Source/SIMPLib/Common/Constants.h
@@ -847,6 +847,18 @@ namespace SIMPL
     const QString SharedTetList("SharedTetList");
     const QString UnsharedEdgeList("UnsharedEdgeList");
     const QString UnsharedFaceList("UnsharedFaceList");
+
+    const QString TransformContainerGroup("TransformContainerGroup");
+    const QString TransformContainer("TransformContainer");
+    const QString CompositeTransformContainer("CompositeTransformContainer");
+    const QString TransformContainerTypeName("TransformContainerTypeName");
+    const QString UnknownTransformContainer("UnknownTransformContainer");
+    const QString TransformContainerParameters("TransformParameters");
+    const QString TransformContainerFixedParameters("TransformFixedParameters");
+    const QString TransformContainerTypeAsString("TransformType");
+    const QString TransformContainerMovingName("TransformMovingName");
+    const QString TransformContainerReferenceName("TransformReferenceName");
+
   }
 
 //  namespace GeometryType

--- a/Source/SIMPLib/Common/Constants.h
+++ b/Source/SIMPLib/Common/Constants.h
@@ -36,8 +36,8 @@
 #ifndef _constants_h_
 #define _constants_h_
 
-#if defined (_MSC_VER)
-#define WIN32_LEAN_AND_MEAN   // Exclude rarely-used stuff from Windows headers
+#if defined(_MSC_VER)
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #endif
 
 #include <limits>
@@ -54,732 +54,724 @@
 namespace SIMPL
 {
 
-  typedef uint32_t Rgb;
-  const Rgb  RGB_MASK    = 0x00ffffff;                // masks RGB values
-  const QString PathSep("|");
-  static const uint8_t Unchecked = 0;
-  static const uint8_t PartiallyChecked = 1;
-  static const uint8_t Checked = 2;
-
-  enum InfoStringFormat
-  {
-    HtmlFormat = 0,
-//      JsonFormat,
-//      TextFormat,
-//      XmlFormat,
-    UnknownFormat
-  };
-
-
-  /** @brief Constants defined for the Stacking order of images into a 3D Volume */
-  namespace RefFrameZDir
-  {
-    static const unsigned int LowtoHigh = 0;
-    static const unsigned int HightoLow = 1;
-    static const unsigned int UnknownRefFrameZDirection = 2;
-  }
-
-  namespace TypeNames
-  {
-    const QString Bool("bool");
-    const QString Float("float");
-    const QString Double("double");
-    const QString Int8("int8_t");
-    const QString UInt8("uint8_t");
-    const QString Int16("int16_t");
-    const QString UInt16("uint16_t");
-    const QString Int32("int32_t");
-    const QString UInt32("uint32_t");
-    const QString Int64("int64_t");
-    const QString UInt64("uint64_t");
-    const QString String("string");
-    const QString StatsDataArray("StatsDataArray");
-    const QString NeighborList("NeighborList<T>");
-    const QString StringArray("StringDataArray");
-    const QString Unknown("Unknown");
-    const QString SupportedTypeList(TypeNames::Bool + ", " + TypeNames::StringArray + ", " + TypeNames::Int8 + ", " + TypeNames::UInt8 + ", " + TypeNames::Int16 + ", " + TypeNames::UInt16 + ", " +
-                                    TypeNames::Int32 + ", " + TypeNames::UInt32 + ", " + TypeNames::Int64 + ", " + TypeNames::UInt64 + ", " + TypeNames::Float + ", " + TypeNames::Double);
-  }
-
-  namespace TypeEnums
-  {
-    static const int Int8 = 0;
-    static const int UInt8 = 1;
-    static const int Int16 = 2;
-    static const int UInt16 = 3;
-    static const int Int32 = 4;
-    static const int UInt32 = 5;
-    static const int Int64 = 6;
-    static const int UInt64 = 7;
-    static const int Float = 8;
-    static const int Double = 9;
-    static const int Bool = 10;
-
-    static const int UnknownType = 11;
-    const QString SupportedTypeList(TypeNames::Bool + ", " + TypeNames::Int8 + ", " + TypeNames::UInt8 + ", " + TypeNames::Int16 + ", " + TypeNames::UInt16 + ", " + TypeNames::Int32 + ", " +
-                                    TypeNames::UInt32 + ", " + TypeNames::Int64 + ", " + TypeNames::UInt64 + ", " + TypeNames::Float + ", " + TypeNames::Double);
-  }
-
-  namespace NumericTypes
-  {
-    namespace Names
-    {
-      const QString Int8("signed   int 8  bit");
-      const QString UInt8("unsigned int 8  bit");
-      const QString Int16("signed   int 16 bit");
-      const QString UInt16("unsigned int 16 bit");
-      const QString Int32("signed   int 32 bit");
-      const QString UInt32("unsigned int 32 bit");
-      const QString Int64("signed   int 64 bit");
-      const QString UInt64("unsigned int 64 bit");
-      const QString Float("       Float 32 bit");
-      const QString Double("      Double 64 bit");
-      const QString Bool("Bool");
-    }
-
-    enum class Type : int
-    {
-      Int8 = 0,
-      UInt8,
-      Int16,
-      UInt16,
-      Int32,
-      UInt32,
-      Int64,
-      UInt64,
-      Float,
-      Double,
-      Bool,
-      UnknownNumType
-    };
-
-    const QString SupportedTypeList(NumericTypes::Names::Int8 + ", " + NumericTypes::Names::UInt8 + ", " + NumericTypes::Names::Int16 + ", " + NumericTypes::Names::UInt16 + ", " +
-                                    NumericTypes::Names::Int32 + ", " + NumericTypes::Names::UInt32 + ", " + NumericTypes::Names::Int64 + ", " + NumericTypes::Names::UInt64 + ", " +
-                                    NumericTypes::Names::Float + ", " + NumericTypes::Names::Double + ", " + NumericTypes::Names::Bool);
-  }
-
-  namespace ScalarTypes
-  {
-    enum class Type : int
-    {
-      Int8 = 0,
-      UInt8,
-      Int16,
-      UInt16,
-      Int32,
-      UInt32,
-      Int64,
-      UInt64,
-      Float,
-      Double,
-      Bool
-    };
-  }
-
-  namespace IO
-  {
-    const QString DAPSettingsHeader("Path");
-  }
-
-
-  namespace Defaults
-  {
-    const QString None("None");
-    const QString AnyPrimitive("Any");
-    static const size_t AnyComponentSize = std::numeric_limits<size_t>::max();
-    //static const uint32_t AnyAttributeMatrix = std::numeric_limits<uint32_t>::max();
-    //static const uint32_t AnyGeometry = std::numeric_limits<uint32_t>::max();
-
-    const QString AttributeMatrixName("AttributeMatrix");
-    const QString ElementAttributeMatrixName("ElementAttributeMatrix");
-    const QString FeatureAttributeMatrixName("FeatureAttributeMatrix");
-    const QString EnsembleAttributeMatrixName("EnsembleAttributeMatrix");
-
-    const QString ImageDataContainerName("ImageDataContainer");
-    const QString NewImageDataContainerName("NewImageDataContainer");
-    const QString TriangleDataContainerName("TriangleDataContainer");
-    const QString QuadDataContainerName("QuadDataContainer");
-    const QString TetrahedralDataContainerName("TetrahedralDataContainer");
-
-    const QString VertexDataContainerName("VertexDataContainer");
-    const QString VertexAttributeMatrixName("VertexData");
-    const QString VertexFeatureAttributeMatrixName("VertexFeatureData");
-    const QString VertexEnsembleAttributeMatrixName("VertexEnsembleData");
-
-    const QString EdgeDataContainerName("EdgeDataContainer");
-    const QString EdgeAttributeMatrixName("EdgeData");
-    const QString EdgeFeatureAttributeMatrixName("EdgeFeatureData");
-    const QString EdgeEnsembleAttributeMatrixName("EdgeEnsembleData");
-
-    const QString SurfaceDataContainerName("SurfaceDataContainer");
-    const QString FaceAttributeMatrixName("FaceData");
-    const QString FaceFeatureAttributeMatrixName("FaceFeatureData");
-    const QString FaceEnsembleAttributeMatrixName("FaceEnsembleData");
-
-    const QString VolumeDataContainerName("VolumeDataContainer");
-    const QString NewVolumeDataContainerName("NewVolumeDataContainer");
-    const QString CellAttributeMatrixName("CellData");
-    const QString NewCellAttributeMatrixName("NewCellData");
-    const QString CellFeatureAttributeMatrixName("CellFeatureData");
-    const QString NewCellFeatureAttributeMatrixName("NewCellFeatureData");
-    const QString CellEnsembleAttributeMatrixName("CellEnsembleData");
-
-    const QString VoxelDataName("VoxelData");
-
-    const QString SyntheticVolumeDataContainerName("SyntheticVolumeDataContainer");
-    const QString StatsGenerator("StatsGeneratorDataContainer");
-
-    const QString SomePath("SomeDataContainer|SomeAttributeMatrix|SomeDataArray");
-
-    const QString GenericBundleName("GenericBundle");
-    const QString TimeSeriesBundleName("TimeSeriesBundle");
-
-    const QString GenericBundleAttributeMatrixName("GenericBundleAttributeMatrix");
-    const QString TimeSeriesBundleAttributeMatrixName("TimeSeriesBundleAttributeMatrix");
-
-    const QString DataContainerName("DataContainer");
-    const QString NewDataContainerName("NewDataContainer");
-    const QString NewAttributeMatrixName("NewAttributeMatrixName");
-  }
-
-  namespace PipelineVersionNumbers
-  {
-    const int CurrentVersion(6);
-  }
-
-  namespace FilterGroups
-  {
-    const QString CoreFilters("Core");
-    const QString Generic("Generic");
-    const QString IOFilters("IO");
-    const QString ProcessingFilters("Processing");
-    const QString ReconstructionFilters("Reconstruction");
-    const QString SamplingFilters("Sampling");
-    const QString StatisticsFilters("Statistics");    
-    const QString SyntheticBuildingFilters("Synthetic Building");
-    const QString SurfaceMeshingFilters("Surface Meshing");
-    const QString Utilities("Utilities");
-    const QString CustomFilters("Custom");
-    const QString Unsupported("Unsupported");
-  }
-
-  namespace FilterSubGroups
-  {
-    const QString EnsembleStatsFilters("Ensemble");
-    const QString MemoryManagementFilters("Memory/Management");
-    const QString SpatialFilters("Spatial");
-    const QString StatisticsFilters("Statistics");
-    const QString FeatureIdentificationFilters("FeatureIdentification");
-    const QString OutputFilters("Output");
-    const QString InputFilters("Input");
-    const QString ImageFilters("Image");
-    const QString CleanupFilters("Cleanup");
-    const QString ThresholdFilters("Threshold");
-    const QString RegularizationFilters("Regularization");
-    const QString ConversionFilters("Conversion");
-    const QString FusionFilters("Fusion");
-    const QString WarpingFilters("Warping");
-    const QString AlignmentFilters("Alignment");
-    const QString SegmentationFilters("Segmentation");
-    const QString GroupingFilters("Grouping");
-    const QString CropCutFilters("Croping/Cutting");
-    const QString RotationTransformationFilters("Rotating/Transforming");
-    const QString ResolutionFilters("Resolution");
-    const QString MorphologicalFilters("Morphological");
-    const QString PackingFilters("Packing");
-    const QString CrystallographyFilters("Crystallography");
-    const QString GenerationFilters("Generation");
-    const QString SmoothingFilters("Smoothing");
-    const QString CurvatureFilters("Curvature");
-    const QString ConnectivityArrangementFilters("Connectivity/Arrangement");
-    const QString MappingFilters("Mapping");
-    const QString MiscFilters("Misc");
-    const QString GeometryFilters("Geometry");
-  }
-
-  namespace GeneralData
-  {
-    const QString CombinedData("CombinedData");
-    const QString ThresholdArray("ThresholdArray");
-    const QString Mask("Mask");
-  }
-
-  namespace CellData
-  {
-    const QString AxisAngles("AxisAngles");
-    const QString BC("BandContrasts");
-    const QString BandContrast("BandContrast");
-    const QString CellPhases("Phases");
-    const QString ConfidenceIndex("Confidence Index");
-    const QString CAxisLocation("CAxisLocation");
-    const QString ConfidenceIndexNoSpace("ConfidenceIndex");
-    const QString Current("Current");
-    const QString DislocationTensors("DislocationTensors");
-    const QString EulerAngles("EulerAngles");
-    const QString EulerColor("EulerColor");
-    const QString FarFeatureQuats("FarFeatureQuats");
-    const QString FarFeatureZoneIds("FarFeatureZoneIds");
-    const QString FitQuality("FitQuality");
-    const QString FlatImageData("FlatImageData");
-    const QString GBEuclideanDistances("GBEuclideanDistances");
-    const QString GBManhattanDistances("GBManhattanDistances");
-    const QString GlobAlpha("GlobAlpha");
-    const QString GoodVoxels("GoodVoxels");
-    const QString FeatureIds("FeatureIds");
-    const QString FeatureReferenceCAxisMisorientations("FeatureReferenceCAxisMisorientations");
-    const QString FeatureReferenceMisorientations("FeatureReferenceMisorientations");
-    const QString IPFColor("IPFColor");
-    const QString ImageData("ImageData");
-    const QString ImageQuality("Image Quality");
-    const QString ImageQualityNoSpace("ImageQuality");
-    const QString KernelAverageMisorientations("KernelAverageMisorientations");
-    const QString Mask("Mask");
-    const QString MotionDirection("MotionDirection");
-    const QString MicroTexVolFrac("MicroTexVolFrac");
-    const QString MisorientationColor("MisorientationColor");
-    const QString ParentDensity("ParentDensity");
-    const QString MTRgKAM("MTRgKAM");
-    const QString NearestNeighbors("NearestNeighbors");
-    const QString ParentIds("ParentIds");
-    const QString Phases("Phases");
-    const QString ProjectedImageMin("ProjectedImageMin");
-    const QString ProjectedImageMax("ProjectedImageMax");
-    const QString ProjectedImageAvg("ProjectedImageAvg");
-    const QString ProjectedImageStd("ProjectedImageStd");
-    const QString ProjectedImageVar("ProjectedImageVar");
-    const QString QPEuclideanDistances("QPEuclideanDistances");
-    const QString QPManhattanDistances("QPManhattanDistances");
-    const QString Quats("Quats");
-    const QString RodriguesColor("RodriguesColor");
-    const QString RodriguesVectors("RodriguesVectors");
-    const QString SolidMeshNodes("SolidMeshNodes");
-    const QString SineParams("SineParams");
-    const QString SolidMeshTetrahedrons("SolidMeshTetrahedrons");
-    const QString Speed("Speed");
-    const QString SurfaceMeshCells("SurfaceMeshCells");
-    const QString BoundaryCells("BoundaryCells");
-    const QString TJManhattanDistances("TJManhattanDistances");
-    const QString TJEuclideanDistances("TJEuclideanDistances");
-    const QString VectorColor("VectorColor");
-    const QString VectorData("VectorData");
-    const QString Histogram("Histogram");
-  }
-
-  namespace FeatureData
-  {
-    const QString FeatureID("Feature_ID");
-    const QString Active("Active");
-    const QString AspectRatios("AspectRatios");
-    const QString AvgCAxes("AvgCAxes");
-    const QString AvgCAxisMisalignments("AvgCAxisMisalignments");
-    const QString LocalCAxisMisalignments("LocalCAxisMisalignments");
-    const QString UnbiasedLocalCAxisMisalignments("UnbiasedLocalCAxisMisalignments");
-    const QString AvgQuats("AvgQuats");
-    const QString AxisEulerAngles("AxisEulerAngles");
-    const QString AxisLengths("AxisLengths");
-    const QString BasalLoadingFactor("BasalLoadingFactor");
-    const QString BiasedFeatures("BiasedFeatures");
-    const QString CAxisMisalignmentList("CAxisMisalignmentList");
-    const QString Centroids("Centroids");
-    const QString ClusteringList("ClusteringList");
-    const QString ElasticStrains("ElasticStrains");
-    const QString EquivalentDiameters("EquivalentDiameters");
-    const QString SaltykovEquivalentDiameters("SaltykovEquivalentDiameters");
-    const QString EulerAngles("EulerAngles");
-    const QString AvgEulerAngles("AvgEulerAngles");
-    const QString F1List("F1List");
-    const QString F1sptList("F1sptList");
-    const QString F7List("F7List");
-    const QString FarFeatureOrientations("FarFeatureOrientations");
-    const QString FeaturePhases("Phases");
-    const QString GoodFeatures("GoodFeatures");
-    const QString FeatureAvgCAxisMisorientations("FeatureAvgCAxisMisorientations");
-    const QString FeatureAvgMisorientations("FeatureAvgMisorientations");
-    const QString FeatureStdevCAxisMisorientations("FeatureStdevCAxisMisorientations");
-    const QString KernelAvgMisorientations("KernelAvgMisorientations");
-    const QString LMG("LMG");
-    const QString LargestCrossSections("LargestCrossSections");
-    const QString Mask("Mask");
-    const QString MTRdensity("MTRdensity");
-    const QString MTRgKAM("MTRgKAM");
-
-    const QString MisorientationList("MisorientationList");
-    const QString NeighborList("NeighborList");
-    const QString NeighborhoodList("NeighborhoodList");
-    const QString Neighborhoods("Neighborhoods");
-    const QString NumCells("NumCells");
-    const QString NumElements("NumElements");
-    const QString NumFeaturesPerParent("NumFeaturesPerParent");
-    const QString NumNeighbors("NumNeighbors");
-    const QString Omega3s("Omega3s");
-    const QString ParentIds("ParentIds");
-    const QString Phases("Phases");
-    const QString Poles("Poles");
-    const QString RGBs("RGBs");
-    const QString Schmids("Schmids");
-    const QString SharedSurfaceAreaList("SharedSurfaceAreaList");
-    const QString SlipSystems("SlipSystems");
-    const QString SurfaceAreaVol("SurfaceAreaVolumeRatio");
-    const QString SurfaceFeatures("SurfaceFeatures");
-    const QString SurfaceElementFractions("SurfaceElementFractions");
-    const QString Volumes("Volumes");
-    const QString AvgMisorientations("AvgMisorientations");
-    const QString mPrimeList("mPrimeList");
-    const QString NumBins("NumBins");
-    const QString ScalarAverages("ScalarAverages");
-
-  }
-
-  namespace EnsembleData
-  {
-    const QString NumFeatures("NumFeatures");
-    const QString VolFractions("VolFractions");
-    const QString TotalSurfaceAreas("TotalSurfaceAreas");
-    const QString CrystalSymmetry("Crystal Symmetry");
-    const QString CrystalStructures("CrystalStructures");
-    const QString PhaseTypes("PhaseTypes");
-    const QString BravaisLattice("BravaisLattice");
-    const QString PrecipitateFractions("PrecipitateFractions");
-    const QString ShapeTypes("ShapeTypes");
-    const QString Statistics("Statistics");
-    const QString PhaseName("PhaseName");
-    const QString LatticeConstants("LatticeConstants");
-    const QString GBCD("GBCD");
-    const QString GBCDdimensions("GBCDdimensions");
-    const QString FitParameters("FitParameters");
-    const QString MaterialName("MaterialName");
-  }
-
-
-  namespace VertexData
-  {
-    const QString AtomVelocities("AtomVelocities");
-    const QString AtomTypes("AtomTypes");
-    const QString AtomFeatureLabels("AtomFeatureLabels");
-    const QString NumberOfArms("NumberOfArms");
-    const QString NodeConstraints("NodeConstraints");
-    const QString SurfaceMeshNodes("Nodes");
-    const QString SurfaceMeshNodeType("NodeType");
-    const QString SurfaceMeshNodeNormals("NodeNormals");
-    const QString SurfaceMeshNodeFaces("NodeFaces");
-  }
-
-  namespace FaceData
-  {
-    const QString SurfaceMeshFaces("Faces");
-    const QString SurfaceMeshFaceIPFColors("IPFColors");
-    const QString SurfaceMeshFaceMisorientationColors("MisorientationColors");
-    const QString SurfaceMeshFaceSchuhMisorientationColors("SchuhMisorientationColors");
-    const QString SurfaceMeshFaceLabels("FaceLabels");
-    const QString SurfaceMeshFacePhases("Phases");
-    const QString SurfaceMeshF1s("F1s");
-    const QString SurfaceMeshF1spts("F1spts");
-    const QString SurfaceMeshF7s("F7s");
-    const QString SurfaceMeshmPrimes("mPrimes");
-    const QString SurfaceMeshVoxels("SurfaceMeshVoxels");
-    const QString SurfaceMeshFaceCentroids("FaceCentroids");
-    const QString SurfaceMeshFaceAreas("FaceAreas");
-    const QString SurfaceMeshTwinBoundary("TwinBoundary");
-    const QString SurfaceMeshTwinBoundaryIncoherence("TwinBoundaryIncoherence");
-    const QString SurfaceMeshTwinBoundarySchmidFactors("TwinBoundarySchmidFactors");
-    const QString SurfaceMeshFaceDihedralAngles("FaceDihedralAngles");
-    const QString SurfaceMeshFaceNormals("FaceNormals");
-    const QString SurfaceMeshFeatureFaceId("FeatureFaceId");
-    const QString SurfaceMeshGaussianCurvatures("GaussianCurvatures");
-    const QString SurfaceMeshMeanCurvatures("MeanCurvatures");
-    const QString SurfaceMeshPrincipalCurvature1("PrincipalCurvature1");
-    const QString SurfaceMeshPrincipalCurvature2("PrincipalCurvature2");
-    const QString SurfaceMeshPrincipalDirection1("PrincipalDirection1");
-    const QString SurfaceMeshPrincipalDirection2("PrincipalDirection2");
-  }
-
-  namespace EdgeData
-  {
-    const QString DislocationIds("DislocationIds");
-    const QString BurgersVectors("BurgersVectors");
-    const QString SlipPlaneNormals("SlipPlaneNormals");
-    const QString SurfaceMeshEdges("SurfaceMeshEdges");
-    const QString SurfaceMeshUniqueEdges("SurfaceMeshUniqueEdges");
-    const QString SurfaceMeshInternalEdges("SurfaceMeshInternalEdges");
-    const QString SurfaceMeshTriangleEdges("SurfaceMeshTriangleEdges");
-    const QString SurfaceMeshEdgeFaces("SurfaceMeshEdgeFaces");
-  }
-
-  namespace Settings
-  {
-    const QString Library("Filter Library");
-    const QString PrebuiltPipelines("Prebuilt Pipelines");
-    const QString FavoritePipelines("Favorite Pipelines");
-    const QString PipelineBuilderGroup("PipelineBuilder");
-    const QString FavoriteConfig("favorite_config");
-    const QString NumFilters("Number_Filters");
-    const QString PipelineName("Name");
-    const QString FilterName("Filter_Name");
-    const QString FilterUuid("Filter_Uuid");
-    const QString FilterVersion("FilterVersion");
-    const QString HumanLabel("Filter_Human_Label");
-    const QString FilterEnabled("Filter_Enabled");
-    const QString Version("Version");
-    const QString PipelineBuilderGeomertry("PipelineBuilderGeometry");
-  }
-
-
-  namespace HDF5
-  {
-    const QString FileVersion("7.0");
-    const QString FileVersionName("FileVersion");
-    const QString DREAM3DVersion("DREAM3D Version");
-    const QString ObjectType("ObjectType");
-    const QString Rank("Rank");
-    const QString TupleDimensions("TupleDimensions");
-    const QString ComponentDimensions("ComponentDimensions");
-    const QString AxisDimensions("Tuple Axis Dimensions");
-    const QString DataArrayVersion("DataArrayVersion");
-  }
-
-  namespace StringConstants
-  {
-    const QString Alpha("Alpha");
-    const QString Angle("Angle");
-
-    const QString Average("Average");
-    const QString Axis("Axis");
-    const QString AxisODFWeights("AxisODF-Weights");
-    const QString AxisOrientation("AxisOrientation");
-    const QString Beta("Beta");
-    const QString BetaDistribution("Beta Distribution");
-    const QString BinNumber("BinNumber");
-    const QString BinCount("Bin Count");
-    const QString BinStepSize("Bin Step Size");
-    const QString BoundaryArea("BoundaryArea");
-    const QString BoundaryStatsData("BoundaryStatsData");
-    const QString CellNeighbors("CellNeighbors");
-
-    const QString CellsContainingVert("CellsContainingVert");
-    const QString CellsName("Cells");
-    const QString CrystalStructure("CrystalStructure");
-    const QString DataContainerGroupName("DataContainers");
-    const QString DataContainerBundleGroupName("DataContainerBundles");
-    const QString DataContainerNames("DataContainerNames");
-    const QString MetaDataArrays("MetaDataArrays");
-    const QString DataContainerType("DataContainerType");
-    const QString AttributeMatrixType("AttributeMatrixType");
-
-    const QString Dims("Dims");
-    const QString DistributionType("Distribution Type");
-
-    const QString EdgeNeighbors("EdgeNeighbors");
-    const QString EdgesContainingVert("EdgesContainingVert");
-    const QString EdgesName("Edges");
-    const QString EdgeCentroids("EdgeCentroids");
-    const QString EdgeLengths("EdgeLengths");
-    const QString Euler1("Euler 1");
-    const QString Euler2("Euler 2");
-    const QString Euler3("Euler 3");
-    const QString Exp_k("K");
-
-    const QString FaceNeighbors("FaceNeighbors");
-    const QString FacesContainingVert("FacesContainingVert");
-    const QString FacesName("Faces");
-    const QString TrianglesName("Triangles");
-    const QString TriangleNeighbors("TriangleNeighbors");
-    const QString TrianglesContainingVert("TrianglesContainingVert");
-    const QString TriangleCentroids("TriangleCentroids");
-    const QString TriangleAreas("TriangleAreas");
-    const QString Frequencies("Frequencies");
-
-    const QString QuadsName("Quadrilaterals");
-    const QString QuadNeighbors("QuadrilateralNeighbors");
-    const QString QuadsContainingVert("QuadrilateralsContainingVerts");
-    const QString QuadCentroids("QuadrilateralCentroids");
-    const QString QuadAreas("QuadrilateralAreas");
-
-    const QString TetsName("Tetrahedra");
-    const QString TetNeighbors("TetrahedralNeighbors");
-    const QString TetsContainingVert("TetrahedraContainingVerts");
-    const QString TetCentroids("TetrahedralCentroids");
-    const QString TetVolumes("TetrahedralVolumes");
-
-    const QString VoxelSizes("VoxelSizes");
-    const QString VertexSizes("VertexSizes");
-
-    const QString GBCD("GBCD");
-    const QString FeatureAvgDisorientation ("FeatureAvgDisorientation");
-    const QString Feature_Diameter_Info("Feature_Diameter_Info");
-    const QString Feature_SizeVBoverA_Distributions("FeatureSize Vs B Over A Distributions");
-    const QString Feature_SizeVCoverA_Distributions("FeatureSize Vs C Over A Distributions");
-    const QString Feature_SizeVNeighbors_Distributions("FeatureSize Vs Neighbors Distributions");
-    const QString Feature_SizeVOmega3_Distributions("FeatureSize Vs Omega3 Distributions");
-    const QString Feature_SizeVClustering_Distributions("FeatureSize Vs Clustering Distributions");
-    const QString Feature_Size_Distribution("FeatureSize Distribution");
-    const QString KernelAvgDisorientation( "KernelAvgDisorientation");
-    const QString LogNormalDistribution("Log Normal Distribution");
-    const QString MDFWeights("MDF-Weights");
-    const QString MatrixStatsData("MatrixStatsData");
-    const QString MeshFaceNeighborLists("MeshFaceNeighborLists");
-    const QString MicroTextureBins("MicroTextureBins");
-    const QString MinimumValue("Minimum Value");
-    const QString MinMaxNoOfBins("MinMaxNoOfBins");
-    const QString MisorientationBins("MisorientationBins");
-    const QString Neighbor_Feature_ID_List( "Neighbor_Feature_ID_List");
-
-    const QString ODF("ODF");
-    const QString ODFWeights("ODF-Weights");
-
-    const QString ParentPhase("Parent Phase");
-    const QString PhaseFraction("PhaseFraction");
-    const QString PhaseType("PhaseType");
-    const QString PipelineGroupName("Pipeline");
-    const QString PipelineVersionName("Pipeline Version");
-    const QString PipelineCurrentName("Current Pipeline");
-    const QString PowerLawDistribution("Power Law Distribution");
-    const QString PrecipitateBoundaryFraction("Precipitate Boundary Fraction");
-    const QString PrecipitateStatsData("PrecipitateStatsData");
-    const QString PrimaryStatsData("PrimaryStatsData");
-    const QString PresetName("PresetName");
-
-    const QString RadialDistFunc("Radial Distribution Function");
-    const QString RdfMinDistance("Min");
-    const QString RdfMaxDistance("Max");
-    const QString RdfBoxDims("BoxDims");
-    const QString RdfBoxRes("BoxRes");
-
-    const QString Sigma("Sigma");
-    const QString StandardDeviation("Standard Deviation");
-    const QString Statistics("Statistics");
-    const QString Stats("Stats");
-    const QString StatsData("StatsData");
-    const QString StatsType("StatsType");
-
-    const QString TransformationStatsData("TransformationStatsData");
-    const QString UnknownDistribution("Unknown Distribution");
-
-    const QString VerticesName("Vertices");
-    const QString VertsName("Verts");
-    const QString ImageName("Image");
-
-    const QString Weight("Weight");
-
-    const QString MetaData("_META_DATA");
-
-    const QString Name("Name");
-    const QString Index("Index");
-  }
-
-  namespace CellType
-  {
-    const QString Quadrilateral("Quadrilateral");
-    const QString Tetrahedron("Tetrahedron");
-    const QString Triangle("Triangle");
-    const QString Face("Face");
-    const QString Edge("Edge");
-    const QString Vertex("Vertex");
-    const QString Node("Node");
-  }
-
-  //namespace PhaseType
-  //{
-  //  //const unsigned int PrimaryPhase = 0;              //!<
-  //  //const unsigned int PrecipitatePhase = 1;          //!<
-  //  //const unsigned int TransformationPhase = 2;       //!<
-  //  //const unsigned int MatrixPhase = 3;              //!<
-  //  //const unsigned int BoundaryPhase = 4;              //!<
-  //  //const unsigned int Unknown = 999;    //!<
-
-  //  const QString Primary("Primary");
-  //  const QString Precipitate("Precipitate");
-  //  const QString Transformation("Transformation");
-  //  const QString Matrix("Matrix");
-  //  const QString Boundary("Boundary");
-  //  const QString UnknownPhase("Unknown");
-  //}
-
-  namespace AlignmentMethod
-  {
-    const unsigned int OuterBoundary = 0;        //!<
-    const unsigned int Misorientation = 1;       //!<
-    const unsigned int MutualInformation = 2;    //!<
-    const unsigned int Count = 3;                //!<
-    const unsigned int UnknownAlignmentMethod = 999;    //!<
-  }
-
-  namespace StatisticsType
-  {
-    const unsigned int Feature_SizeVBoverA = 0;    //!<
-    const unsigned int Feature_SizeVCoverA = 1;        //!<
-    const unsigned int Feature_SizeVNeighbors = 2;     //!<
-    const unsigned int Feature_SizeVOmega3 = 3;        //!<
-    const unsigned int Feature_SizeVClustering = 4;        //!<
-    const unsigned int UnknownStatisticsGroup = 999;    //!<
-
-  }
-
-  namespace DistributionType
-  {
-    const unsigned int Beta = 0;         //!<
-    const unsigned int LogNormal = 1;    //!<
-    const unsigned int Power = 2;        //!<
-    const unsigned int RDFFrequency = 3; //!<
-    const unsigned int RDFMaxMin = 4; //!<
-    const unsigned int UnknownDistributionType = 5;    //!<
-    const unsigned int Count = 6; //!<
-
-    enum ColumnCount
-    {
-      BetaColumnCount = 2,       //!<
-      LogNormalColumnCount = 2,  //!<
-      PowerLawColumnCount = 2,   //!<
-      RawDistDataColumnCount = 1,   //!<
-      UnknownColumCount = 0      //!<
-    };
-
-
-  }
-
-  namespace EulerAngleConversionType
-  {
-    const unsigned int DegreesToRadians = 0; //!<
-    const unsigned int RadiansToDegrees = 1; //!<
-  }
-
-  namespace FlattenImageMethod
-  {
-    const unsigned int Lightness = 0; //!<
-    const unsigned int Average = 1; //!<
-    const unsigned int Luminosity = 2; //!<
-  }
-
-  namespace EulerFrameRotationAxis
-  {
-    const unsigned int RD = 0; //!<
-    const unsigned int TD = 1; //!<
-    const unsigned int ND = 2; //!<
-    const unsigned int None = 3; //!<
-  }
-
-  namespace SampleFrameRotationAxis
-  {
-    const unsigned int X = 0; //!<
-    const unsigned int Y = 1; //!<
-    const unsigned int Z = 2; //!<
-    const unsigned int None = 3; //!<
-  }
-
-  namespace RefFrameRotationAngle
-  {
-    const unsigned int Ninety = 0; //!<
-    const unsigned int oneEighty = 1; //!<
-    const unsigned int twoSeventy = 2; //!<
-    const unsigned int Mirror = 3; //!<
-    const unsigned int Zero = 4; //!<
-  }
-
-  namespace Overlap
-  {
-    const unsigned int Rigid = 0; //!<
-    const unsigned int Progressive = 1; //!<
-    const unsigned int UnknownOverlap = 999; //!<
-  }
+typedef uint32_t Rgb;
+const Rgb RGB_MASK = 0x00ffffff; // masks RGB values
+const QString PathSep("|");
+static const uint8_t Unchecked = 0;
+static const uint8_t PartiallyChecked = 1;
+static const uint8_t Checked = 2;
+
+enum InfoStringFormat
+{
+  HtmlFormat = 0,
+  //      JsonFormat,
+  //      TextFormat,
+  //      XmlFormat,
+  UnknownFormat
+};
+
+/** @brief Constants defined for the Stacking order of images into a 3D Volume */
+namespace RefFrameZDir
+{
+static const unsigned int LowtoHigh = 0;
+static const unsigned int HightoLow = 1;
+static const unsigned int UnknownRefFrameZDirection = 2;
+}
+
+namespace TypeNames
+{
+const QString Bool("bool");
+const QString Float("float");
+const QString Double("double");
+const QString Int8("int8_t");
+const QString UInt8("uint8_t");
+const QString Int16("int16_t");
+const QString UInt16("uint16_t");
+const QString Int32("int32_t");
+const QString UInt32("uint32_t");
+const QString Int64("int64_t");
+const QString UInt64("uint64_t");
+const QString String("string");
+const QString StatsDataArray("StatsDataArray");
+const QString NeighborList("NeighborList<T>");
+const QString StringArray("StringDataArray");
+const QString Unknown("Unknown");
+const QString SupportedTypeList(TypeNames::Bool + ", " + TypeNames::StringArray + ", " + TypeNames::Int8 + ", " + TypeNames::UInt8 + ", " + TypeNames::Int16 + ", " + TypeNames::UInt16 + ", " +
+                                TypeNames::Int32 + ", " + TypeNames::UInt32 + ", " + TypeNames::Int64 + ", " + TypeNames::UInt64 + ", " + TypeNames::Float + ", " + TypeNames::Double);
+}
+
+namespace TypeEnums
+{
+static const int Int8 = 0;
+static const int UInt8 = 1;
+static const int Int16 = 2;
+static const int UInt16 = 3;
+static const int Int32 = 4;
+static const int UInt32 = 5;
+static const int Int64 = 6;
+static const int UInt64 = 7;
+static const int Float = 8;
+static const int Double = 9;
+static const int Bool = 10;
+
+static const int UnknownType = 11;
+const QString SupportedTypeList(TypeNames::Bool + ", " + TypeNames::Int8 + ", " + TypeNames::UInt8 + ", " + TypeNames::Int16 + ", " + TypeNames::UInt16 + ", " + TypeNames::Int32 + ", " +
+                                TypeNames::UInt32 + ", " + TypeNames::Int64 + ", " + TypeNames::UInt64 + ", " + TypeNames::Float + ", " + TypeNames::Double);
+}
+
+namespace NumericTypes
+{
+namespace Names
+{
+const QString Int8("signed   int 8  bit");
+const QString UInt8("unsigned int 8  bit");
+const QString Int16("signed   int 16 bit");
+const QString UInt16("unsigned int 16 bit");
+const QString Int32("signed   int 32 bit");
+const QString UInt32("unsigned int 32 bit");
+const QString Int64("signed   int 64 bit");
+const QString UInt64("unsigned int 64 bit");
+const QString Float("       Float 32 bit");
+const QString Double("      Double 64 bit");
+const QString Bool("Bool");
+}
+
+enum class Type : int
+{
+  Int8 = 0,
+  UInt8,
+  Int16,
+  UInt16,
+  Int32,
+  UInt32,
+  Int64,
+  UInt64,
+  Float,
+  Double,
+  Bool,
+  UnknownNumType
+};
+
+const QString SupportedTypeList(NumericTypes::Names::Int8 + ", " + NumericTypes::Names::UInt8 + ", " + NumericTypes::Names::Int16 + ", " + NumericTypes::Names::UInt16 + ", " +
+                                NumericTypes::Names::Int32 + ", " + NumericTypes::Names::UInt32 + ", " + NumericTypes::Names::Int64 + ", " + NumericTypes::Names::UInt64 + ", " +
+                                NumericTypes::Names::Float + ", " + NumericTypes::Names::Double + ", " + NumericTypes::Names::Bool);
+}
+
+namespace ScalarTypes
+{
+enum class Type : int
+{
+  Int8 = 0,
+  UInt8,
+  Int16,
+  UInt16,
+  Int32,
+  UInt32,
+  Int64,
+  UInt64,
+  Float,
+  Double,
+  Bool
+};
+}
+
+namespace IO
+{
+const QString DAPSettingsHeader("Path");
+}
+
+namespace Defaults
+{
+const QString None("None");
+const QString AnyPrimitive("Any");
+static const size_t AnyComponentSize = std::numeric_limits<size_t>::max();
+// static const uint32_t AnyAttributeMatrix = std::numeric_limits<uint32_t>::max();
+// static const uint32_t AnyGeometry = std::numeric_limits<uint32_t>::max();
+
+const QString AttributeMatrixName("AttributeMatrix");
+const QString ElementAttributeMatrixName("ElementAttributeMatrix");
+const QString FeatureAttributeMatrixName("FeatureAttributeMatrix");
+const QString EnsembleAttributeMatrixName("EnsembleAttributeMatrix");
+
+const QString ImageDataContainerName("ImageDataContainer");
+const QString NewImageDataContainerName("NewImageDataContainer");
+const QString TriangleDataContainerName("TriangleDataContainer");
+const QString QuadDataContainerName("QuadDataContainer");
+const QString TetrahedralDataContainerName("TetrahedralDataContainer");
+
+const QString VertexDataContainerName("VertexDataContainer");
+const QString VertexAttributeMatrixName("VertexData");
+const QString VertexFeatureAttributeMatrixName("VertexFeatureData");
+const QString VertexEnsembleAttributeMatrixName("VertexEnsembleData");
+
+const QString EdgeDataContainerName("EdgeDataContainer");
+const QString EdgeAttributeMatrixName("EdgeData");
+const QString EdgeFeatureAttributeMatrixName("EdgeFeatureData");
+const QString EdgeEnsembleAttributeMatrixName("EdgeEnsembleData");
+
+const QString SurfaceDataContainerName("SurfaceDataContainer");
+const QString FaceAttributeMatrixName("FaceData");
+const QString FaceFeatureAttributeMatrixName("FaceFeatureData");
+const QString FaceEnsembleAttributeMatrixName("FaceEnsembleData");
+
+const QString VolumeDataContainerName("VolumeDataContainer");
+const QString NewVolumeDataContainerName("NewVolumeDataContainer");
+const QString CellAttributeMatrixName("CellData");
+const QString NewCellAttributeMatrixName("NewCellData");
+const QString CellFeatureAttributeMatrixName("CellFeatureData");
+const QString NewCellFeatureAttributeMatrixName("NewCellFeatureData");
+const QString CellEnsembleAttributeMatrixName("CellEnsembleData");
+
+const QString VoxelDataName("VoxelData");
+
+const QString SyntheticVolumeDataContainerName("SyntheticVolumeDataContainer");
+const QString StatsGenerator("StatsGeneratorDataContainer");
+
+const QString SomePath("SomeDataContainer|SomeAttributeMatrix|SomeDataArray");
+
+const QString GenericBundleName("GenericBundle");
+const QString TimeSeriesBundleName("TimeSeriesBundle");
+
+const QString GenericBundleAttributeMatrixName("GenericBundleAttributeMatrix");
+const QString TimeSeriesBundleAttributeMatrixName("TimeSeriesBundleAttributeMatrix");
+
+const QString DataContainerName("DataContainer");
+const QString NewDataContainerName("NewDataContainer");
+const QString NewAttributeMatrixName("NewAttributeMatrixName");
+}
+
+namespace PipelineVersionNumbers
+{
+const int CurrentVersion(6);
+}
+
+namespace FilterGroups
+{
+const QString CoreFilters("Core");
+const QString Generic("Generic");
+const QString IOFilters("IO");
+const QString ProcessingFilters("Processing");
+const QString ReconstructionFilters("Reconstruction");
+const QString SamplingFilters("Sampling");
+const QString StatisticsFilters("Statistics");
+const QString SyntheticBuildingFilters("Synthetic Building");
+const QString SurfaceMeshingFilters("Surface Meshing");
+const QString Utilities("Utilities");
+const QString CustomFilters("Custom");
+const QString Unsupported("Unsupported");
+}
+
+namespace FilterSubGroups
+{
+const QString EnsembleStatsFilters("Ensemble");
+const QString MemoryManagementFilters("Memory/Management");
+const QString SpatialFilters("Spatial");
+const QString StatisticsFilters("Statistics");
+const QString FeatureIdentificationFilters("FeatureIdentification");
+const QString OutputFilters("Output");
+const QString InputFilters("Input");
+const QString ImageFilters("Image");
+const QString CleanupFilters("Cleanup");
+const QString ThresholdFilters("Threshold");
+const QString RegularizationFilters("Regularization");
+const QString ConversionFilters("Conversion");
+const QString FusionFilters("Fusion");
+const QString WarpingFilters("Warping");
+const QString AlignmentFilters("Alignment");
+const QString SegmentationFilters("Segmentation");
+const QString GroupingFilters("Grouping");
+const QString CropCutFilters("Croping/Cutting");
+const QString RotationTransformationFilters("Rotating/Transforming");
+const QString ResolutionFilters("Resolution");
+const QString MorphologicalFilters("Morphological");
+const QString PackingFilters("Packing");
+const QString CrystallographyFilters("Crystallography");
+const QString GenerationFilters("Generation");
+const QString SmoothingFilters("Smoothing");
+const QString CurvatureFilters("Curvature");
+const QString ConnectivityArrangementFilters("Connectivity/Arrangement");
+const QString MappingFilters("Mapping");
+const QString MiscFilters("Misc");
+const QString GeometryFilters("Geometry");
+}
+
+namespace GeneralData
+{
+const QString CombinedData("CombinedData");
+const QString ThresholdArray("ThresholdArray");
+const QString Mask("Mask");
+}
+
+namespace CellData
+{
+const QString AxisAngles("AxisAngles");
+const QString BC("BandContrasts");
+const QString BandContrast("BandContrast");
+const QString CellPhases("Phases");
+const QString ConfidenceIndex("Confidence Index");
+const QString CAxisLocation("CAxisLocation");
+const QString ConfidenceIndexNoSpace("ConfidenceIndex");
+const QString Current("Current");
+const QString DislocationTensors("DislocationTensors");
+const QString EulerAngles("EulerAngles");
+const QString EulerColor("EulerColor");
+const QString FarFeatureQuats("FarFeatureQuats");
+const QString FarFeatureZoneIds("FarFeatureZoneIds");
+const QString FitQuality("FitQuality");
+const QString FlatImageData("FlatImageData");
+const QString GBEuclideanDistances("GBEuclideanDistances");
+const QString GBManhattanDistances("GBManhattanDistances");
+const QString GlobAlpha("GlobAlpha");
+const QString GoodVoxels("GoodVoxels");
+const QString FeatureIds("FeatureIds");
+const QString FeatureReferenceCAxisMisorientations("FeatureReferenceCAxisMisorientations");
+const QString FeatureReferenceMisorientations("FeatureReferenceMisorientations");
+const QString IPFColor("IPFColor");
+const QString ImageData("ImageData");
+const QString ImageQuality("Image Quality");
+const QString ImageQualityNoSpace("ImageQuality");
+const QString KernelAverageMisorientations("KernelAverageMisorientations");
+const QString Mask("Mask");
+const QString MotionDirection("MotionDirection");
+const QString MicroTexVolFrac("MicroTexVolFrac");
+const QString MisorientationColor("MisorientationColor");
+const QString ParentDensity("ParentDensity");
+const QString MTRgKAM("MTRgKAM");
+const QString NearestNeighbors("NearestNeighbors");
+const QString ParentIds("ParentIds");
+const QString Phases("Phases");
+const QString ProjectedImageMin("ProjectedImageMin");
+const QString ProjectedImageMax("ProjectedImageMax");
+const QString ProjectedImageAvg("ProjectedImageAvg");
+const QString ProjectedImageStd("ProjectedImageStd");
+const QString ProjectedImageVar("ProjectedImageVar");
+const QString QPEuclideanDistances("QPEuclideanDistances");
+const QString QPManhattanDistances("QPManhattanDistances");
+const QString Quats("Quats");
+const QString RodriguesColor("RodriguesColor");
+const QString RodriguesVectors("RodriguesVectors");
+const QString SolidMeshNodes("SolidMeshNodes");
+const QString SineParams("SineParams");
+const QString SolidMeshTetrahedrons("SolidMeshTetrahedrons");
+const QString Speed("Speed");
+const QString SurfaceMeshCells("SurfaceMeshCells");
+const QString BoundaryCells("BoundaryCells");
+const QString TJManhattanDistances("TJManhattanDistances");
+const QString TJEuclideanDistances("TJEuclideanDistances");
+const QString VectorColor("VectorColor");
+const QString VectorData("VectorData");
+const QString Histogram("Histogram");
+}
+
+namespace FeatureData
+{
+const QString FeatureID("Feature_ID");
+const QString Active("Active");
+const QString AspectRatios("AspectRatios");
+const QString AvgCAxes("AvgCAxes");
+const QString AvgCAxisMisalignments("AvgCAxisMisalignments");
+const QString LocalCAxisMisalignments("LocalCAxisMisalignments");
+const QString UnbiasedLocalCAxisMisalignments("UnbiasedLocalCAxisMisalignments");
+const QString AvgQuats("AvgQuats");
+const QString AxisEulerAngles("AxisEulerAngles");
+const QString AxisLengths("AxisLengths");
+const QString BasalLoadingFactor("BasalLoadingFactor");
+const QString BiasedFeatures("BiasedFeatures");
+const QString CAxisMisalignmentList("CAxisMisalignmentList");
+const QString Centroids("Centroids");
+const QString ClusteringList("ClusteringList");
+const QString ElasticStrains("ElasticStrains");
+const QString EquivalentDiameters("EquivalentDiameters");
+const QString SaltykovEquivalentDiameters("SaltykovEquivalentDiameters");
+const QString EulerAngles("EulerAngles");
+const QString AvgEulerAngles("AvgEulerAngles");
+const QString F1List("F1List");
+const QString F1sptList("F1sptList");
+const QString F7List("F7List");
+const QString FarFeatureOrientations("FarFeatureOrientations");
+const QString FeaturePhases("Phases");
+const QString GoodFeatures("GoodFeatures");
+const QString FeatureAvgCAxisMisorientations("FeatureAvgCAxisMisorientations");
+const QString FeatureAvgMisorientations("FeatureAvgMisorientations");
+const QString FeatureStdevCAxisMisorientations("FeatureStdevCAxisMisorientations");
+const QString KernelAvgMisorientations("KernelAvgMisorientations");
+const QString LMG("LMG");
+const QString LargestCrossSections("LargestCrossSections");
+const QString Mask("Mask");
+const QString MTRdensity("MTRdensity");
+const QString MTRgKAM("MTRgKAM");
+
+const QString MisorientationList("MisorientationList");
+const QString NeighborList("NeighborList");
+const QString NeighborhoodList("NeighborhoodList");
+const QString Neighborhoods("Neighborhoods");
+const QString NumCells("NumCells");
+const QString NumElements("NumElements");
+const QString NumFeaturesPerParent("NumFeaturesPerParent");
+const QString NumNeighbors("NumNeighbors");
+const QString Omega3s("Omega3s");
+const QString ParentIds("ParentIds");
+const QString Phases("Phases");
+const QString Poles("Poles");
+const QString RGBs("RGBs");
+const QString Schmids("Schmids");
+const QString SharedSurfaceAreaList("SharedSurfaceAreaList");
+const QString SlipSystems("SlipSystems");
+const QString SurfaceAreaVol("SurfaceAreaVolumeRatio");
+const QString SurfaceFeatures("SurfaceFeatures");
+const QString SurfaceElementFractions("SurfaceElementFractions");
+const QString Volumes("Volumes");
+const QString AvgMisorientations("AvgMisorientations");
+const QString mPrimeList("mPrimeList");
+const QString NumBins("NumBins");
+const QString ScalarAverages("ScalarAverages");
+}
+
+namespace EnsembleData
+{
+const QString NumFeatures("NumFeatures");
+const QString VolFractions("VolFractions");
+const QString TotalSurfaceAreas("TotalSurfaceAreas");
+const QString CrystalSymmetry("Crystal Symmetry");
+const QString CrystalStructures("CrystalStructures");
+const QString PhaseTypes("PhaseTypes");
+const QString BravaisLattice("BravaisLattice");
+const QString PrecipitateFractions("PrecipitateFractions");
+const QString ShapeTypes("ShapeTypes");
+const QString Statistics("Statistics");
+const QString PhaseName("PhaseName");
+const QString LatticeConstants("LatticeConstants");
+const QString GBCD("GBCD");
+const QString GBCDdimensions("GBCDdimensions");
+const QString FitParameters("FitParameters");
+const QString MaterialName("MaterialName");
+}
+
+namespace VertexData
+{
+const QString AtomVelocities("AtomVelocities");
+const QString AtomTypes("AtomTypes");
+const QString AtomFeatureLabels("AtomFeatureLabels");
+const QString NumberOfArms("NumberOfArms");
+const QString NodeConstraints("NodeConstraints");
+const QString SurfaceMeshNodes("Nodes");
+const QString SurfaceMeshNodeType("NodeType");
+const QString SurfaceMeshNodeNormals("NodeNormals");
+const QString SurfaceMeshNodeFaces("NodeFaces");
+}
+
+namespace FaceData
+{
+const QString SurfaceMeshFaces("Faces");
+const QString SurfaceMeshFaceIPFColors("IPFColors");
+const QString SurfaceMeshFaceMisorientationColors("MisorientationColors");
+const QString SurfaceMeshFaceSchuhMisorientationColors("SchuhMisorientationColors");
+const QString SurfaceMeshFaceLabels("FaceLabels");
+const QString SurfaceMeshFacePhases("Phases");
+const QString SurfaceMeshF1s("F1s");
+const QString SurfaceMeshF1spts("F1spts");
+const QString SurfaceMeshF7s("F7s");
+const QString SurfaceMeshmPrimes("mPrimes");
+const QString SurfaceMeshVoxels("SurfaceMeshVoxels");
+const QString SurfaceMeshFaceCentroids("FaceCentroids");
+const QString SurfaceMeshFaceAreas("FaceAreas");
+const QString SurfaceMeshTwinBoundary("TwinBoundary");
+const QString SurfaceMeshTwinBoundaryIncoherence("TwinBoundaryIncoherence");
+const QString SurfaceMeshTwinBoundarySchmidFactors("TwinBoundarySchmidFactors");
+const QString SurfaceMeshFaceDihedralAngles("FaceDihedralAngles");
+const QString SurfaceMeshFaceNormals("FaceNormals");
+const QString SurfaceMeshFeatureFaceId("FeatureFaceId");
+const QString SurfaceMeshGaussianCurvatures("GaussianCurvatures");
+const QString SurfaceMeshMeanCurvatures("MeanCurvatures");
+const QString SurfaceMeshPrincipalCurvature1("PrincipalCurvature1");
+const QString SurfaceMeshPrincipalCurvature2("PrincipalCurvature2");
+const QString SurfaceMeshPrincipalDirection1("PrincipalDirection1");
+const QString SurfaceMeshPrincipalDirection2("PrincipalDirection2");
+}
+
+namespace EdgeData
+{
+const QString DislocationIds("DislocationIds");
+const QString BurgersVectors("BurgersVectors");
+const QString SlipPlaneNormals("SlipPlaneNormals");
+const QString SurfaceMeshEdges("SurfaceMeshEdges");
+const QString SurfaceMeshUniqueEdges("SurfaceMeshUniqueEdges");
+const QString SurfaceMeshInternalEdges("SurfaceMeshInternalEdges");
+const QString SurfaceMeshTriangleEdges("SurfaceMeshTriangleEdges");
+const QString SurfaceMeshEdgeFaces("SurfaceMeshEdgeFaces");
+}
+
+namespace Settings
+{
+const QString Library("Filter Library");
+const QString PrebuiltPipelines("Prebuilt Pipelines");
+const QString FavoritePipelines("Favorite Pipelines");
+const QString PipelineBuilderGroup("PipelineBuilder");
+const QString FavoriteConfig("favorite_config");
+const QString NumFilters("Number_Filters");
+const QString PipelineName("Name");
+const QString FilterName("Filter_Name");
+const QString FilterUuid("Filter_Uuid");
+const QString FilterVersion("FilterVersion");
+const QString HumanLabel("Filter_Human_Label");
+const QString FilterEnabled("Filter_Enabled");
+const QString Version("Version");
+const QString PipelineBuilderGeomertry("PipelineBuilderGeometry");
+}
+
+namespace HDF5
+{
+const QString FileVersion("7.0");
+const QString FileVersionName("FileVersion");
+const QString DREAM3DVersion("DREAM3D Version");
+const QString ObjectType("ObjectType");
+const QString Rank("Rank");
+const QString TupleDimensions("TupleDimensions");
+const QString ComponentDimensions("ComponentDimensions");
+const QString AxisDimensions("Tuple Axis Dimensions");
+const QString DataArrayVersion("DataArrayVersion");
+}
+
+namespace StringConstants
+{
+const QString Alpha("Alpha");
+const QString Angle("Angle");
+
+const QString Average("Average");
+const QString Axis("Axis");
+const QString AxisODFWeights("AxisODF-Weights");
+const QString AxisOrientation("AxisOrientation");
+const QString Beta("Beta");
+const QString BetaDistribution("Beta Distribution");
+const QString BinNumber("BinNumber");
+const QString BinCount("Bin Count");
+const QString BinStepSize("Bin Step Size");
+const QString BoundaryArea("BoundaryArea");
+const QString BoundaryStatsData("BoundaryStatsData");
+const QString CellNeighbors("CellNeighbors");
+
+const QString CellsContainingVert("CellsContainingVert");
+const QString CellsName("Cells");
+const QString CrystalStructure("CrystalStructure");
+const QString DataContainerGroupName("DataContainers");
+const QString DataContainerBundleGroupName("DataContainerBundles");
+const QString DataContainerNames("DataContainerNames");
+const QString MetaDataArrays("MetaDataArrays");
+const QString DataContainerType("DataContainerType");
+const QString AttributeMatrixType("AttributeMatrixType");
+
+const QString Dims("Dims");
+const QString DistributionType("Distribution Type");
+
+const QString EdgeNeighbors("EdgeNeighbors");
+const QString EdgesContainingVert("EdgesContainingVert");
+const QString EdgesName("Edges");
+const QString EdgeCentroids("EdgeCentroids");
+const QString EdgeLengths("EdgeLengths");
+const QString Euler1("Euler 1");
+const QString Euler2("Euler 2");
+const QString Euler3("Euler 3");
+const QString Exp_k("K");
+
+const QString FaceNeighbors("FaceNeighbors");
+const QString FacesContainingVert("FacesContainingVert");
+const QString FacesName("Faces");
+const QString TrianglesName("Triangles");
+const QString TriangleNeighbors("TriangleNeighbors");
+const QString TrianglesContainingVert("TrianglesContainingVert");
+const QString TriangleCentroids("TriangleCentroids");
+const QString TriangleAreas("TriangleAreas");
+const QString Frequencies("Frequencies");
+
+const QString QuadsName("Quadrilaterals");
+const QString QuadNeighbors("QuadrilateralNeighbors");
+const QString QuadsContainingVert("QuadrilateralsContainingVerts");
+const QString QuadCentroids("QuadrilateralCentroids");
+const QString QuadAreas("QuadrilateralAreas");
+
+const QString TetsName("Tetrahedra");
+const QString TetNeighbors("TetrahedralNeighbors");
+const QString TetsContainingVert("TetrahedraContainingVerts");
+const QString TetCentroids("TetrahedralCentroids");
+const QString TetVolumes("TetrahedralVolumes");
+
+const QString VoxelSizes("VoxelSizes");
+const QString VertexSizes("VertexSizes");
+
+const QString GBCD("GBCD");
+const QString FeatureAvgDisorientation("FeatureAvgDisorientation");
+const QString Feature_Diameter_Info("Feature_Diameter_Info");
+const QString Feature_SizeVBoverA_Distributions("FeatureSize Vs B Over A Distributions");
+const QString Feature_SizeVCoverA_Distributions("FeatureSize Vs C Over A Distributions");
+const QString Feature_SizeVNeighbors_Distributions("FeatureSize Vs Neighbors Distributions");
+const QString Feature_SizeVOmega3_Distributions("FeatureSize Vs Omega3 Distributions");
+const QString Feature_SizeVClustering_Distributions("FeatureSize Vs Clustering Distributions");
+const QString Feature_Size_Distribution("FeatureSize Distribution");
+const QString KernelAvgDisorientation("KernelAvgDisorientation");
+const QString LogNormalDistribution("Log Normal Distribution");
+const QString MDFWeights("MDF-Weights");
+const QString MatrixStatsData("MatrixStatsData");
+const QString MeshFaceNeighborLists("MeshFaceNeighborLists");
+const QString MicroTextureBins("MicroTextureBins");
+const QString MinimumValue("Minimum Value");
+const QString MinMaxNoOfBins("MinMaxNoOfBins");
+const QString MisorientationBins("MisorientationBins");
+const QString Neighbor_Feature_ID_List("Neighbor_Feature_ID_List");
+
+const QString ODF("ODF");
+const QString ODFWeights("ODF-Weights");
+
+const QString ParentPhase("Parent Phase");
+const QString PhaseFraction("PhaseFraction");
+const QString PhaseType("PhaseType");
+const QString PipelineGroupName("Pipeline");
+const QString PipelineVersionName("Pipeline Version");
+const QString PipelineCurrentName("Current Pipeline");
+const QString PowerLawDistribution("Power Law Distribution");
+const QString PrecipitateBoundaryFraction("Precipitate Boundary Fraction");
+const QString PrecipitateStatsData("PrecipitateStatsData");
+const QString PrimaryStatsData("PrimaryStatsData");
+const QString PresetName("PresetName");
+
+const QString RadialDistFunc("Radial Distribution Function");
+const QString RdfMinDistance("Min");
+const QString RdfMaxDistance("Max");
+const QString RdfBoxDims("BoxDims");
+const QString RdfBoxRes("BoxRes");
+
+const QString Sigma("Sigma");
+const QString StandardDeviation("Standard Deviation");
+const QString Statistics("Statistics");
+const QString Stats("Stats");
+const QString StatsData("StatsData");
+const QString StatsType("StatsType");
+
+const QString TransformationStatsData("TransformationStatsData");
+const QString UnknownDistribution("Unknown Distribution");
+
+const QString VerticesName("Vertices");
+const QString VertsName("Verts");
+const QString ImageName("Image");
+
+const QString Weight("Weight");
+
+const QString MetaData("_META_DATA");
+
+const QString Name("Name");
+const QString Index("Index");
+}
+
+namespace CellType
+{
+const QString Quadrilateral("Quadrilateral");
+const QString Tetrahedron("Tetrahedron");
+const QString Triangle("Triangle");
+const QString Face("Face");
+const QString Edge("Edge");
+const QString Vertex("Vertex");
+const QString Node("Node");
+}
+
+// namespace PhaseType
+//{
+//  //const unsigned int PrimaryPhase = 0;              //!<
+//  //const unsigned int PrecipitatePhase = 1;          //!<
+//  //const unsigned int TransformationPhase = 2;       //!<
+//  //const unsigned int MatrixPhase = 3;              //!<
+//  //const unsigned int BoundaryPhase = 4;              //!<
+//  //const unsigned int Unknown = 999;    //!<
+
+//  const QString Primary("Primary");
+//  const QString Precipitate("Precipitate");
+//  const QString Transformation("Transformation");
+//  const QString Matrix("Matrix");
+//  const QString Boundary("Boundary");
+//  const QString UnknownPhase("Unknown");
+//}
+
+namespace AlignmentMethod
+{
+const unsigned int OuterBoundary = 0;            //!<
+const unsigned int Misorientation = 1;           //!<
+const unsigned int MutualInformation = 2;        //!<
+const unsigned int Count = 3;                    //!<
+const unsigned int UnknownAlignmentMethod = 999; //!<
+}
+
+namespace StatisticsType
+{
+const unsigned int Feature_SizeVBoverA = 0;      //!<
+const unsigned int Feature_SizeVCoverA = 1;      //!<
+const unsigned int Feature_SizeVNeighbors = 2;   //!<
+const unsigned int Feature_SizeVOmega3 = 3;      //!<
+const unsigned int Feature_SizeVClustering = 4;  //!<
+const unsigned int UnknownStatisticsGroup = 999; //!<
+}
+
+namespace DistributionType
+{
+const unsigned int Beta = 0;                    //!<
+const unsigned int LogNormal = 1;               //!<
+const unsigned int Power = 2;                   //!<
+const unsigned int RDFFrequency = 3;            //!<
+const unsigned int RDFMaxMin = 4;               //!<
+const unsigned int UnknownDistributionType = 5; //!<
+const unsigned int Count = 6;                   //!<
+
+enum ColumnCount
+{
+  BetaColumnCount = 2,        //!<
+  LogNormalColumnCount = 2,   //!<
+  PowerLawColumnCount = 2,    //!<
+  RawDistDataColumnCount = 1, //!<
+  UnknownColumCount = 0       //!<
+};
+}
+
+namespace EulerAngleConversionType
+{
+const unsigned int DegreesToRadians = 0; //!<
+const unsigned int RadiansToDegrees = 1; //!<
+}
+
+namespace FlattenImageMethod
+{
+const unsigned int Lightness = 0;  //!<
+const unsigned int Average = 1;    //!<
+const unsigned int Luminosity = 2; //!<
+}
+
+namespace EulerFrameRotationAxis
+{
+const unsigned int RD = 0;   //!<
+const unsigned int TD = 1;   //!<
+const unsigned int ND = 2;   //!<
+const unsigned int None = 3; //!<
+}
+
+namespace SampleFrameRotationAxis
+{
+const unsigned int X = 0;    //!<
+const unsigned int Y = 1;    //!<
+const unsigned int Z = 2;    //!<
+const unsigned int None = 3; //!<
+}
+
+namespace RefFrameRotationAngle
+{
+const unsigned int Ninety = 0;     //!<
+const unsigned int oneEighty = 1;  //!<
+const unsigned int twoSeventy = 2; //!<
+const unsigned int Mirror = 3;     //!<
+const unsigned int Zero = 4;       //!<
+}
+
+namespace Overlap
+{
+const unsigned int Rigid = 0;            //!<
+const unsigned int Progressive = 1;      //!<
+const unsigned int UnknownOverlap = 999; //!<
+}
 
 //  namespace DataContainerType
 //  {
@@ -817,49 +809,48 @@ namespace SIMPL
 //    const unsigned int Any = 3;
 //  }
 
-  namespace Geometry
-  {
-    const QString Geometry("_SIMPL_GEOMETRY");
-    const QString GeometryName("GeometryName");
-    const QString GeometryType("GeometryType");
-    const QString GeometryTypeName("GeometryTypeName");
-    const QString NumberOfTuples("NumberOfTuples");
-    const QString UnitDimensionality("UnitDimensionality");
-    const QString SpatialDimensionality("SpatialDimensionality");
+namespace Geometry
+{
+const QString Geometry("_SIMPL_GEOMETRY");
+const QString GeometryName("GeometryName");
+const QString GeometryType("GeometryType");
+const QString GeometryTypeName("GeometryTypeName");
+const QString NumberOfTuples("NumberOfTuples");
+const QString UnitDimensionality("UnitDimensionality");
+const QString SpatialDimensionality("SpatialDimensionality");
 
-    const QString AnyGeometry("AnyGeometry");
-    const QString UnknownGeometry("UnkownGeometry");
-    const QString ImageGeometry("ImageGeometry");
-    const QString RectGridGeometry("RectGridGeometry");
-    const QString VertexGeometry("VertexGeometry");
-    const QString EdgeGeometry("EdgeGeometry");
-    const QString TriangleGeometry("TriangleGeometry");
-    const QString QuadGeometry("QuadrilateralGeometry");
-    const QString TetrahedralGeometry("TetrahedralGeometry");
+const QString AnyGeometry("AnyGeometry");
+const QString UnknownGeometry("UnkownGeometry");
+const QString ImageGeometry("ImageGeometry");
+const QString RectGridGeometry("RectGridGeometry");
+const QString VertexGeometry("VertexGeometry");
+const QString EdgeGeometry("EdgeGeometry");
+const QString TriangleGeometry("TriangleGeometry");
+const QString QuadGeometry("QuadrilateralGeometry");
+const QString TetrahedralGeometry("TetrahedralGeometry");
 
-    const QString xBoundsList("xBounds");
-    const QString yBoundsList("yBounds");
-    const QString zBoundsList("zBounds");
-    const QString SharedVertexList("SharedVertexList");
-    const QString SharedEdgeList("SharedEdgeList");
-    const QString SharedTriList("SharedTriList");
-    const QString SharedQuadList("SharedQuadList");
-    const QString SharedTetList("SharedTetList");
-    const QString UnsharedEdgeList("UnsharedEdgeList");
-    const QString UnsharedFaceList("UnsharedFaceList");
+const QString xBoundsList("xBounds");
+const QString yBoundsList("yBounds");
+const QString zBoundsList("zBounds");
+const QString SharedVertexList("SharedVertexList");
+const QString SharedEdgeList("SharedEdgeList");
+const QString SharedTriList("SharedTriList");
+const QString SharedQuadList("SharedQuadList");
+const QString SharedTetList("SharedTetList");
+const QString UnsharedEdgeList("UnsharedEdgeList");
+const QString UnsharedFaceList("UnsharedFaceList");
 
-    const QString TransformContainerGroup("TransformContainerGroup");
-    const QString TransformContainer("TransformContainer");
-    const QString CompositeTransformContainer("CompositeTransformContainer");
-    const QString TransformContainerTypeName("TransformContainerTypeName");
-    const QString UnknownTransformContainer("UnknownTransformContainer");
-    const QString TransformContainerParameters("TransformParameters");
-    const QString TransformContainerFixedParameters("TransformFixedParameters");
-    const QString TransformContainerTypeAsString("TransformType");
-    const QString TransformContainerMovingName("TransformMovingName");
-    const QString TransformContainerReferenceName("TransformReferenceName");
-
-  }
+const QString TransformContainerGroup("TransformContainerGroup");
+const QString TransformContainer("TransformContainer");
+const QString CompositeTransformContainer("CompositeTransformContainer");
+const QString TransformContainerTypeName("TransformContainerTypeName");
+const QString UnknownTransformContainer("UnknownTransformContainer");
+const QString TransformContainerParameters("TransformParameters");
+const QString TransformContainerFixedParameters("TransformFixedParameters");
+const QString TransformContainerTypeAsString("TransformType");
+const QString TransformContainerMovingName("TransformMovingName");
+const QString TransformContainerReferenceName("TransformReferenceName");
+}
 
 //  namespace GeometryType
 //  {
@@ -873,151 +864,148 @@ namespace SIMPL
 //    const unsigned int UnknownGeometry = 999;
 //  }
 
-  namespace XdmfGridType
-  {
-    const unsigned int PolyData = 0;
-    const unsigned int RectilinearGrid = 1;
-    const unsigned int UnknownGrid = 0xFFFFFFFF;
-  }
+namespace XdmfGridType
+{
+const unsigned int PolyData = 0;
+const unsigned int RectilinearGrid = 1;
+const unsigned int UnknownGrid = 0xFFFFFFFF;
+}
 
-  namespace XdmfCenterType
-  {
-    const QString Node("Node");
-    const QString Edge("Edge");
-    const QString Face("Face");
-    const QString Cell("Cell");
-    const QString Grid("Grid");
-  }
+namespace XdmfCenterType
+{
+const QString Node("Node");
+const QString Edge("Edge");
+const QString Face("Face");
+const QString Cell("Cell");
+const QString Grid("Grid");
+}
 
-  //namespace ShapeType
-  //{
-  //  const unsigned int EllipsoidShape = 0; //!<
-  //  const unsigned int SuperEllipsoidShape = 1; //!<
-  //  const unsigned int CubeOctahedronShape = 2; //!<
-  //  const unsigned int CylinderAShape = 3; //!<
-  //  const unsigned int CylinderBShape = 4; //!<
-  //  const unsigned int CylinderCShape = 5; //!<
-  //  const unsigned int ShapeTypeEnd = 6;
-  //  const unsigned int UnknownShapeType = 999; //!<
-  //}
+// namespace ShapeType
+//{
+//  const unsigned int EllipsoidShape = 0; //!<
+//  const unsigned int SuperEllipsoidShape = 1; //!<
+//  const unsigned int CubeOctahedronShape = 2; //!<
+//  const unsigned int CylinderAShape = 3; //!<
+//  const unsigned int CylinderBShape = 4; //!<
+//  const unsigned int CylinderCShape = 5; //!<
+//  const unsigned int ShapeTypeEnd = 6;
+//  const unsigned int UnknownShapeType = 999; //!<
+//}
 
-  enum class Precipitates : unsigned int
-  {
-    NoPrecipitates = 0, //!<
-    BoundaryPrecipitates = 1, //!<
-    BulkPrecipitates = 2, //!<
-    UnknownPrecipitates = 999 //!<
-  };
+enum class Precipitates : unsigned int
+{
+  NoPrecipitates = 0,       //!<
+  BoundaryPrecipitates = 1, //!<
+  BulkPrecipitates = 2,     //!<
+  UnknownPrecipitates = 999 //!<
+};
 
-  namespace Reconstruction
-  {
-    /*    Reconstruction related */
-    const QString H5VoxelFile("VoxelData.h5voxel");
+namespace Reconstruction
+{
+/*    Reconstruction related */
+const QString H5VoxelFile("VoxelData.h5voxel");
 
-    const QString VisualizationVizFile("Visualization.vtk");//11
-    const QString DownSampledVizFile("DownSampled_Visualization.vtk");//11
-    const QString HDF5FeatureFile("Features.h5feature");
-  }
+const QString VisualizationVizFile("Visualization.vtk");           // 11
+const QString DownSampledVizFile("DownSampled_Visualization.vtk"); // 11
+const QString HDF5FeatureFile("Features.h5feature");
+}
 
-  namespace SyntheticBuilder
-  {
-    const QString FeatureDataFile("FeatureData.csv");
-    const QString H5VoxelFile("VoxelData.h5voxel");
+namespace SyntheticBuilder
+{
+const QString FeatureDataFile("FeatureData.csv");
+const QString H5VoxelFile("VoxelData.h5voxel");
 
-    const QString VisualizationVizFile("Visualization.vtk");
-    const QString HDF5FeatureFile("Features.h5feature");
+const QString VisualizationVizFile("Visualization.vtk");
+const QString HDF5FeatureFile("Features.h5feature");
 
-    const QString ErrorFile("Error.txt");
-    const QString VtkFile("Test.vtk");
-  }
+const QString ErrorFile("Error.txt");
+const QString VtkFile("Test.vtk");
+}
 
-  /*   Surface Meshing Related   */
-  namespace SurfaceMesh
-  {
-    namespace NodeType
-    {
-      const signed char Unused = 0;
-      const signed char Default = 2;
-      const signed char TriplePoint = 3;
-      const signed char QuadPoint = 4;
-      const signed char SurfaceDefault = 12;
-      const signed char SurfaceTriplePoint = 13;
-      const signed char SurfaceQuadPoint = 14;
-    }
-    namespace NodeId
-    {
-      const signed char Unused = -1;
-    }
-  }
+/*   Surface Meshing Related   */
+namespace SurfaceMesh
+{
+namespace NodeType
+{
+const signed char Unused = 0;
+const signed char Default = 2;
+const signed char TriplePoint = 3;
+const signed char QuadPoint = 4;
+const signed char SurfaceDefault = 12;
+const signed char SurfaceTriplePoint = 13;
+const signed char SurfaceQuadPoint = 14;
+}
+namespace NodeId
+{
+const signed char Unused = -1;
+}
+}
 
-  namespace SolidMeshing
-  {
-    /* Solid Meshing Related */
-    const QString MeshFile("solid_mesh_v5_1.vtk");
-    const QString MeshFile2("solid_mesh_v5_2.vtk");
-    const QString ElementQualityFile("element_quality_measures_v5.txt");
-    const QString VoxelsFile("voxels_v5.txt");
-  }
+namespace SolidMeshing
+{
+/* Solid Meshing Related */
+const QString MeshFile("solid_mesh_v5_1.vtk");
+const QString MeshFile2("solid_mesh_v5_2.vtk");
+const QString ElementQualityFile("element_quality_measures_v5.txt");
+const QString VoxelsFile("voxels_v5.txt");
+}
 
-  namespace Union
-  {
-    namespace Strings
-    {
-      const QString And("And");
-      const QString Or("Or");
-    }
-    enum Enumeration
-    {
-      Operator_And = 0,
-      Operator_Or,
-      Operator_Unknown
-    };
-  }
+namespace Union
+{
+namespace Strings
+{
+const QString And("And");
+const QString Or("Or");
+}
+enum Enumeration
+{
+  Operator_And = 0,
+  Operator_Or,
+  Operator_Unknown
+};
+}
 
-  namespace Comparison
-  {
-    namespace Strings
-    {
-      const QString LessThan("<");
-      const QString GreaterThan(">");
-      const QString Equal("=");
-      const QString NotEqual("!=");
-    }
-    enum Enumeration
-    {
-      Operator_LessThan = 0,
-      Operator_GreaterThan,
-      Operator_Equal,
-      Operator_NotEqual,
-      Operator_Unknown
-    };
+namespace Comparison
+{
+namespace Strings
+{
+const QString LessThan("<");
+const QString GreaterThan(">");
+const QString Equal("=");
+const QString NotEqual("!=");
+}
+enum Enumeration
+{
+  Operator_LessThan = 0,
+  Operator_GreaterThan,
+  Operator_Equal,
+  Operator_NotEqual,
+  Operator_Unknown
+};
+}
 
-  }
-
-  namespace Layout
-  {
-    const signed int Horizontal = 0;
-    const signed int Vertical = 1;
-    const signed int Square = 2;
-  };
-
+namespace Layout
+{
+const signed int Horizontal = 0;
+const signed int Vertical = 1;
+const signed int Square = 2;
+};
 }
 
 namespace Core
 {
-  const QString CoreBaseName("Core");
+const QString CoreBaseName("Core");
 }
 
 namespace Test
 {
-  const QString TestPluginFile("TestPlugin");
-  const QString TestPluginDisplayName("Test Plugin");
-  const QString TestBaseName("Test");
+const QString TestPluginFile("TestPlugin");
+const QString TestPluginDisplayName("Test Plugin");
+const QString TestBaseName("Test");
 }
 
 Q_DECLARE_METATYPE(SIMPL::NumericTypes::Type)
 Q_DECLARE_METATYPE(SIMPL::ScalarTypes::Type)
-
 
 #if 0
 namespace Generic
@@ -1036,4 +1024,3 @@ namespace IO
 #endif
 
 #endif /* _SIMPLib_CONSTANTS_H_ */
-

--- a/Source/SIMPLib/CoreFilters/DataContainerReader.cpp
+++ b/Source/SIMPLib/CoreFilters/DataContainerReader.cpp
@@ -37,19 +37,19 @@
 
 #include <QtCore/QFileInfo>
 
-#include "H5Support/QH5Utilities.h"
 #include "H5Support/H5ScopedSentinel.h"
+#include "H5Support/QH5Utilities.h"
 
 #include "SIMPLib/Common/Constants.h"
-#include "SIMPLib/DataContainers/DataContainerBundle.h"
 #include "SIMPLib/DataContainers/DataContainer.h"
+#include "SIMPLib/DataContainers/DataContainerBundle.h"
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/BooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/DataContainerReaderFilterParameter.h"
 #include "SIMPLib/FilterParameters/H5FilterParametersReader.h"
 #include "SIMPLib/Filtering/FilterManager.h"
-#include "SIMPLib/Utilities/SIMPLH5DataReader.h"
 #include "SIMPLib/SIMPLibVersion.h"
+#include "SIMPLib/Utilities/SIMPLH5DataReader.h"
 #include "SIMPLib/Utilities/SIMPLH5DataReaderRequirements.h"
 
 // -----------------------------------------------------------------------------
@@ -63,7 +63,6 @@ DataContainerReader::DataContainerReader()
 , m_InputFileDataContainerArrayProxy()
 {
   m_PipelineFromFile = FilterPipeline::New();
-
 }
 
 // -----------------------------------------------------------------------------
@@ -71,7 +70,6 @@ DataContainerReader::DataContainerReader()
 // -----------------------------------------------------------------------------
 DataContainerReader::~DataContainerReader()
 {
-
 }
 
 // -----------------------------------------------------------------------------
@@ -121,9 +119,8 @@ void DataContainerReader::readFilterParameters(QJsonObject& obj)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataContainerReader::preWriteFilterParameters(QJsonObject &obj, QJsonObject &rootObject)
+void DataContainerReader::preWriteFilterParameters(QJsonObject& obj, QJsonObject& rootObject)
 {
-
 }
 
 // -----------------------------------------------------------------------------
@@ -131,7 +128,7 @@ void DataContainerReader::preWriteFilterParameters(QJsonObject &obj, QJsonObject
 // -----------------------------------------------------------------------------
 void DataContainerReader::writeFilterParameters(QJsonObject& obj)
 {
-  //writeExistingPipelineToFile(obj);
+  // writeExistingPipelineToFile(obj);
   AbstractFilter::writeFilterParameters(obj);
 }
 
@@ -151,7 +148,7 @@ void DataContainerReader::dataCheck()
   QFileInfo fi(getInputFile());
   if(getInputFile() == getLastFileRead() && getLastRead() < fi.lastModified())
   {
-    if (syncProxies() == false)
+    if(syncProxies() == false)
     {
       return;
     }
@@ -176,15 +173,18 @@ void DataContainerReader::dataCheck()
     // something has gone wrong and errors were logged already so just return
     return;
   }
-  
 
-  
   DataContainerArray::Pointer dca = getDataContainerArray();
 
   // Read either the structure or all the data depending on the preflight status
   DataContainerArray::Pointer tempDCA = readData(m_InputFileDataContainerArrayProxy);
+  if(!tempDCA.get())
+  {
+    return;
+  }
 
   QList<DataContainer::Pointer>& tempContainers = tempDCA->getDataContainers();
+
   QListIterator<DataContainer::Pointer> iter(tempContainers);
   while(iter.hasNext())
   {
@@ -258,18 +258,18 @@ DataContainerArray::Pointer DataContainerReader::readData(DataContainerArrayProx
   setWarningCondition(0);
 
   SIMPLH5DataReader::Pointer simplReader = SIMPLH5DataReader::New();
-  connect(simplReader.get(), &SIMPLH5DataReader::errorGenerated, [=] (const QString &title, const QString &msg, const int &code) {
+  connect(simplReader.get(), &SIMPLH5DataReader::errorGenerated, [=](const QString& title, const QString& msg, const int& code) {
     setErrorCondition(code);
     notifyErrorMessage(getHumanLabel(), msg, getErrorCondition());
   });
 
-  if (simplReader->openFile(getInputFile()) == false)
+  if(simplReader->openFile(getInputFile()) == false)
   {
     return DataContainerArray::NullPointer();
   }
 
   DataContainerArray::Pointer dca = simplReader->readSIMPLDataUsingProxy(proxy, getInPreflight());
-  if (dca == DataContainerArray::NullPointer())
+  if(dca == DataContainerArray::NullPointer())
   {
     return DataContainerArray::NullPointer();
   }
@@ -305,7 +305,7 @@ DataContainerArray::Pointer DataContainerReader::readData(DataContainerArrayProx
 DataContainerArrayProxy DataContainerReader::readDataContainerArrayStructure(const QString& path)
 {
   SIMPLH5DataReader::Pointer h5Reader = SIMPLH5DataReader::New();
-  if (h5Reader->openFile(path) == false)
+  if(h5Reader->openFile(path) == false)
   {
     return DataContainerArrayProxy();
   }
@@ -313,7 +313,7 @@ DataContainerArrayProxy DataContainerReader::readDataContainerArrayStructure(con
   int err = 0;
   SIMPLH5DataReaderRequirements req(SIMPL::Defaults::AnyPrimitive, SIMPL::Defaults::AnyComponentSize, AttributeMatrix::Type::Any, IGeometry::Type::Any);
   DataContainerArrayProxy proxy = h5Reader->readDataContainerArrayStructure(&req, err);
-  if (err < 0)
+  if(err < 0)
   {
     return DataContainerArrayProxy();
   }
@@ -421,12 +421,12 @@ bool DataContainerReader::syncProxies()
   SIMPLH5DataReaderRequirements req(SIMPL::Defaults::AnyPrimitive, SIMPL::Defaults::AnyComponentSize, AttributeMatrix::Type::Any, IGeometry::Type::Any);
 
   SIMPLH5DataReader::Pointer simplReader = SIMPLH5DataReader::New();
-  connect(simplReader.get(), &SIMPLH5DataReader::errorGenerated, [=] (const QString &title, const QString &msg, const int &code) {
+  connect(simplReader.get(), &SIMPLH5DataReader::errorGenerated, [=](const QString& title, const QString& msg, const int& code) {
     setErrorCondition(code);
     notifyErrorMessage(getHumanLabel(), msg, getErrorCondition());
   });
 
-  if (simplReader->openFile(getInputFile()) == false)
+  if(simplReader->openFile(getInputFile()) == false)
   {
     return false;
   }
@@ -436,7 +436,7 @@ bool DataContainerReader::syncProxies()
   {
     int err = 0;
     DataContainerArrayProxy fileProxy = simplReader->readDataContainerArrayStructure(&req, err);
-    if (err < 0)
+    if(err < 0)
     {
       return false;
     }
@@ -451,7 +451,7 @@ bool DataContainerReader::syncProxies()
   {
     int err = 0;
     DataContainerArrayProxy fileProxy = simplReader->readDataContainerArrayStructure(&req, err);
-    if (err < 0)
+    if(err < 0)
     {
       return false;
     }

--- a/Source/SIMPLib/DataContainers/DataContainer.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainer.cpp
@@ -43,6 +43,7 @@
 #include "SIMPLib/DataContainers/DataContainerProxy.h"
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/Geometry/EdgeGeom.h"
+#include "SIMPLib/Geometry/IGeometry.h"
 #include "SIMPLib/Geometry/ImageGeom.h"
 #include "SIMPLib/Geometry/QuadGeom.h"
 #include "SIMPLib/Geometry/RectGridGeom.h"
@@ -51,9 +52,8 @@
 #include "SIMPLib/Geometry/VertexGeom.h"
 #include "SIMPLib/Utilities/SIMPLH5DataReaderRequirements.h"
 
-#include "H5Support/QH5Utilities.h"
 #include "H5Support/H5ScopedSentinel.h"
-
+#include "H5Support/QH5Utilities.h"
 
 // -----------------------------------------------------------------------------
 //
@@ -89,7 +89,7 @@ DataContainer::Pointer DataContainer::createNewDataContainer(const QString& name
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataContainer::ReadDataContainerStructure(hid_t dcArrayGroupId, DataContainerArrayProxy& proxy, SIMPLH5DataReaderRequirements *req, const QString &h5InternalPath)
+void DataContainer::ReadDataContainerStructure(hid_t dcArrayGroupId, DataContainerArrayProxy& proxy, SIMPLH5DataReaderRequirements* req, const QString& h5InternalPath)
 {
   QList<QString> dataContainers;
   QH5Utilities::getGroupObjects(dcArrayGroupId, H5Utilities::H5Support_GROUP, dataContainers);
@@ -112,15 +112,14 @@ void DataContainer::ReadDataContainerStructure(hid_t dcArrayGroupId, DataContain
 
     int32_t geometryType;
     herr_t err = QH5Lite::readScalarAttribute(containerGid, SIMPL::Geometry::Geometry, SIMPL::Geometry::GeometryType, geometryType);
-    if (err >= 0)
+    if(err >= 0)
     {
       dcProxy.dcType = static_cast<unsigned int>(geometryType);
-      if (req != nullptr)
+      if(req != nullptr)
       {
         IGeometry::Types geomTypes = req->getDCGeometryTypes();
         if(geomTypes.empty() || geomTypes.contains(static_cast<IGeometry::Type>(geometryType)))
         {
-
         }
 
         dcProxy.flag = Qt::Checked;
@@ -380,7 +379,7 @@ int DataContainer::readAttributeMatricesFromHDF5(bool preflight, hid_t dcGid, co
     err = QH5Lite::readScalarAttribute(dcGid, amName, SIMPL::StringConstants::AttributeMatrixType, amTypeTmp);
     if(err < 0)
     {
-        return -1;
+      return -1;
     }
 
     err = QH5Lite::readVectorAttribute(dcGid, amName, SIMPL::HDF5::TupleDimensions, tDims);
@@ -397,7 +396,7 @@ int DataContainer::readAttributeMatricesFromHDF5(bool preflight, hid_t dcGid, co
 
     if(getAttributeMatrix(amName) == nullptr)
     {
-        amType = static_cast<AttributeMatrix::Type>(amTypeTmp);
+      amType = static_cast<AttributeMatrix::Type>(amTypeTmp);
       AttributeMatrix::Pointer am = AttributeMatrix::New(tDims, amName, amType);
       addAttributeMatrix(amName, am);
     }
@@ -461,7 +460,7 @@ int DataContainer::writeMeshToHDF5(hid_t dcGid, bool writeXdmf)
 
   if(nullptr == m_Geometry.get())
   {
-    err = QH5Lite::writeScalarAttribute(dcGid, SIMPL::Geometry::Geometry, SIMPL::Geometry::GeometryType,  static_cast<AttributeMatrix::EnumType>(IGeometry::Type::Unknown));
+    err = QH5Lite::writeScalarAttribute(dcGid, SIMPL::Geometry::Geometry, SIMPL::Geometry::GeometryType, static_cast<AttributeMatrix::EnumType>(IGeometry::Type::Unknown));
     if(err < 0)
     {
       return err;
@@ -495,6 +494,11 @@ int DataContainer::writeMeshToHDF5(hid_t dcGid, bool writeXdmf)
       return err;
     }
     err = QH5Lite::writeScalarAttribute(dcGid, SIMPL::Geometry::Geometry, SIMPL::Geometry::SpatialDimensionality, m_Geometry->getSpatialDimensionality());
+    if(err < 0)
+    {
+      return err;
+    }
+    err = m_Geometry->IGeometry::writeGeometryToHDF5(geometryId, writeXdmf);
     if(err < 0)
     {
       return err;
@@ -768,6 +772,11 @@ int DataContainer::readMeshDataFromHDF5(hid_t dcGid, bool preflight)
     else
     {
       setGeometry(geomPtr);
+    }
+    // If no error in previous steps.
+    if(err >= 0)
+    {
+      err = m_Geometry->IGeometry::readGeometryFromHDF5(geometryId, preflight);
     }
   }
 

--- a/Source/SIMPLib/Geometry/CompositeTransformContainer.cpp
+++ b/Source/SIMPLib/Geometry/CompositeTransformContainer.cpp
@@ -1,0 +1,157 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "CompositeTransformContainer.h"
+
+#include "H5Support/H5Lite.h"
+#include "H5Support/H5ScopedSentinel.h"
+#include "H5Support/QH5Lite.h"
+#include "H5Support/QH5Utilities.h"
+#include "SIMPLib/Common/Constants.h"
+#include "SIMPLib/Geometry/TransformContainer.h"
+
+CompositeTransformContainer::CompositeTransformContainer() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+CompositeTransformContainer::~CompositeTransformContainer() = default;
+
+int CompositeTransformContainer::writeTransformContainerToHDF5(hid_t parentId, const std::string& transformContainerName)
+{
+  herr_t err = 0;
+
+  hid_t transformContainerId;
+  err = QH5Utilities::createGroupsFromPath(transformContainerName.c_str(), parentId);
+  if(err < 0)
+  {
+    return err;
+  }
+  transformContainerId = H5Gopen(parentId, transformContainerName.c_str(), H5P_DEFAULT);
+  if(transformContainerId < 0)
+  {
+    return -1;
+  }
+  H5ScopedGroupSentinel gSentinel(&transformContainerId, false);
+
+  err = QH5Lite::writeStringAttribute(parentId, transformContainerName.c_str(), SIMPL::Geometry::TransformContainerTypeName, SIMPL::Geometry::CompositeTransformContainer);
+  if(err < 0)
+  {
+    return err;
+  }
+
+  size_t position = 0;
+  for(auto transformContainer : m_TransformContainers)
+  {
+    QString childTransformContainerName = QString::number(position);
+    err = transformContainer->writeTransformContainerToHDF5(transformContainerId, childTransformContainerName.toLatin1().data());
+    if(err < 0)
+    {
+      return err;
+    }
+    position += 1;
+  }
+  return err;
+}
+
+int CompositeTransformContainer::readTransformContainerFromHDF5(hid_t parentId, bool metaDataOnly, const std::string& transformContainerName)
+{
+  herr_t err = 0;
+
+  hid_t transformContainerGrpId = H5Gopen(parentId, transformContainerName.c_str(), H5P_DEFAULT);
+  if(transformContainerGrpId < 0)
+  {
+    return -1;
+  }
+  H5ScopedGroupSentinel gSentinel(&transformContainerGrpId, false);
+
+  hsize_t idx = 0;
+  H5Gget_num_objs(transformContainerGrpId, &idx);
+  for(hsize_t i = 0; i < idx; i++)
+  {
+    QString childTransformContainerName = QString::number(i);
+    err = QH5Utilities::createGroupsFromPath(childTransformContainerName, transformContainerGrpId);
+    if(err < 0)
+    {
+      return err;
+    }
+    std::string transformContainerTypeName = SIMPL::Geometry::UnknownTransformContainer.toStdString();
+    err =
+        H5Lite::readStringAttribute(transformContainerGrpId, childTransformContainerName.toLatin1().data(), SIMPL::Geometry::TransformContainerTypeName.toLatin1().data(), transformContainerTypeName);
+    if(err < 0)
+    {
+      return err;
+    }
+
+    if(transformContainerTypeName.compare(SIMPL::Geometry::TransformContainer.toStdString()) == 0)
+    {
+      TransformContainer::Pointer transformContainer = TransformContainer::New();
+      err = transformContainer->readTransformContainerFromHDF5(transformContainerGrpId, metaDataOnly, childTransformContainerName.toLatin1().data());
+      if(err < 0)
+      {
+        return err;
+      }
+      this->addTransformContainer(transformContainer);
+    }
+    else if(transformContainerTypeName.compare(SIMPL::Geometry::CompositeTransformContainer.toStdString()) == 0)
+    {
+      CompositeTransformContainer::Pointer CompositeTransformContainer = CompositeTransformContainer::New();
+      err = CompositeTransformContainer->readTransformContainerFromHDF5(transformContainerGrpId, metaDataOnly, childTransformContainerName.toLatin1().data());
+      if(err < 0)
+      {
+        return err;
+      }
+      this->addTransformContainer(CompositeTransformContainer);
+    }
+    else // SIMPL::Geometry::UnknownTransformContainer
+    {
+      return -1;
+    }
+    return 0;
+  }
+  return err;
+}
+
+CompositeTransformContainer& CompositeTransformContainer::operator=(const CompositeTransformContainer& old)
+{
+  if(this != &old)
+  {
+    this->m_TransformContainers = old.m_TransformContainers;
+  }
+  return *this;
+}
+
+void CompositeTransformContainer::addTransformContainer(ITransformContainer::Pointer transformContainer)
+{
+  this->m_TransformContainers.push_back(transformContainer);
+}

--- a/Source/SIMPLib/Geometry/CompositeTransformContainer.h
+++ b/Source/SIMPLib/Geometry/CompositeTransformContainer.h
@@ -1,0 +1,54 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "SIMPLib/Geometry/ITransformContainer.h"
+#include "SIMPLib/SIMPLib.h"
+
+#include "H5Support/H5Lite.h"
+
+class SIMPLib_EXPORT CompositeTransformContainer : public ITransformContainer
+{
+public:
+  SIMPL_SHARED_POINTERS(CompositeTransformContainer)
+  SIMPL_STATIC_NEW_MACRO(CompositeTransformContainer)
+  SIMPL_TYPE_MACRO_SUPER_OVERRIDE(CompositeTransformContainer, ITransformContainer)
+  CompositeTransformContainer();
+  virtual ~CompositeTransformContainer();
+  CompositeTransformContainer& operator=(const CompositeTransformContainer&);
+  int writeTransformContainerToHDF5(hid_t parentId, const std::string& transformContainerName) override;
+  int readTransformContainerFromHDF5(hid_t parentId, bool metaDataOnly, const std::string& transformContainerName) override;
+  SIMPL_INSTANCE_PROPERTY(std::vector<ITransformContainer::Pointer>, TransformContainers)
+  void addTransformContainer(ITransformContainer::Pointer transformContainer);
+};

--- a/Source/SIMPLib/Geometry/IGeometry.cpp
+++ b/Source/SIMPLib/Geometry/IGeometry.cpp
@@ -1,45 +1,49 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include "SIMPLib/Geometry/IGeometry.h"
+#include "H5Support/H5ScopedSentinel.h"
+#include "H5Support/QH5Utilities.h"
+#include "SIMPLib/Geometry/CompositeTransformContainer.h"
+#include "SIMPLib/Geometry/TransformContainer.h"
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IGeometry::IGeometry() :
-  m_TimeValue(0.0f)
+IGeometry::IGeometry()
+: m_TimeValue(0.0f)
 , m_EnableTimeSeries(false)
 {
 }
@@ -213,4 +217,60 @@ AttributeMatrix::Pointer IGeometry::removeAttributeMatrix(const QString& name)
   AttributeMatrix::Pointer p = it.value();
   m_AttributeMatrices.erase(it);
   return p;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+int IGeometry::writeGeometryToHDF5(hid_t parentId, bool SIMPL_NOT_USED(writeXdmf))
+{
+  herr_t err = 0;
+  if(m_TransformContainer)
+  {
+    const char* transformGroup = SIMPL::Geometry::TransformContainerGroup.toLatin1().data();
+    err = m_TransformContainer->writeTransformContainerToHDF5(parentId, transformGroup);
+  }
+
+  return err;
+}
+
+int IGeometry::readGeometryFromHDF5(hid_t parentId, bool preflight)
+{
+  herr_t err = 0;
+  std::string transformTypeName = SIMPL::Geometry::UnknownTransformContainer.toStdString();
+
+  QString transformName = QString::number(0).toLatin1().data();
+  err = H5Lite::readStringAttribute(parentId, transformName.toLatin1().data(), SIMPL::Geometry::TransformContainerTypeName.toLatin1().data(), transformTypeName);
+  // No transform information found.
+  if(err < 0)
+  {
+    return 0;
+  }
+
+  if(transformTypeName.compare(SIMPL::Geometry::TransformContainer.toStdString()) == 0)
+  {
+    TransformContainer::Pointer transformContainer = TransformContainer::New();
+    err = transformContainer->readTransformContainerFromHDF5(parentId, preflight, transformName.toLatin1().data());
+    if(err < 0)
+    {
+      return err;
+    }
+    setTransformContainer(transformContainer);
+  }
+  else if(transformTypeName.compare(SIMPL::Geometry::CompositeTransformContainer.toStdString()) == 0)
+  {
+    CompositeTransformContainer::Pointer compositeTransformContainer = CompositeTransformContainer::New();
+    err = compositeTransformContainer->readTransformContainerFromHDF5(parentId, preflight, transformName.toLatin1().data());
+    if(err < 0)
+    {
+      return err;
+    }
+    setTransformContainer(compositeTransformContainer);
+  }
+  else // SIMPL::Geometry::UnknownTransformContainer
+  {
+    return -1;
+  }
+
+  return err;
 }

--- a/Source/SIMPLib/Geometry/IGeometry.h
+++ b/Source/SIMPLib/Geometry/IGeometry.h
@@ -36,16 +36,17 @@
 #ifndef _igeometry_h_
 #define _igeometry_h_
 
-#include <QtCore/QString>
-#include <QtCore/QMap>
 #include <QMutex>
+#include <QtCore/QMap>
+#include <QtCore/QString>
 
-#include "SIMPLib/SIMPLib.h"
-#include "SIMPLib/Common/SIMPLibSetGetMacros.h"
 #include "SIMPLib/Common/Observable.h"
-#include "SIMPLib/DataArrays/DynamicListArray.hpp"
+#include "SIMPLib/Common/SIMPLibSetGetMacros.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
+#include "SIMPLib/DataArrays/DynamicListArray.hpp"
 #include "SIMPLib/DataContainers/AttributeMatrix.h"
+#include "SIMPLib/Geometry/ITransformContainer.h"
+#include "SIMPLib/SIMPLib.h"
 
 class QTextStream;
 
@@ -87,362 +88,361 @@ class SIMPLib_EXPORT IGeometry : public Observable
   PYB11_METHOD(AttributeMatrix getAttributeMatrix ARGS Name)
   PYB11_METHOD(AttributeMatrix removeAttributeMatrix ARGS Name)
 
-  public:
-    SIMPL_SHARED_POINTERS(IGeometry)
-    SIMPL_TYPE_MACRO_SUPER_OVERRIDE(IGeometry, Observable)
+public:
+  SIMPL_SHARED_POINTERS(IGeometry)
+  SIMPL_TYPE_MACRO_SUPER_OVERRIDE(IGeometry, Observable)
 
-    IGeometry();
-    virtual ~IGeometry();
+  IGeometry();
+  virtual ~IGeometry();
 
-    using EnumType = unsigned int;
+  using EnumType = unsigned int;
 
-    /**
-     * @brief The VtkCellType enum
-     */
-    enum class VtkCellType : EnumType
-    {
-       Image = 11,
-       RectGrid = 11,
-       Vertex = 1,
-       Edge = 3,
-       Triangle = 5,
-       Quad = 9,
-       Tetrahedral = 10,
-       Unknown = 999,
-       Any = 4294967295U
-    };
+  /**
+   * @brief The VtkCellType enum
+   */
+  enum class VtkCellType : EnumType
+  {
+    Image = 11,
+    RectGrid = 11,
+    Vertex = 1,
+    Edge = 3,
+    Triangle = 5,
+    Quad = 9,
+    Tetrahedral = 10,
+    Unknown = 999,
+    Any = 4294967295U
+  };
 
-    /**
-     * @ brief The Type enum
-     */
-    enum class Type : EnumType
-    {
-      Image,
-      RectGrid,
-      Vertex,
-      Edge,
-      Triangle,
-      Quad,
-      Tetrahedral,
-      Unknown = 999,
-      Any = 4294967295U
-    };
+  /**
+   * @ brief The Type enum
+   */
+  enum class Type : EnumType
+  {
+    Image,
+    RectGrid,
+    Vertex,
+    Edge,
+    Triangle,
+    Quad,
+    Tetrahedral,
+    Unknown = 999,
+    Any = 4294967295U
+  };
 
-    using VtkCellTypes = QVector <VtkCellType>;
-    using Types = QVector<Type>;
+  using VtkCellTypes = QVector<VtkCellType>;
+  using Types = QVector<Type>;
 
-    /**
-     * @brief AttributeMatrixMap_t
-     */
-    typedef QMap<QString, AttributeMatrix::Pointer> AttributeMatrixMap_t;
+  /**
+   * @brief AttributeMatrixMap_t
+   */
+  typedef QMap<QString, AttributeMatrix::Pointer> AttributeMatrixMap_t;
 
+  SIMPL_INSTANCE_PROPERTY(float, TimeValue)
+  SIMPL_INSTANCE_PROPERTY(bool, EnableTimeSeries)
+  SIMPL_INSTANCE_PROPERTY(ITransformContainer::Pointer, TransformContainer)
 
-    SIMPL_INSTANCE_PROPERTY(float, TimeValue)
-    SIMPL_INSTANCE_PROPERTY(bool, EnableTimeSeries)
+  // -----------------------------------------------------------------------------
+  // Connectivity
+  // -----------------------------------------------------------------------------
 
-// -----------------------------------------------------------------------------
-// Connectivity
-// -----------------------------------------------------------------------------
+  /**
+   * @brief findElementsContainingVert
+   * @return
+   */
+  virtual int findElementsContainingVert() = 0;
 
-    /**
-     * @brief findElementsContainingVert
-     * @return
-     */
-    virtual int findElementsContainingVert() = 0;
+  /**
+   * @brief getElementsContainingVert
+   * @return
+   */
+  virtual ElementDynamicList::Pointer getElementsContainingVert() = 0;
 
-    /**
-     * @brief getElementsContainingVert
-     * @return
-     */
-    virtual ElementDynamicList::Pointer getElementsContainingVert() = 0;
+  /**
+   * @brief deleteElementsContainingVert
+   */
+  virtual void deleteElementsContainingVert() = 0;
 
-    /**
-     * @brief deleteElementsContainingVert
-     */
-    virtual void deleteElementsContainingVert() = 0;
+  /**
+   * @brief findElementNeighbors
+   * @return
+   */
+  virtual int findElementNeighbors() = 0;
 
-    /**
-     * @brief findElementNeighbors
-     * @return
-     */
-    virtual int findElementNeighbors() = 0;
+  /**
+   * @brief getElementNeighbors
+   * @return
+   */
+  virtual ElementDynamicList::Pointer getElementNeighbors() = 0;
 
-    /**
-     * @brief getElementNeighbors
-     * @return
-     */
-    virtual ElementDynamicList::Pointer getElementNeighbors() = 0;
+  /**
+   * @brief deleteElementNeighbors
+   */
+  virtual void deleteElementNeighbors() = 0;
 
-    /**
-     * @brief deleteElementNeighbors
-     */
-    virtual void deleteElementNeighbors() = 0;
+  // -----------------------------------------------------------------------------
+  // Topology
+  // -----------------------------------------------------------------------------
 
-// -----------------------------------------------------------------------------
-// Topology
-// -----------------------------------------------------------------------------
+  /**
+   * @brief getNumberOfElements
+   * @return
+   */
+  virtual size_t getNumberOfElements() = 0;
 
-    /**
-     * @brief getNumberOfElements
-     * @return
-     */
-    virtual size_t getNumberOfElements() = 0;
+  /**
+   * @brief findElementSizes
+   * @return
+   */
+  virtual int findElementSizes() = 0;
 
-    /**
-     * @brief findElementSizes
-     * @return
-     */
-    virtual int findElementSizes() = 0;
+  /**
+   * @brief getElementSizes
+   * @return
+   */
+  virtual FloatArrayType::Pointer getElementSizes() = 0;
 
-    /**
-     * @brief getElementSizes
-     * @return
-     */
-    virtual FloatArrayType::Pointer getElementSizes() = 0;
+  /**
+   * @brief deleteElementSizes
+   */
+  virtual void deleteElementSizes() = 0;
 
-    /**
-     * @brief deleteElementSizes
-     */
-    virtual void deleteElementSizes() = 0;
+  /**
+   * @brief findElementCentroids
+   * @return
+   */
+  virtual int findElementCentroids() = 0;
 
-    /**
-     * @brief findElementCentroids
-     * @return
-     */
-    virtual int findElementCentroids() = 0;
+  /**
+   * @brief getElementCentroids
+   * @return
+   */
+  virtual FloatArrayType::Pointer getElementCentroids() = 0;
 
-    /**
-     * @brief getElementCentroids
-     * @return
-     */
-    virtual FloatArrayType::Pointer getElementCentroids() = 0;
+  /**
+   * @brief deleteElementCentroids
+   */
+  virtual void deleteElementCentroids() = 0;
 
-    /**
-     * @brief deleteElementCentroids
-     */
-    virtual void deleteElementCentroids() = 0;
+  /**
+   * @brief getParametricCenter
+   * @param pCoords
+   */
+  virtual void getParametricCenter(double pCoords[3]) = 0;
 
-    /**
-     * @brief getParametricCenter
-     * @param pCoords
-     */
-    virtual void getParametricCenter(double pCoords[3]) = 0;
+  /**
+   * @brief getShapeFunctions
+   * @param pCoords
+   * @param derivs
+   */
+  virtual void getShapeFunctions(double pCoords[3], double* shape) = 0;
 
-    /**
-     * @brief getShapeFunctions
-     * @param pCoords
-     * @param derivs
-     */
-    virtual void getShapeFunctions(double pCoords[3], double* shape) = 0;
+  /**
+   * @brief findDerivatives
+   * @param field
+   * @param derivatives
+   */
+  virtual void findDerivatives(DoubleArrayType::Pointer field, DoubleArrayType::Pointer derivatives, Observable* observable) = 0;
 
-    /**
-     * @brief findDerivatives
-     * @param field
-     * @param derivatives
-     */
-    virtual void findDerivatives(DoubleArrayType::Pointer field, DoubleArrayType::Pointer derivatives, Observable* observable) = 0;
+  // -----------------------------------------------------------------------------
+  // Generic
+  // -----------------------------------------------------------------------------
 
-// -----------------------------------------------------------------------------
-// Generic
-// -----------------------------------------------------------------------------
+  /**
+   * @brief setName
+   * @param name
+   */
+  virtual void setName(const QString& name) final;
 
-    /**
-     * @brief setName
-     * @param name
-     */
-    virtual void setName(const QString& name) final;
+  /**
+   * @brief getName
+   * @return
+   */
+  virtual QString getName() final;
 
-    /**
-     * @brief getName
-     * @return
-     */
-    virtual QString getName() final;
+  /**
+   * @brief getGeometryType
+   * @return
+   */
+  virtual Type getGeometryType() final;
 
-    /**
-     * @brief getGeometryType
-     * @return
-     */
-    virtual Type getGeometryType() final;
+  /**
+   * @brief getGeometryTypeAsString
+   * @return
+   */
+  virtual QString getGeometryTypeAsString() final;
 
-    /**
-     * @brief getGeometryTypeAsString
-     * @return
-     */
-    virtual QString getGeometryTypeAsString() final;
+  /**
+   * @brief getInfoString
+   * @return Returns a formatted string that contains general infomation about
+   * the instance of the object.
+   */
+  virtual QString getInfoString(SIMPL::InfoStringFormat) = 0;
 
-    /**
-     * @brief getInfoString
-     * @return Returns a formatted string that contains general infomation about
-     * the instance of the object.
-     */
-    virtual QString getInfoString(SIMPL::InfoStringFormat) = 0;
+  /**
+   * @brief setMessagePrefix
+   * @param prefix
+   */
+  virtual void setMessagePrefix(const QString& prefix) final;
 
-    /**
-     * @brief setMessagePrefix
-     * @param prefix
-     */
-    virtual void setMessagePrefix(const QString& prefix) final;
+  /**
+   * @brief getMessagePrefix
+   * @return
+   */
+  virtual QString getMessagePrefix() final;
 
-    /**
-     * @brief getMessagePrefix
-     * @return
-     */
-    virtual QString getMessagePrefix() final;
+  /**
+   * @brief setMessageTitle
+   * @param title
+   */
+  virtual void setMessageTitle(const QString& title) final;
 
-    /**
-     * @brief setMessageTitle
-     * @param title
-     */
-    virtual void setMessageTitle(const QString& title) final;
+  /**
+   * @brief getMessageTitle
+   * @return
+   */
+  virtual QString getMessageTitle() final;
 
-    /**
-     * @brief getMessageTitle
-     * @return
-     */
-    virtual QString getMessageTitle() final;
+  /**
+   * @brief setMessageLabel
+   * @param label
+   */
+  virtual void setMessageLabel(const QString& label) final;
 
-    /**
-     * @brief setMessageLabel
-     * @param label
-     */
-    virtual void setMessageLabel(const QString& label) final;
+  /**
+   * @brief getMessageLabel
+   * @return
+   */
+  virtual QString getMessageLabel() final;
 
-    /**
-     * @brief getMessageLabel
-     * @return
-     */
-    virtual QString getMessageLabel() final;
+  /**
+   * @brief getXdmfGridType
+   * @return
+   */
+  virtual unsigned int getXdmfGridType() final;
 
-    /**
-     * @brief getXdmfGridType
-     * @return
-     */
-    virtual unsigned int getXdmfGridType() final;
+  /**
+   * @brief getUnitDimensionality
+   * @return
+   */
+  virtual unsigned int getUnitDimensionality() final;
 
-    /**
-     * @brief getUnitDimensionality
-     * @return
-     */
-    virtual unsigned int getUnitDimensionality() final;
+  /**
+   * @brief setSpatialDimensionality
+   * @param spatialDims
+   */
+  virtual void setSpatialDimensionality(unsigned int spatialDims) final;
 
-    /**
-     * @brief setSpatialDimensionality
-     * @param spatialDims
-     */
-    virtual void setSpatialDimensionality(unsigned int spatialDims) final;
+  /**
+   * @brief getSpatialDimensionality
+   * @return
+   */
+  virtual unsigned int getSpatialDimensionality() final;
 
-    /**
-     * @brief getSpatialDimensionality
-     * @return
-     */
-    virtual unsigned int getSpatialDimensionality() final;
+  /**
+   * @brief writeGeometryToHDF5
+   * @param parentId
+   * @param writeXdmf
+   * @return
+   */
+  virtual int writeGeometryToHDF5(hid_t parentId, bool writeXdmf) = 0;
 
-    /**
-     * @brief writeGeometryToHDF5
-     * @param parentId
-     * @param writeXdmf
-     * @return
-     */
-    virtual int writeGeometryToHDF5(hid_t parentId, bool writeXdmf) = 0;
+  /**
+   * @brief writeXdmf
+   * @param out
+   * @param dcName
+   * @param hdfFileName
+   * @return
+   */
+  virtual int writeXdmf(QTextStream& out, QString dcName, QString hdfFileName) = 0;
 
-    /**
-     * @brief writeXdmf
-     * @param out
-     * @param dcName
-     * @param hdfFileName
-     * @return
-     */
-    virtual int writeXdmf(QTextStream& out, QString dcName, QString hdfFileName) = 0;
+  /**
+   * @brief readGeometryFromHDF5
+   * @param parentId
+   * @param preflight
+   * @return
+   */
+  virtual int readGeometryFromHDF5(hid_t parentId, bool preflight) = 0;
 
-    /**
-     * @brief readGeometryFromHDF5
-     * @param parentId
-     * @param preflight
-     * @return
-     */
-    virtual int readGeometryFromHDF5(hid_t parentId, bool preflight) = 0;
+  /**
+   * @brief deepCopy
+   * @return
+   */
+  virtual Pointer deepCopy(bool forceNoAllocate = false) = 0;
 
-    /**
-     * @brief deepCopy
-     * @return
-     */
-    virtual Pointer deepCopy(bool forceNoAllocate = false) = 0;
+  /**
+   * @brief initializeWithZeros
+   */
+  virtual void initializeWithZeros() = 0;
 
-    /**
-     * @brief initializeWithZeros
-     */
-    virtual void initializeWithZeros() = 0;
+  /**
+   * @brief addAttributeMatrix
+   */
+  virtual void addAttributeMatrix(const QString& name, AttributeMatrix::Pointer data) = 0;
 
-    /**
-     * @brief addAttributeMatrix
-     */
-    virtual void addAttributeMatrix(const QString& name, AttributeMatrix::Pointer data) = 0;
+  /**
+   * @brief getAttributeMatrix
+   * @param name
+   * @return
+   */
+  virtual AttributeMatrix::Pointer getAttributeMatrix(const QString& name) final;
 
-    /**
-     * @brief getAttributeMatrix
-     * @param name
-     * @return
-     */
-    virtual AttributeMatrix::Pointer getAttributeMatrix(const QString& name) final;
+  /**
+   * @brief removeAttributeMatrix
+   * @param name
+   * @return
+   */
+  virtual AttributeMatrix::Pointer removeAttributeMatrix(const QString& name) final;
 
-    /**
-     * @brief removeAttributeMatrix
-     * @param name
-     * @return
-     */
-    virtual AttributeMatrix::Pointer removeAttributeMatrix(const QString& name) final;
+protected:
+  QString m_Name;
+  QString m_GeometryTypeName;
+  QString m_MessagePrefix;
+  QString m_MessageTitle;
+  QString m_MessageLabel;
+  Type m_GeometryType = Type::Unknown;
+  unsigned int m_XdmfGridType = SIMPL::XdmfGridType::UnknownGrid;
+  unsigned int m_UnitDimensionality = 0;
+  unsigned int m_SpatialDimensionality = 0;
 
-  protected:
-    QString m_Name;
-    QString m_GeometryTypeName;
-    QString m_MessagePrefix;
-    QString m_MessageTitle;
-    QString m_MessageLabel;
-    Type m_GeometryType = Type::Unknown;
-    unsigned int m_XdmfGridType = SIMPL::XdmfGridType::UnknownGrid;
-    unsigned int m_UnitDimensionality = 0;
-    unsigned int m_SpatialDimensionality = 0;
+  AttributeMatrixMap_t m_AttributeMatrices;
 
-    AttributeMatrixMap_t m_AttributeMatrices;
+  QMutex m_Mutex;
+  int64_t m_ProgressCounter;
 
-    QMutex m_Mutex;
-    int64_t m_ProgressCounter;
+  /**
+   * @brief sendThreadSafeProgressMessage
+   * @param counter
+   * @param max
+   */
+  virtual void sendThreadSafeProgressMessage(int64_t counter, int64_t max) final;
 
-    /**
-     * @brief sendThreadSafeProgressMessage
-     * @param counter
-     * @param max
-     */
-    virtual void sendThreadSafeProgressMessage(int64_t counter, int64_t max) final;
+  /**
+   * @brief setElementsContaingVert
+   * @param elementsContaingVert
+   */
+  virtual void setElementsContainingVert(ElementDynamicList::Pointer elementsContainingVert) = 0;
 
-    /**
-     * @brief setElementsContaingVert
-     * @param elementsContaingVert
-     */
-    virtual void setElementsContainingVert(ElementDynamicList::Pointer elementsContainingVert) = 0;
+  /**
+   * @brief setElementNeighbors
+   * @param elementNeighbors
+   */
+  virtual void setElementNeighbors(ElementDynamicList::Pointer elementsNeighbors) = 0;
 
-    /**
-     * @brief setElementNeighbors
-     * @param elementNeighbors
-     */
-    virtual void setElementNeighbors(ElementDynamicList::Pointer elementsNeighbors) = 0;
+  /**
+   * @brief setElementCentroids
+   * @param elementCentroids
+   */
+  virtual void setElementCentroids(FloatArrayType::Pointer elementCentroids) = 0;
 
-    /**
-     * @brief setElementCentroids
-     * @param elementCentroids
-     */
-    virtual void setElementCentroids(FloatArrayType::Pointer elementCentroids) = 0;
+  /**
+   * @brief setElementSizes
+   * @param elementSizes
+   */
+  virtual void setElementSizes(FloatArrayType::Pointer elementSizes) = 0;
 
-    /**
-     * @brief setElementSizes
-     * @param elementSizes
-     */
-    virtual void setElementSizes(FloatArrayType::Pointer elementSizes) = 0;
-
-  private:
-    IGeometry(const IGeometry&) = delete;      // Copy Constructor Not Implemented
-    void operator=(const IGeometry&) = delete; // Move assignment Not Implemented
+private:
+  IGeometry(const IGeometry&) = delete;      // Copy Constructor Not Implemented
+  void operator=(const IGeometry&) = delete; // Move assignment Not Implemented
 };
 
 #endif /* _IGeometry_H_ */
-

--- a/Source/SIMPLib/Geometry/ITransformContainer.h
+++ b/Source/SIMPLib/Geometry/ITransformContainer.h
@@ -1,0 +1,48 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+#pragma once
+
+#include "SIMPLib/Common/Observable.h"
+#include "SIMPLib/SIMPLib.h"
+
+#include "H5Support/H5Lite.h"
+
+class SIMPLib_EXPORT ITransformContainer : public Observable
+{
+public:
+  SIMPL_SHARED_POINTERS(ITransformContainer)
+  SIMPL_TYPE_MACRO_SUPER_OVERRIDE(ITransformContainer, Observable)
+  virtual int writeTransformContainerToHDF5(hid_t parentId, const std::string& transformContainerName) = 0;
+  virtual int readTransformContainerFromHDF5(hid_t parentId, bool metaDataOnly, const std::string& transformContainerName) = 0;
+  virtual ~ITransformContainer() = default;
+};

--- a/Source/SIMPLib/Geometry/SourceList.cmake
+++ b/Source/SIMPLib/Geometry/SourceList.cmake
@@ -3,6 +3,7 @@ set(SUBDIR_NAME Geometry)
 
 
 set(SIMPLib_${SUBDIR_NAME}_HDRS
+  ${SIMPLib_SOURCE_DIR}/Geometry/CompositeTransformContainer.h
   ${SIMPLib_SOURCE_DIR}/Geometry/EdgeGeom.h
   ${SIMPLib_SOURCE_DIR}/Geometry/GeometryHelpers.h
   ${SIMPLib_SOURCE_DIR}/Geometry/IGeometry.h
@@ -10,6 +11,7 @@ set(SIMPLib_${SUBDIR_NAME}_HDRS
   ${SIMPLib_SOURCE_DIR}/Geometry/IGeometry3D.h
   ${SIMPLib_SOURCE_DIR}/Geometry/IGeometryGrid.h
   ${SIMPLib_SOURCE_DIR}/Geometry/ImageGeom.h
+  ${SIMPLib_SOURCE_DIR}/Geometry/ITransformContainer.h
   ${SIMPLib_SOURCE_DIR}/Geometry/MeshStructs.h
   ${SIMPLib_SOURCE_DIR}/Geometry/QuadGeom.h
   ${SIMPLib_SOURCE_DIR}/Geometry/RectGridGeom.h
@@ -21,11 +23,13 @@ set(SIMPLib_${SUBDIR_NAME}_HDRS
   ${SIMPLib_SOURCE_DIR}/Geometry/ShapeOps/ShapeOps.h
   ${SIMPLib_SOURCE_DIR}/Geometry/ShapeOps/SuperEllipsoidOps.h
   ${SIMPLib_SOURCE_DIR}/Geometry/TetrahedralGeom.h
+  ${SIMPLib_SOURCE_DIR}/Geometry/TransformContainer.h
   ${SIMPLib_SOURCE_DIR}/Geometry/TriangleGeom.h
   ${SIMPLib_SOURCE_DIR}/Geometry/VertexGeom.h
 )
 
 set(SIMPLib_${SUBDIR_NAME}_SRCS
+  ${SIMPLib_SOURCE_DIR}/Geometry/CompositeTransformContainer.cpp
   ${SIMPLib_SOURCE_DIR}/Geometry/EdgeGeom.cpp
   ${SIMPLib_SOURCE_DIR}/Geometry/GeometryHelpers.cpp
   ${SIMPLib_SOURCE_DIR}/Geometry/IGeometry.cpp
@@ -43,6 +47,7 @@ set(SIMPLib_${SUBDIR_NAME}_SRCS
   ${SIMPLib_SOURCE_DIR}/Geometry/ShapeOps/ShapeOps.cpp
   ${SIMPLib_SOURCE_DIR}/Geometry/ShapeOps/SuperEllipsoidOps.cpp
   ${SIMPLib_SOURCE_DIR}/Geometry/TetrahedralGeom.cpp
+  ${SIMPLib_SOURCE_DIR}/Geometry/TransformContainer.cpp
   ${SIMPLib_SOURCE_DIR}/Geometry/TriangleGeom.cpp
   ${SIMPLib_SOURCE_DIR}/Geometry/VertexGeom.cpp
 )

--- a/Source/SIMPLib/Geometry/TransformContainer.cpp
+++ b/Source/SIMPLib/Geometry/TransformContainer.cpp
@@ -1,0 +1,166 @@
+/* ============================================================================
+ * Copyright (c) 2009-2018 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-15-D-5231
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "TransformContainer.h"
+#include "H5Support/H5Lite.h"
+#include "H5Support/H5Utilities.h"
+#include "H5Support/QH5Lite.h"
+#include "H5Support/QH5Utilities.h"
+#include "SIMPLib/Common/Constants.h"
+
+#include "H5Support/H5ScopedSentinel.h"
+
+TransformContainer::TransformContainer() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+TransformContainer::~TransformContainer() = default;
+
+int TransformContainer::writeTransformContainerToHDF5(hid_t parentId, const std::string& transformName)
+{
+  herr_t err = 0;
+  err = H5Utilities::createGroupsFromPath(transformName, parentId);
+  if(err < 0)
+  {
+    return err;
+  }
+  hid_t transformId = H5Gopen(parentId, transformName.c_str(), H5P_DEFAULT);
+  if(transformId < 0)
+  {
+    return -1;
+  }
+  H5ScopedGroupSentinel gSentinel(&transformId, false);
+  std::vector<hsize_t> dims(1);
+  TransformParametersType parameters = this->getParameters();
+  dims[0] = parameters.size();
+  err = H5Lite::writeVectorDataset(transformId, SIMPL::Geometry::TransformContainerParameters.toLatin1().data(), dims, parameters);
+  if(err < 0)
+  {
+    return err;
+  }
+  err = H5Lite::writeStringAttribute(parentId, transformName, SIMPL::Geometry::TransformContainerTypeName.toLatin1().data(), SIMPL::Geometry::TransformContainer.toLatin1().data());
+  if(err < 0)
+  {
+    return err;
+  }
+  err = H5Lite::writeStringAttribute(parentId, transformName, SIMPL::Geometry::TransformContainerMovingName.toLatin1().data(), this->getMovingName().c_str());
+  if(err < 0)
+  {
+    return err;
+  }
+  err = H5Lite::writeStringAttribute(parentId, transformName, SIMPL::Geometry::TransformContainerReferenceName.toLatin1().data(), this->getReferenceName().c_str());
+  if(err < 0)
+  {
+    return err;
+  }
+  dims[0] = this->getTransformTypeAsString().size();
+  err = H5Lite::writeStringDataset(transformId, SIMPL::Geometry::TransformContainerTypeAsString.toLatin1().data(), this->getTransformTypeAsString().c_str());
+  if(err < 0)
+  {
+    return err;
+  }
+  TransformFixedParametersType fixedParameters = this->getFixedParameters();
+  dims[0] = fixedParameters.size();
+  if(dims[0] > 0)
+  {
+    err = H5Lite::writeVectorDataset(transformId, SIMPL::Geometry::TransformContainerFixedParameters.toLatin1().data(), dims, fixedParameters);
+  }
+  return err;
+}
+
+int TransformContainer::readTransformContainerFromHDF5(hid_t parentId, bool SIMPL_NOT_USED(metaDataOnly), const std::string& transformName)
+{
+  herr_t err = 0;
+  err = H5Utilities::createGroupsFromPath(transformName, parentId);
+  if(err < 0)
+  {
+    return err;
+  }
+  hid_t transformId = H5Gopen(parentId, transformName.c_str(), H5P_DEFAULT);
+  if(transformId < 0)
+  {
+    return -1;
+  }
+  H5ScopedGroupSentinel gSentinel(&transformId, false);
+  TransformParametersType parameters;
+  err = H5Lite::readVectorDataset(transformId, SIMPL::Geometry::TransformContainerParameters.toLatin1().data(), parameters);
+  if(err < 0)
+  {
+    return err;
+  }
+  this->setParameters(parameters);
+  std::string movingName;
+  err = H5Lite::readStringAttribute(parentId, transformName, SIMPL::Geometry::TransformContainerMovingName.toLatin1().data(), movingName);
+  // An error can occur if the attribute is missing or empty. If it is the case, we use an empty string.
+  if(err < 0)
+  {
+    movingName = "";
+  }
+  this->setMovingName(movingName);
+  std::string referenceName;
+  err = H5Lite::readStringAttribute(parentId, transformName, SIMPL::Geometry::TransformContainerReferenceName.toLatin1().data(), referenceName);
+  // An error can occur if the attribute is missing or empty. If it is the case, we use an empty string.
+  if(err < 0)
+  {
+    referenceName = "";
+  }
+  this->setReferenceName(referenceName);
+  std::string transformTypeAsString;
+  err = H5Lite::readStringDataset(transformId, SIMPL::Geometry::TransformContainerTypeAsString.toLatin1().data(), transformTypeAsString);
+  if(err < 0)
+  {
+    return err;
+  }
+  this->setTransformTypeAsString(transformTypeAsString);
+  TransformFixedParametersType fixedParameters;
+  err = H5Lite::readVectorDataset(transformId, SIMPL::Geometry::TransformContainerFixedParameters.toLatin1().data(), fixedParameters);
+  if(err >= 0)
+  {
+    this->setFixedParameters(fixedParameters);
+  }
+  return 0;
+}
+
+TransformContainer& TransformContainer::operator=(const TransformContainer& old)
+{
+  if(this != &old)
+  {
+    this->m_Parameters = old.m_Parameters;
+    this->m_FixedParameters = old.m_FixedParameters;
+    this->m_TransformTypeAsString = old.m_TransformTypeAsString;
+    this->m_MovingName = old.m_MovingName;
+    this->m_ReferenceName = old.m_ReferenceName;
+  }
+  return *this;
+}

--- a/Source/SIMPLib/Geometry/TransformContainer.h
+++ b/Source/SIMPLib/Geometry/TransformContainer.h
@@ -1,0 +1,61 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "SIMPLib/Geometry/ITransformContainer.h"
+#include "SIMPLib/SIMPLib.h"
+
+#include "H5Support/H5Lite.h"
+
+class SIMPLib_EXPORT TransformContainer : public ITransformContainer
+{
+public:
+  typedef double ParametersValueType;
+  typedef std::vector<ParametersValueType> TransformParametersType;
+  typedef std::vector<ParametersValueType> TransformFixedParametersType;
+  SIMPL_SHARED_POINTERS(TransformContainer)
+  SIMPL_STATIC_NEW_MACRO(TransformContainer)
+  SIMPL_TYPE_MACRO_SUPER_OVERRIDE(TransformContainer, ITransformContainer)
+  TransformContainer();
+  virtual ~TransformContainer();
+  TransformContainer& operator=(const TransformContainer&);
+  int writeTransformContainerToHDF5(hid_t parentId, const std::string& transformContainerName) override;
+  int readTransformContainerFromHDF5(hid_t parentId, bool metaDataOnly, const std::string& transformContainerName) override;
+
+  SIMPL_INSTANCE_PROPERTY(TransformParametersType, Parameters)
+  SIMPL_INSTANCE_PROPERTY(TransformFixedParametersType, FixedParameters)
+  SIMPL_INSTANCE_PROPERTY(std::string, TransformTypeAsString)
+  SIMPL_INSTANCE_PROPERTY(std::string, MovingName)
+  SIMPL_INSTANCE_PROPERTY(std::string, ReferenceName)
+};

--- a/Source/SIMPLib/ITK/Dream3DTemplateAliasMacro.h
+++ b/Source/SIMPLib/ITK/Dream3DTemplateAliasMacro.h
@@ -450,7 +450,7 @@
       if(imageGeometry.get() != nullptr)                                                                                                                                                               \
       {                                                                                                                                                                                                \
         QVector<size_t> tDims(3, 0);                                                                                                                                                                   \
-        imageGeometry->getDimensions(tDims[0], tDims[1], tDims[2]);                                                                                                                                    \
+        std::tie(tDims[0], tDims[1], tDims[2]) = imageGeometry->getDimensions();                                                                                                                       \
         if(getErrorCondition() >= 0)                                                                                                                                                                   \
         {                                                                                                                                                                                              \
           QString str_type = ptr->getTypeAsString();                                                                                                                                                   \

--- a/Source/SIMPLib/ITK/SourceList.cmake
+++ b/Source/SIMPLib/ITK/SourceList.cmake
@@ -1,0 +1,9 @@
+set(SUBDIR_NAME ITK)
+
+#-------------------------------------------------------------------------------
+# Add the unit testing sources
+# -------------------------------------------------------------------- 
+# If Testing is enabled, turn on the Unit Tests 
+if(SIMPL_BUILD_TESTING)
+  include(${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/Testing/Cxx/SourceList.cmake)
+endif()

--- a/Source/SIMPLib/ITK/Testing/Cxx/SourceList.cmake
+++ b/Source/SIMPLib/ITK/Testing/Cxx/SourceList.cmake
@@ -1,0 +1,9 @@
+set(TEST_${SUBDIR_NAME}_NAMES
+  itkDream3DITransformContainerToTransformTest
+  itkDream3DTransformContainerToTransformTest
+  itkTransformToDream3DTransformContainerTest
+  itkTransformToDream3DITransformContainerTest
+)
+
+include( ${CMP_SOURCE_DIR}/ITKSupport/IncludeITK.cmake)
+SIMPL_ADD_UNIT_TEST("${TEST_${SUBDIR_NAME}_NAMES}" "${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/Testing/Cxx")

--- a/Source/SIMPLib/ITK/Testing/Cxx/itkDream3DITransformContainerToTransformTest.cpp
+++ b/Source/SIMPLib/ITK/Testing/Cxx/itkDream3DITransformContainerToTransformTest.cpp
@@ -1,0 +1,116 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "itkDream3DTransformContainerTestHelper.h"
+
+#include "SIMPLib/ITK/itkDream3DITransformContainerToTransform.h"
+#include "itkTransformFactory.h"
+
+class itkDream3DITransformContainerToTransformTest
+{
+
+public:
+  itkDream3DITransformContainerToTransformTest() = default;
+  virtual ~itkDream3DITransformContainerToTransformTest() = default;
+
+  int TestitkDream3DITransformContainerToTransformTest()
+  {
+    AffineType::Pointer itkAffine = GetTestAffine();
+    TransformContainer::Pointer transformContainer = GetTransformContainerFromITKAffineTransform(itkAffine);
+
+    // Test simple conversion from ITK transform to transform container.
+    using FilterType = itk::Dream3DITransformContainerToTransform<float, 3>;
+    FilterType::Pointer filter = FilterType::New();
+    filter->SetInput(transformContainer);
+    filter->Update();
+    auto convertedITKTransform = filter->GetOutput()->Get();
+    CompareITKParameters(itkAffine->GetParameters(), convertedITKTransform->GetParameters());
+    CompareITKParameters(itkAffine->GetFixedParameters(), convertedITKTransform->GetFixedParameters());
+    DREAM3D_REQUIRE_EQUAL(QString(itkAffine->GetTransformTypeAsString().c_str()), QString(convertedITKTransform->GetTransformTypeAsString().c_str()));
+
+    // Modify manually transform type to an existing transform type that is
+    // not automatically registered in the transform factory. The test
+    // should fail by throwing an exception (that we catch).
+    using MO = itk::MatrixOffsetTransformBase<float, 3, 3>;
+    MO::Pointer matrixOffset = MO::New();
+    matrixOffset->SetMatrix(itkAffine->GetMatrix());
+    transformContainer->setTransformTypeAsString(matrixOffset->GetTransformTypeAsString());
+    filter->Modified();
+    try
+    {
+      filter->Update();
+      DREAM3D_TEST_THROW_EXCEPTION("An exception was expected and this line should not be executed.");
+    } catch(itk::ExceptionObject& ex)
+    {
+      std::cout << "Caught exception as expected." << std::endl;
+    }
+    // If we manually register the transform to the transform factory,
+    // the test should now pass.
+    itk::TransformFactory<MO>::RegisterTransform();
+    filter->Update();
+
+    // We test that we can also convert
+    CompositeTransformContainer::Pointer ct = CompositeTransformContainer::New();
+    ct->addTransformContainer(transformContainer);
+    ct->addTransformContainer(transformContainer);
+    ct->addTransformContainer(transformContainer);
+
+    filter->SetInput(ct);
+    filter->Update();
+    auto convertedCompositeContainer = filter->GetOutput()->Get();
+
+    CompositeTransform::Pointer compositeTransform = dynamic_cast<CompositeTransform*>(convertedCompositeContainer.GetPointer());
+
+    DREAM3D_REQUIRE_VALID_POINTER(compositeTransform.GetPointer());
+
+    DREAM3D_REQUIRE_EQUAL(compositeTransform->GetNumberOfTransforms(), 3)
+    DREAM3D_REQUIRE_EQUAL(QString(compositeTransform->GetNthTransform(0)->GetTransformTypeAsString().c_str()), QString(matrixOffset->GetTransformTypeAsString().c_str()));
+
+    return 0;
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void operator()()
+  {
+    int err = EXIT_SUCCESS;
+    std::cout << "#### itkDream3DITransformContainerToTransformTest Starting ####" << std::endl;
+
+    DREAM3D_REGISTER_TEST(TestitkDream3DITransformContainerToTransformTest());
+  }
+
+private:
+  itkDream3DITransformContainerToTransformTest(const itkDream3DITransformContainerToTransformTest&) = delete; // Copy Constructor Not Implemented
+  void operator=(const itkDream3DITransformContainerToTransformTest&) = delete;                               // Move assignment Not Implemented
+};

--- a/Source/SIMPLib/ITK/Testing/Cxx/itkDream3DTransformContainerTestHelper.h
+++ b/Source/SIMPLib/ITK/Testing/Cxx/itkDream3DTransformContainerTestHelper.h
@@ -1,0 +1,103 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#ifndef itkDream3DTransforContainerTestHelper_h
+#define itkDream3DTransforContainerTestHelper_h
+
+#include "itkAffineTransform.h"
+#include "itkCompositeTransform.h"
+
+#include "SIMPLib/Geometry/CompositeTransformContainer.h"
+#include "SIMPLib/Geometry/TransformContainer.h"
+
+using AffineType = itk::AffineTransform<float, 3>;
+using CompositeTransform = itk::CompositeTransform<float, 3>;
+
+template <typename ParameterType> bool CompareITKParameters(ParameterType trans1, ParameterType trans2)
+{
+  DREAM3D_REQUIRE_EQUAL(trans1.GetSize(), trans2.GetSize());
+  for(size_t p = 0; p < trans1.GetSize(); p++)
+  {
+    DREAM3D_REQUIRE_EQUAL(trans1[p], trans2[p]);
+  }
+  return true;
+}
+
+template <typename ParameterType> bool CompareDREAM3DParameters(ParameterType trans1, ParameterType trans2)
+{
+  DREAM3D_REQUIRE_EQUAL(trans1.size(), trans2.size());
+  for(size_t p = 0; p < trans1.size(); p++)
+  {
+    DREAM3D_REQUIRE_EQUAL(trans1[p], trans2[p]);
+  }
+  return true;
+}
+
+typename AffineType::Pointer GetTestAffine()
+{
+  // Create an ITK affine transform as a reference
+  AffineType::Pointer itkAffine = AffineType::New();
+  itk::Matrix<float, 3, 3> matrix;
+  matrix.SetIdentity();
+  itkAffine->SetMatrix(matrix);
+  return itkAffine;
+}
+
+typename TransformContainer::Pointer GetTransformContainerFromITKAffineTransform(const AffineType::Pointer& itkAffine)
+{
+  auto parameters = itkAffine->GetParameters();
+  auto fixedParameters = itkAffine->GetFixedParameters();
+  auto itkAffineName = itkAffine->GetTransformTypeAsString();
+
+  std::vector<::TransformContainer::ParametersValueType> dream3DParameters(parameters.GetSize());
+  std::vector<::TransformContainer::ParametersValueType> dream3DFixedParameters(fixedParameters.GetSize());
+  for(size_t p = 0; p < dream3DParameters.size(); p++)
+  {
+    dream3DParameters[p] = parameters[p];
+  }
+  for(size_t p = 0; p < dream3DFixedParameters.size(); p++)
+  {
+    dream3DFixedParameters[p] = fixedParameters[p];
+  }
+  // Create a SIMPL transform container and manually convert the ITK transform to
+  // a SIMPL transform container.
+  TransformContainer::Pointer transformContainer = TransformContainer::New();
+  transformContainer->setTransformTypeAsString(itkAffineName);
+  transformContainer->setMovingName("");
+  transformContainer->setReferenceName("World");
+  transformContainer->setFixedParameters(dream3DFixedParameters);
+  transformContainer->setParameters(dream3DParameters);
+  return transformContainer;
+}
+
+#endif

--- a/Source/SIMPLib/ITK/Testing/Cxx/itkDream3DTransformContainerToTransformTest.cpp
+++ b/Source/SIMPLib/ITK/Testing/Cxx/itkDream3DTransformContainerToTransformTest.cpp
@@ -1,0 +1,76 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "SIMPLib/ITK/itkDream3DTransformContainerToTransform.h"
+
+#include "itkDream3DTransformContainerTestHelper.h"
+
+class itkDream3DTransformContainerToTransformTest
+{
+
+public:
+  itkDream3DTransformContainerToTransformTest() = default;
+  virtual ~itkDream3DTransformContainerToTransformTest() = default;
+
+  int TestitkDream3DTransformContainerToTransformTest()
+  {
+    AffineType::Pointer itkAffine = GetTestAffine();
+    TransformContainer::Pointer transformContainer = GetTransformContainerFromITKAffineTransform(itkAffine);
+
+    //
+    using FilterType = itk::Dream3DTransformContainerToTransform<AffineType>;
+
+    FilterType::Pointer filter = FilterType::New();
+    filter->SetInput(transformContainer);
+    filter->Update();
+    auto convertedITKTransform = filter->GetOutput()->Get();
+    CompareITKParameters(itkAffine->GetParameters(), convertedITKTransform->GetParameters());
+    CompareITKParameters(itkAffine->GetFixedParameters(), convertedITKTransform->GetFixedParameters());
+    DREAM3D_REQUIRE_EQUAL(typeid(itkAffine).name(), typeid(convertedITKTransform).name());
+    return 0;
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void operator()()
+  {
+    int err = EXIT_SUCCESS;
+    std::cout << "#### itkDream3DTransformContainerToTransformTest Starting ####" << std::endl;
+    DREAM3D_REGISTER_TEST(TestitkDream3DTransformContainerToTransformTest());
+  }
+
+private:
+  itkDream3DTransformContainerToTransformTest(const itkDream3DTransformContainerToTransformTest&) = delete; // Copy Constructor Not Implemented
+  void operator=(const itkDream3DTransformContainerToTransformTest&) = delete;                              // Move assignment Not Implemented
+};

--- a/Source/SIMPLib/ITK/Testing/Cxx/itkTransformToDream3DITransformContainerTest.cpp
+++ b/Source/SIMPLib/ITK/Testing/Cxx/itkTransformToDream3DITransformContainerTest.cpp
@@ -1,0 +1,97 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+#include "SIMPLib/ITK/itkTransformToDream3DITransformContainer.h"
+
+#include "itkDream3DTransformContainerTestHelper.h"
+
+class itkTransformToDream3DITransformContainerTest
+{
+
+public:
+  itkTransformToDream3DITransformContainerTest() = default;
+  virtual ~itkTransformToDream3DITransformContainerTest() = default;
+
+  int TestitkTransformToDream3DITransformContainerTest()
+  {
+    AffineType::Pointer itkAffine = GetTestAffine();
+    TransformContainer::Pointer transformContainer = GetTransformContainerFromITKAffineTransform(itkAffine);
+    auto containerParameters = transformContainer->getParameters();
+    auto containerFixedParameters = transformContainer->getFixedParameters();
+
+    //
+    using FilterType = itk::TransformToDream3DITransformContainer<float, 3>;
+
+    FilterType::Pointer filter = FilterType::New();
+    filter->SetInput(itkAffine);
+    filter->Update();
+    ::ITransformContainer::Pointer convertedITransformContainer = filter->GetOutput()->Get();
+    ::TransformContainer::Pointer convertedTransformContainer = std::dynamic_pointer_cast<::TransformContainer>(convertedITransformContainer);
+
+    DREAM3D_REQUIRE_VALID_POINTER(convertedTransformContainer.get());
+    CompareDREAM3DParameters(convertedTransformContainer->getParameters(), containerParameters);
+    CompareDREAM3DParameters(convertedTransformContainer->getFixedParameters(), containerFixedParameters);
+    DREAM3D_REQUIRE_EQUAL(QString(itkAffine->GetTransformTypeAsString().c_str()), QString(convertedTransformContainer->getTransformTypeAsString().c_str()));
+
+    using CompositeTransform = itk::CompositeTransform<float, 3>;
+    CompositeTransform::Pointer ct = CompositeTransform::New();
+    ct->AddTransform(itkAffine);
+    ct->AddTransform(itkAffine);
+
+    filter->SetInput(ct);
+    filter->Update();
+    ::ITransformContainer::Pointer convertedITransformContainer2 = filter->GetOutput()->Get();
+    ::CompositeTransformContainer::Pointer ctransformContainer = std::dynamic_pointer_cast<::CompositeTransformContainer>(convertedITransformContainer2);
+    DREAM3D_REQUIRE_VALID_POINTER(ctransformContainer.get());
+    ::ITransformContainer::Pointer iTransformContainer = ctransformContainer->getTransformContainers()[0];
+    ::TransformContainer::Pointer convertedTransformContainer2 = std::dynamic_pointer_cast<::TransformContainer>(iTransformContainer);
+    DREAM3D_REQUIRE_VALID_POINTER(convertedTransformContainer2.get());
+    CompareDREAM3DParameters(containerParameters, convertedTransformContainer2->getParameters());
+    CompareDREAM3DParameters(containerFixedParameters, convertedTransformContainer2->getFixedParameters());
+    DREAM3D_REQUIRE_EQUAL(QString(itkAffine->GetTransformTypeAsString().c_str()), QString(convertedTransformContainer2->getTransformTypeAsString().c_str()));
+    return 0;
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void operator()()
+  {
+    int err = EXIT_SUCCESS;
+    std::cout << "#### itkTransformToDream3DITransformContainerTest Starting ####" << std::endl;
+    DREAM3D_REGISTER_TEST(TestitkTransformToDream3DITransformContainerTest());
+  }
+
+private:
+  itkTransformToDream3DITransformContainerTest(const itkTransformToDream3DITransformContainerTest&) = delete; // Copy Constructor Not Implemented
+  void operator=(const itkTransformToDream3DITransformContainerTest&) = delete;                               // Move assignment Not Implemented
+};

--- a/Source/SIMPLib/ITK/Testing/Cxx/itkTransformToDream3DTransformContainerTest.cpp
+++ b/Source/SIMPLib/ITK/Testing/Cxx/itkTransformToDream3DTransformContainerTest.cpp
@@ -1,0 +1,78 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "SIMPLib/ITK/itkTransformToDream3DTransformContainer.h"
+
+#include "itkDream3DTransformContainerTestHelper.h"
+
+class itkTransformToDream3DTransformContainerTest
+{
+
+public:
+  itkTransformToDream3DTransformContainerTest() = default;
+  virtual ~itkTransformToDream3DTransformContainerTest() = default;
+
+  int TestitkTransformToDream3DTransformContainerTest()
+  {
+    AffineType::Pointer itkAffine = GetTestAffine();
+    TransformContainer::Pointer transformContainer = GetTransformContainerFromITKAffineTransform(itkAffine);
+    auto containerParameters = transformContainer->getParameters();
+    auto containerFixedParameters = transformContainer->getFixedParameters();
+
+    //
+    using FilterType = itk::TransformToDream3DTransformContainer<AffineType>;
+
+    FilterType::Pointer filter = FilterType::New();
+    filter->SetInput(itkAffine);
+    filter->Update();
+    auto convertedTransformContainer = filter->GetOutput()->Get();
+    CompareDREAM3DParameters(containerParameters, convertedTransformContainer->getParameters());
+    CompareDREAM3DParameters(containerFixedParameters, convertedTransformContainer->getFixedParameters());
+    DREAM3D_REQUIRE_EQUAL(QString(itkAffine->GetTransformTypeAsString().c_str()), QString(convertedTransformContainer->getTransformTypeAsString().c_str()));
+    return 0;
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void operator()()
+  {
+    int err = EXIT_SUCCESS;
+    std::cout << "#### itkTransformToDream3DTransformContainerTest Starting ####" << std::endl;
+    DREAM3D_REGISTER_TEST(TestitkTransformToDream3DTransformContainerTest());
+  }
+
+private:
+  itkTransformToDream3DTransformContainerTest(const itkTransformToDream3DTransformContainerTest&) = delete; // Copy Constructor Not Implemented
+  void operator=(const itkTransformToDream3DTransformContainerTest&) = delete;                              // Move assignment Not Implemented
+};

--- a/Source/SIMPLib/ITK/itkDream3DFilterInterruption.h
+++ b/Source/SIMPLib/ITK/itkDream3DFilterInterruption.h
@@ -22,7 +22,7 @@ private:
   AbstractFilter* m_Filter;
   Dream3DFilterInterruption()
   {
-    m_Filter = ITK_NULLPTR;
+    m_Filter = nullptr;
   }
 
 public:

--- a/Source/SIMPLib/ITK/itkDream3DITransformContainerToTransform.h
+++ b/Source/SIMPLib/ITK/itkDream3DITransformContainerToTransform.h
@@ -1,0 +1,87 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "itkCompositeTransform.h"
+#include "itkProcessObject.h"
+#include "itkSimpleDataObjectDecorator.h"
+#include "itkTransformBase.h"
+
+#include "SIMPLib/Geometry/ITransformContainer.h"
+
+namespace itk
+{
+template <typename TParametersValueType = double, unsigned int CompositeNDimensions = 3> class Dream3DITransformContainerToTransform : public ProcessObject
+{
+public:
+  /** Standard class typedefs. */
+  using Self = Dream3DITransformContainerToTransform;
+  using Pointer = SmartPointer<Self>;
+  using Superclass = ProcessObject;
+  using ITKTransformType = TransformBaseTemplate<TParametersValueType>;
+  using ITKTransformPointer = typename ITKTransformType::Pointer;
+  using CompositeType = itk::CompositeTransform<TParametersValueType, CompositeNDimensions>;
+  using DecoratorType = typename itk::SimpleDataObjectDecorator<typename TransformBaseTemplate<TParametersValueType>::Pointer>;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+  itkTypeMacro(Dream3DITransformContainerToTransform, ProcessObject);
+
+  virtual void SetInput(const ITransformContainer::Pointer& transformContainer);
+  DecoratorType* GetOutput();
+
+protected:
+  Dream3DITransformContainerToTransform();
+  virtual ~Dream3DITransformContainerToTransform();
+
+  virtual void VerifyPreconditions() override;
+
+  virtual void GenerateData() override;
+  ProcessObject::DataObjectPointer MakeOutput(ProcessObject::DataObjectPointerArraySizeType) override;
+  ITransformContainer::Pointer m_ITransformContainer;
+
+private:
+  Dream3DITransformContainerToTransform(const Dream3DITransformContainerToTransform&) = delete; // Copy Constructor Not Implemented
+  void operator=(const Dream3DITransformContainerToTransform&) = delete;                        // Move assignment Not Implemented
+
+  void TransformGenerateData(ITKTransformPointer& itktransform, ::TransformContainer* transformContainer);
+  void GenerateData(ITKTransformPointer& itktransform, const ::ITransformContainer::Pointer& mTransformContainer);
+  void CreateTransform(ITKTransformPointer& ptr, const std::string& ClassName);
+  using Superclass::SetInput;
+};
+} // end of itk namespace
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkDream3DITransformContainerToTransform.hxx"
+#endif

--- a/Source/SIMPLib/ITK/itkDream3DITransformContainerToTransform.hxx
+++ b/Source/SIMPLib/ITK/itkDream3DITransformContainerToTransform.hxx
@@ -1,0 +1,215 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "itkDream3DITransformContainerToTransform.h"
+
+#include "itkTransform.h"
+#include "itkTransformFactoryBase.h"
+
+#include "SIMPLib/Geometry/CompositeTransformContainer.h"
+#include "SIMPLib/Geometry/TransformContainer.h"
+
+namespace itk
+{
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions> Dream3DITransformContainerToTransform<TParametersValueType, CompositeNDimensions>::Dream3DITransformContainerToTransform()
+{
+  // Create the output. We use static_cast<> here because we know the default
+  // output must be of type DecoratorType
+  typename DecoratorType::Pointer output = static_cast<DecoratorType*>(this->MakeOutput(0).GetPointer());
+  this->ProcessObject::SetNumberOfRequiredOutputs(1);
+  this->ProcessObject::SetNthOutput(0, output.GetPointer());
+  m_ITransformContainer = ::ITransformContainer::NullPointer();
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+Dream3DITransformContainerToTransform<TParametersValueType, CompositeNDimensions>::~Dream3DITransformContainerToTransform() = default;
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+void Dream3DITransformContainerToTransform<TParametersValueType, CompositeNDimensions>::SetInput(const ITransformContainer::Pointer& transformContainer)
+{
+  if(transformContainer != m_ITransformContainer)
+  {
+    m_ITransformContainer = transformContainer;
+    this->Modified();
+  }
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+ProcessObject::DataObjectPointer Dream3DITransformContainerToTransform<TParametersValueType, CompositeNDimensions>::MakeOutput(ProcessObject::DataObjectPointerArraySizeType)
+{
+  typename DecoratorType::Pointer output = DecoratorType::New();
+  return output.GetPointer();
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions> void Dream3DITransformContainerToTransform<TParametersValueType, CompositeNDimensions>::VerifyPreconditions()
+{
+  if(!m_ITransformContainer)
+  {
+    itkExceptionMacro("Input transform container is empty");
+  }
+  Superclass::VerifyPreconditions();
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+void Dream3DITransformContainerToTransform<TParametersValueType, CompositeNDimensions>::CreateTransform(ITKTransformPointer& ptr, const std::string& ClassName)
+{
+  // The logic of this function is shamelessly copied from itkTransformIOBase.hxx in ITK.
+  
+  // call to GetFactory has side effect of initializing the
+  // TransformFactory overrides
+  TransformFactoryBase* theFactory = TransformFactoryBase::GetFactory();
+
+  // Instantiate the transform
+  itkDebugMacro("About to call ObjectFactory");
+  LightObject::Pointer i = ObjectFactoryBase::CreateInstance(ClassName.c_str());
+  itkDebugMacro("After call ObjectFactory");
+  ptr = dynamic_cast<ITKTransformType*>(i.GetPointer());
+  if(ptr.IsNull())
+  {
+    std::ostringstream msg;
+    msg << "Could not create an instance of \"" << ClassName << "\"" << std::endl
+        << "The usual cause of this error is not registering the "
+        << "transform with TransformFactory" << std::endl;
+    msg << "Currently registered Transforms: " << std::endl;
+    std::list<std::string> names = theFactory->GetClassOverrideWithNames();
+    for(auto& name : names)
+    {
+      msg << "\t\"" << name << "\"" << std::endl;
+    }
+    itkExceptionMacro(<< msg.str());
+  }
+  // Correct extra reference count from CreateInstance()
+  ptr->UnRegister();
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+void Dream3DITransformContainerToTransform<TParametersValueType, CompositeNDimensions>::TransformGenerateData(ITKTransformPointer& itktransform, ::TransformContainer* transformContainer)
+{
+  CreateTransform(itktransform, transformContainer->getTransformTypeAsString().c_str());
+  auto dream3DParameters = transformContainer->getParameters();
+  auto dream3DFixedParameters = transformContainer->getFixedParameters();
+
+  // Kernel transforms need an additional initialization. We do not handle that and
+  // therefore Kernel transforms are not currently supported.
+  std::string transformTypeName = itktransform->GetNameOfClass();
+  const size_t len = strlen("KernelTransform"); // Computed at compile time in most cases
+  if(transformTypeName.size() >= len && !transformTypeName.compare(transformTypeName.size() - len, len, "KernelTransform"))
+  {
+    itkExceptionMacro("KernelTransforms are not currently supported.");
+  }
+
+  if(dream3DParameters.size() != itktransform->GetParameters().size() || dream3DFixedParameters.size() != itktransform->GetFixedParameters().size())
+  {
+    std::ostringstream msg;
+    msg << "Size mismatch in Dream3D transform container parameters and ITK transform parameters." << std::endl
+        << "There must be an error in the transform name saved in TransformTypeAsString." << std::endl;
+
+    itkExceptionMacro(<< msg.str());
+  }
+  typename ITKTransformType::ParametersType itkParameters(dream3DParameters.size());
+  typename ITKTransformType::FixedParametersType itkFixedParameters(dream3DFixedParameters.size());
+  for(size_t p = 0; p < dream3DParameters.size(); p++)
+  {
+    itkParameters[p] = static_cast<TParametersValueType>(dream3DParameters[p]);
+  }
+  for(size_t p = 0; p < dream3DFixedParameters.size(); p++)
+  {
+    itkFixedParameters[p] = static_cast<TParametersValueType>(dream3DFixedParameters[p]);
+  }
+  itktransform->SetParameters(itkParameters);
+  itktransform->SetFixedParameters(itkFixedParameters);
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+void Dream3DITransformContainerToTransform<TParametersValueType, CompositeNDimensions>::GenerateData(ITKTransformPointer& itktransform, const ITransformContainer::Pointer& mTransformContainer)
+{
+  ::TransformContainer* transformContainer = dynamic_cast<::TransformContainer*>(mTransformContainer.get());
+  if(transformContainer)
+  {
+    this->TransformGenerateData(itktransform, transformContainer);
+  }
+  else
+  {
+    ::CompositeTransformContainer* ctransformContainer = dynamic_cast<::CompositeTransformContainer*>(mTransformContainer.get());
+    if(ctransformContainer)
+    {
+      using cTransformType = Transform<TParametersValueType, CompositeNDimensions, CompositeNDimensions>;  
+
+      typename CompositeType::Pointer itkcompositetransform = CompositeType::New();
+
+      for(auto& t : ctransformContainer->getTransformContainers())
+      {
+        ITKTransformPointer itkctransform;
+        this->GenerateData(itkctransform, t);
+        cTransformType* itkDimTransform = dynamic_cast<cTransformType*>(itkctransform.GetPointer());
+        if(itkDimTransform)
+        {
+          itkcompositetransform->AddTransform(itkDimTransform);
+        }
+        else
+        {
+          std::ostringstream msg;
+          msg << "Transform dimension mismatch between given dimension (Input=" << CompositeNDimensions << ", Output=" << CompositeNDimensions << ")" << std::endl
+              << "and dimension of internal transform (Input=" << itktransform->GetInputSpaceDimension() << ", Output=" << itktransform->GetOutputSpaceDimension() << ")." << std::endl;
+          itkExceptionMacro(<< msg.str());
+        }
+      }
+      itktransform = itkcompositetransform;
+    }
+    else
+    {
+      // Should never arrive here
+      itkExceptionMacro("Input transform is neither a TransformContainer nor a CompositeTransformContainer. Type not supported!!!");
+    }
+  }
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions> void Dream3DITransformContainerToTransform<TParametersValueType, CompositeNDimensions>::GenerateData()
+{
+  auto* outputPtr = this->GetOutput();
+  ITKTransformPointer itktransform;
+  GenerateData(itktransform, m_ITransformContainer);
+  outputPtr->Set(itktransform);
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+typename Dream3DITransformContainerToTransform<TParametersValueType, CompositeNDimensions>::DecoratorType*
+Dream3DITransformContainerToTransform<TParametersValueType, CompositeNDimensions>::GetOutput()
+{
+  return itkDynamicCastInDebugMode<DecoratorType*>(this->GetPrimaryOutput());
+}
+
+} // end of itk namespace

--- a/Source/SIMPLib/ITK/itkDream3DImage.h
+++ b/Source/SIMPLib/ITK/itkDream3DImage.h
@@ -158,11 +158,11 @@ public:
 
   /** Allocate the image memory. The size of the image must
    * already be set, e.g. by calling SetRegions(). */
-  virtual void Allocate(bool initializePixels = false) ITK_OVERRIDE;
+  virtual void Allocate(bool initializePixels = false) override;
 
   /** Restore the data object to its initial state. This means releasing
    * memory. */
-  virtual void Initialize() ITK_OVERRIDE;
+  virtual void Initialize() override;
 
   /** Fill the image buffer with a value.  Be sure to call Allocate()
    * first. */
@@ -201,13 +201,13 @@ public:
 
   /** Return a pointer to the beginning of the buffer.  This is used by
    * the image iterator class. */
-  virtual TPixel* GetBufferPointer() ITK_OVERRIDE
+  virtual TPixel* GetBufferPointer() override
   {
-    return m_TemplatedBuffer ? m_TemplatedBuffer->GetBufferPointer() : ITK_NULLPTR;
+    return m_TemplatedBuffer ? m_TemplatedBuffer->GetBufferPointer() : nullptr;
   }
-  virtual const TPixel* GetBufferPointer() const ITK_OVERRIDE
+  virtual const TPixel* GetBufferPointer() const override
   {
-    return m_TemplatedBuffer ? m_TemplatedBuffer->GetBufferPointer() : ITK_NULLPTR;
+    return m_TemplatedBuffer ? m_TemplatedBuffer->GetBufferPointer() : nullptr;
   }
 
   /** Return a pointer to the container. */
@@ -235,7 +235,7 @@ public:
    * simply calls CopyInformation() and copies the region ivars.
    * The implementation here refers to the superclass' implementation
    * and then copies over the pixel container. */
-  virtual void Graft(const DataObject* data) ITK_OVERRIDE;
+  virtual void Graft(const DataObject* data) override;
 
   /** Return the Pixel Accessor object */
   AccessorType GetPixelAccessor(void)
@@ -263,15 +263,15 @@ public:
 
 protected:
   Dream3DImage();
-  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   virtual ~Dream3DImage()
   {
   }
 
 private:
-  Dream3DImage(const Self&) ITK_DELETE_FUNCTION;
-  void operator=(const Self&) ITK_DELETE_FUNCTION;
+  Dream3DImage(const Self&) = delete;
+  void operator=(const Self&) = delete;
 
   /** Memory for the current buffer. */
   PixelContainerPointer m_TemplatedBuffer;

--- a/Source/SIMPLib/ITK/itkDream3DTransformContainerToTransform.h
+++ b/Source/SIMPLib/ITK/itkDream3DTransformContainerToTransform.h
@@ -1,0 +1,78 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "itkProcessObject.h"
+#include "itkSimpleDataObjectDecorator.h"
+
+#include "SIMPLib/Geometry/TransformContainer.h"
+
+namespace itk
+{
+template <typename ITKTransformType> class Dream3DTransformContainerToTransform : public ProcessObject
+{
+public:
+  /** Standard class typedefs. */
+  using Self = Dream3DTransformContainerToTransform;
+  using Pointer = SmartPointer<Self>;
+  using Superclass = ProcessObject;
+  using DecoratorType = typename itk::SimpleDataObjectDecorator<typename ITKTransformType::Pointer>;
+  using TParametersValueType = typename ITKTransformType::ParametersType::ValueType;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+  itkTypeMacro(Dream3DTransformToTransform, ProcessObject);
+
+  virtual void SetInput(::TransformContainer::Pointer& transformContainer);
+  DecoratorType* GetOutput();
+
+protected:
+  Dream3DTransformContainerToTransform();
+  virtual ~Dream3DTransformContainerToTransform();
+
+  virtual void VerifyPreconditions() override;
+
+  virtual void GenerateData() override;
+  ::TransformContainer::Pointer m_TransformContainer;
+  ProcessObject::DataObjectPointer MakeOutput(ProcessObject::DataObjectPointerArraySizeType) override;
+
+private:
+  Dream3DTransformContainerToTransform(const Dream3DTransformContainerToTransform&) = delete; // Copy Constructor Not Implemented
+  void operator=(const Dream3DTransformContainerToTransform&) = delete;                       // Move assignment Not Implemented
+};
+} // end of itk namespace
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkDream3DTransformContainerToTransform.hxx"
+#endif

--- a/Source/SIMPLib/ITK/itkDream3DTransformContainerToTransform.hxx
+++ b/Source/SIMPLib/ITK/itkDream3DTransformContainerToTransform.hxx
@@ -1,0 +1,124 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "itkDream3DTransformContainerToTransform.h"
+
+namespace itk
+{
+
+template <typename ITKTransformType> Dream3DTransformContainerToTransform<ITKTransformType>::Dream3DTransformContainerToTransform()
+{
+  // Create the output. We use static_cast<> here because we know the default
+  // output must be of type DecoratorType
+  typename DecoratorType::Pointer output = static_cast<DecoratorType*>(this->MakeOutput(0).GetPointer());
+  this->ProcessObject::SetNumberOfRequiredOutputs(1);
+  this->ProcessObject::SetNthOutput(0, output.GetPointer());
+  m_TransformContainer = ::TransformContainer::NullPointer();
+}
+
+template <typename ITKTransformType> Dream3DTransformContainerToTransform<ITKTransformType>::~Dream3DTransformContainerToTransform() = default;
+
+template <typename ITKTransformType> void Dream3DTransformContainerToTransform<ITKTransformType>::SetInput(::TransformContainer::Pointer& transformContainer)
+{
+  if(transformContainer != m_TransformContainer)
+  {
+    m_TransformContainer = transformContainer;
+    this->Modified();
+  }
+}
+
+template <typename ITKTransformType> ProcessObject::DataObjectPointer Dream3DTransformContainerToTransform<ITKTransformType>::MakeOutput(ProcessObject::DataObjectPointerArraySizeType)
+{
+  typename DecoratorType::Pointer output = DecoratorType::New();
+  typename ITKTransformType::Pointer transform = ITKTransformType::New();
+  output->Set(transform);
+  return output.GetPointer();
+}
+
+template <typename ITKTransformType> void Dream3DTransformContainerToTransform<ITKTransformType>::VerifyPreconditions()
+{
+  if(!m_TransformContainer)
+  {
+    itkExceptionMacro("Input transform container is empty");
+  }
+  DecoratorType* outputPtr = this->GetOutput();
+  typename ITKTransformType::Pointer transform = outputPtr->Get();
+  // Verifies that the number of Parameters and Fixed Parameters in the transform
+  // match the expected number based on the transform type.
+  if(transform->GetNumberOfParameters() != m_TransformContainer->getParameters().size())
+  {
+    itkExceptionMacro("Transform container parameter size does not match ITK transform parameter size");
+  }
+  if(transform->GetNumberOfFixedParameters() != m_TransformContainer->getFixedParameters().size())
+  {
+    itkExceptionMacro("Transform container fixed parameter size does not match ITK transform fixed parameter size");
+  }
+  if(transform->GetTransformTypeAsString() != m_TransformContainer->getTransformTypeAsString())
+  {
+    itkExceptionMacro("Transform types do not match. Transform container is " + m_TransformContainer->getTransformTypeAsString() + ". ITK transform is " + transform->GetTransformTypeAsString() +
+                      " .");
+  }
+  Superclass::VerifyPreconditions();
+}
+
+template <typename ITKTransformType> void Dream3DTransformContainerToTransform<ITKTransformType>::GenerateData()
+{
+  DecoratorType* outputPtr = this->GetOutput();
+  typename ITKTransformType::Pointer transform = outputPtr->Get();
+
+  auto dream3DParameters = m_TransformContainer->getParameters();
+  auto dream3DFixedParameters = m_TransformContainer->getFixedParameters();
+
+  typename ITKTransformType::ParametersType itkParameters(dream3DParameters.size());
+  typename ITKTransformType::FixedParametersType itkFixedParameters(dream3DFixedParameters.size());
+  for(size_t p = 0; p < dream3DParameters.size(); p++)
+  {
+    itkParameters[p] = static_cast<TParametersValueType>(dream3DParameters[p]);
+  }
+  for(size_t p = 0; p < dream3DFixedParameters.size(); p++)
+  {
+    itkFixedParameters[p] = static_cast<TParametersValueType>(dream3DFixedParameters[p]);
+  }
+
+  transform->SetParameters(itkParameters);
+  transform->SetFixedParameters(itkFixedParameters);
+}
+
+template <typename ITKTransformType> typename Dream3DTransformContainerToTransform<ITKTransformType>::DecoratorType* Dream3DTransformContainerToTransform<ITKTransformType>::GetOutput()
+{
+  return itkDynamicCastInDebugMode<DecoratorType*>(this->GetPrimaryOutput());
+}
+
+} // end of itk namespace

--- a/Source/SIMPLib/ITK/itkImportDream3DImageContainer.h
+++ b/Source/SIMPLib/ITK/itkImportDream3DImageContainer.h
@@ -70,20 +70,20 @@ protected:
   /** PrintSelf routine. Normally this is a protected internal method. It is
    * made public here so that Image can call this method.  Users should not
    * call this method but should call Print() instead. */
-  virtual void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
+  virtual void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /**
    * Allocates elements of the array.  If UseDefaultConstructor is true, then
    * the default constructor is used to initialize each element.  POD date types
    * initialize to zero.
    */
-  virtual Element* AllocateElements(ElementIdentifier size, bool UseDefaultConstructor = false) const ITK_OVERRIDE;
+  virtual Element* AllocateElements(ElementIdentifier size, bool UseDefaultConstructor = false) const override;
 
-  virtual void DeallocateManagedMemory() ITK_OVERRIDE;
+  virtual void DeallocateManagedMemory() override;
 
 private:
-  ImportDream3DImageContainer(const Self&) ITK_DELETE_FUNCTION;
-  void operator=(const Self&) ITK_DELETE_FUNCTION;
+  ImportDream3DImageContainer(const Self&) = delete;
+  void operator=(const Self&) = delete;
 };
 } // end namespace itk
 

--- a/Source/SIMPLib/ITK/itkImportDream3DImageContainer.hxx
+++ b/Source/SIMPLib/ITK/itkImportDream3DImageContainer.hxx
@@ -32,75 +32,61 @@
 
 namespace itk
 {
-  template< typename TElementIdentifier, typename TElement >
-  ImportDream3DImageContainer< TElementIdentifier, TElement >
-    ::ImportDream3DImageContainer()
-  {
-  }
+template <typename TElementIdentifier, typename TElement> ImportDream3DImageContainer<TElementIdentifier, TElement>::ImportDream3DImageContainer()
+{
+}
 
-  template< typename TElementIdentifier, typename TElement >
-  ImportDream3DImageContainer< TElementIdentifier, TElement >
-    ::~ImportDream3DImageContainer()
-  {
-    DeallocateManagedMemory();
-  }
+template <typename TElementIdentifier, typename TElement> ImportDream3DImageContainer<TElementIdentifier, TElement>::~ImportDream3DImageContainer()
+{
+  DeallocateManagedMemory();
+}
 
-  template< typename TElementIdentifier, typename TElement >
-  typename ImportDream3DImageContainer< TElementIdentifier, TElement >::Element *
-  ImportDream3DImageContainer< TElementIdentifier, TElement >
-    ::AllocateElements( ElementIdentifier size, bool UseDefaultConstructor ) const
-  {
+template <typename TElementIdentifier, typename TElement>
+typename ImportDream3DImageContainer<TElementIdentifier, TElement>::Element* ImportDream3DImageContainer<TElementIdentifier, TElement>::AllocateElements(ElementIdentifier size,
+                                                                                                                                                         bool UseDefaultConstructor) const
+{
   // Encapsulate all image memory allocation here to throw an
   // exception when memory allocation fails even when the compiler
   // does not do this by default.
-  Element *data;
+  Element* data;
 
   try
+  {
+    data = (Element*)(malloc(sizeof(TElement) * size));
+    if(UseDefaultConstructor)
     {
-    data = (Element*)(malloc( sizeof( TElement ) * size ));
-    if ( UseDefaultConstructor )
-      {
-        new (data)Element();//POD types initialized to 0, others use default constructor.
-      }
+      new(data) Element(); // POD types initialized to 0, others use default constructor.
     }
-  catch ( ... )
-    {
-    data = ITK_NULLPTR;
-    }
-  if ( !data )
-    {
+  } catch(...)
+  {
+    data = nullptr;
+  }
+  if(!data)
+  {
     // We cannot construct an error string here because we may be out
     // of memory.  Do not use the exception macro.
-    throw MemoryAllocationError(__FILE__, __LINE__,
-                                "Failed to allocate memory for image.",
-                                ITK_LOCATION);
-    }
+    throw MemoryAllocationError(__FILE__, __LINE__, "Failed to allocate memory for image.", ITK_LOCATION);
+  }
   return data;
-  }
+}
 
-  template< typename TElementIdentifier, typename TElement >
-  void
-  ImportDream3DImageContainer< TElementIdentifier, TElement >
-    ::DeallocateManagedMemory()
+template <typename TElementIdentifier, typename TElement> void ImportDream3DImageContainer<TElementIdentifier, TElement>::DeallocateManagedMemory()
+{
+  // Encapsulate all image memory deallocation here
+  if(this->GetContainerManageMemory())
   {
-    // Encapsulate all image memory deallocation here
-    if( this->GetContainerManageMemory() )
-    {
-      Element *data = this->GetBufferPointer();
-      data->~Element();
-      free( data );
-      this->SetImportPointer( ITK_NULLPTR );
-    }
-    Superclass::DeallocateManagedMemory();
+    Element* data = this->GetBufferPointer();
+    data->~Element();
+    free(data);
+    this->SetImportPointer(nullptr);
   }
+  Superclass::DeallocateManagedMemory();
+}
 
-  template< typename TElementIdentifier, typename TElement >
-  void
-  ImportDream3DImageContainer< TElementIdentifier, TElement >
-    ::PrintSelf( std::ostream & os, Indent indent ) const
-  {
-    Superclass::PrintSelf( os, indent );
-  }
+template <typename TElementIdentifier, typename TElement> void ImportDream3DImageContainer<TElementIdentifier, TElement>::PrintSelf(std::ostream& os, Indent indent) const
+{
+  Superclass::PrintSelf(os, indent);
+}
 } // end namespace itk
 
 #endif

--- a/Source/SIMPLib/ITK/itkInPlaceDream3DDataToImageFilter.h
+++ b/Source/SIMPLib/ITK/itkInPlaceDream3DDataToImageFilter.h
@@ -48,10 +48,10 @@ protected:
   InPlaceDream3DDataToImageFilter();
   virtual ~InPlaceDream3DDataToImageFilter();
 
-  virtual void VerifyPreconditions() ITK_OVERRIDE;
+  virtual void VerifyPreconditions() override;
 
-  virtual void GenerateOutputInformation() ITK_OVERRIDE;
-  virtual void GenerateData() ITK_OVERRIDE;
+  virtual void GenerateOutputInformation() override;
+  virtual void GenerateData() override;
   DataContainer::Pointer m_DataContainer;
 
 private:

--- a/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.h
+++ b/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.h
@@ -55,11 +55,11 @@ protected:
   InPlaceImageToDream3DDataFilter();
   virtual ~InPlaceImageToDream3DDataFilter();
 
-  virtual void VerifyPreconditions() ITK_OVERRIDE;
+  virtual void VerifyPreconditions() override;
   ProcessObject::DataObjectPointer MakeOutput(ProcessObject::DataObjectPointerArraySizeType) override;
 
-  virtual void GenerateData() ITK_OVERRIDE;
-  virtual void GenerateOutputInformation() ITK_OVERRIDE;
+  virtual void GenerateData() override;
+  virtual void GenerateOutputInformation() override;
 
   void CheckValidArrayPathComponentName(std::string var);
 

--- a/Source/SIMPLib/ITK/itkTransformToDream3DITransformContainer.h
+++ b/Source/SIMPLib/ITK/itkTransformToDream3DITransformContainer.h
@@ -1,0 +1,82 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "itkProcessObject.h"
+#include "itkSimpleDataObjectDecorator.h"
+
+#include "SIMPLib/Geometry/ITransformContainer.h"
+
+namespace itk
+{
+template <typename TParametersValueType, unsigned int CompositeNDimensions> class TransformToDream3DITransformContainer : public ProcessObject
+{
+public:
+  /** Standard class typedefs. */
+  using Self = TransformToDream3DITransformContainer;
+  using Pointer = SmartPointer<Self>;
+  using Superclass = ProcessObject;
+
+  using ITKTransformType = TransformBaseTemplate<TParametersValueType>;
+  using DecoratorType = typename itk::SimpleDataObjectDecorator<::ITransformContainer::Pointer>;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+  itkTypeMacro(TransformToDream3DITransform, ProcessObject);
+
+  virtual void SetInput(const typename ITKTransformType::Pointer& transform);
+  DecoratorType* GetOutput();
+
+protected:
+  TransformToDream3DITransformContainer();
+  virtual ~TransformToDream3DITransformContainer();
+
+  virtual void VerifyPreconditions() override;
+
+  virtual void GenerateData() override;
+  ProcessObject::DataObjectPointer MakeOutput(ProcessObject::DataObjectPointerArraySizeType);
+  typename ITKTransformType::Pointer m_Transform;
+
+private:
+  TransformToDream3DITransformContainer(const TransformToDream3DITransformContainer&) = delete; // Copy Constructor Not Implemented
+  void operator=(const TransformToDream3DITransformContainer&) = delete;                        // Move assignment Not Implemented
+
+  void GenerateData(::ITransformContainer::Pointer& iTransformContainer, const typename ITKTransformType::Pointer& transform);
+  using Superclass::SetInput;
+};
+} // end of itk namespace
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkTransformToDream3DITransformContainer.hxx"
+#endif

--- a/Source/SIMPLib/ITK/itkTransformToDream3DITransformContainer.hxx
+++ b/Source/SIMPLib/ITK/itkTransformToDream3DITransformContainer.hxx
@@ -1,0 +1,140 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "itkTransformToDream3DITransformContainer.h"
+
+#include "itkCompositeTransform.h"
+
+namespace itk
+{
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions> TransformToDream3DITransformContainer<TParametersValueType, CompositeNDimensions>::TransformToDream3DITransformContainer()
+{
+  // Create the output. We use static_cast<> here because we know the default
+  // output must be of type DecoratorType
+  typename DecoratorType::Pointer output = static_cast<DecoratorType*>(this->MakeOutput(0).GetPointer());
+  this->ProcessObject::SetNumberOfRequiredOutputs(1);
+  this->ProcessObject::SetNthOutput(0, output.GetPointer());
+  m_Transform = nullptr;
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+TransformToDream3DITransformContainer<TParametersValueType, CompositeNDimensions>::~TransformToDream3DITransformContainer() = default;
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+void TransformToDream3DITransformContainer<TParametersValueType, CompositeNDimensions>::SetInput(const typename ITKTransformType::Pointer& transform)
+{
+  if(!(transform == m_Transform))
+  {
+    m_Transform = transform;
+    this->Modified();
+  }
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+ProcessObject::DataObjectPointer TransformToDream3DITransformContainer<TParametersValueType, CompositeNDimensions>::MakeOutput(ProcessObject::DataObjectPointerArraySizeType)
+{
+  typename DecoratorType::Pointer output = DecoratorType::New();
+  return output.GetPointer();
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions> void TransformToDream3DITransformContainer<TParametersValueType, CompositeNDimensions>::VerifyPreconditions()
+{
+  if(!m_Transform)
+  {
+    itkExceptionMacro("Input transform is empty");
+  }
+  Superclass::VerifyPreconditions();
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+void TransformToDream3DITransformContainer<TParametersValueType, CompositeNDimensions>::GenerateData(::ITransformContainer::Pointer& iTransformContainer,
+                                                                                                     const typename ITKTransformType::Pointer& transform)
+{
+
+  using CompositeType = itk::CompositeTransform<TParametersValueType, CompositeNDimensions>;
+  typename CompositeType::Pointer itkCompositeTransform = dynamic_cast<CompositeType*>(transform.GetPointer());
+  if(itkCompositeTransform)
+  {
+    typename ::CompositeTransformContainer::Pointer cTransform = ::CompositeTransformContainer::New();
+    for(auto& t : itkCompositeTransform->GetTransformQueue())
+    {
+      typename ::ITransformContainer::Pointer transformContainer;
+      GenerateData(transformContainer, t);
+      cTransform->addTransformContainer(transformContainer);
+    }
+    iTransformContainer = cTransform;
+  }
+  else
+  {
+    ::TransformContainer::Pointer transformContainer = ::TransformContainer::New();
+    auto itkParameters = transform->GetParameters();
+    auto itkFixedParameters = transform->GetFixedParameters();
+
+    typename ::TransformContainer::TransformParametersType dream3DParameters(itkParameters.size());
+    typename ::TransformContainer::TransformFixedParametersType dream3DFixedParameters(itkFixedParameters.size());
+
+    for(size_t p = 0; p < itkParameters.size(); p++)
+    {
+      dream3DParameters[p] = static_cast<typename ::TransformContainer::ParametersValueType>(itkParameters[p]);
+    }
+    for(size_t p = 0; p < itkFixedParameters.size(); p++)
+    {
+      dream3DFixedParameters[p] = static_cast<typename ::TransformContainer::ParametersValueType>(itkFixedParameters[p]);
+    }
+
+    transformContainer->setParameters(dream3DParameters);
+    transformContainer->setFixedParameters(dream3DFixedParameters);
+    transformContainer->setTransformTypeAsString(transform->GetTransformTypeAsString());
+    iTransformContainer = transformContainer;
+  }
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions> void TransformToDream3DITransformContainer<TParametersValueType, CompositeNDimensions>::GenerateData()
+{
+  DecoratorType* outputPtr = this->GetOutput();
+  typename ::ITransformContainer::Pointer iTransformContainer;
+  this->GenerateData(iTransformContainer, m_Transform);
+  outputPtr->Set(iTransformContainer);
+}
+
+template <typename TParametersValueType, unsigned int CompositeNDimensions>
+typename TransformToDream3DITransformContainer<TParametersValueType, CompositeNDimensions>::DecoratorType*
+TransformToDream3DITransformContainer<TParametersValueType, CompositeNDimensions>::GetOutput()
+{
+  return itkDynamicCastInDebugMode<DecoratorType*>(this->GetPrimaryOutput());
+}
+
+} // end of itk namespace

--- a/Source/SIMPLib/ITK/itkTransformToDream3DTransformContainer.h
+++ b/Source/SIMPLib/ITK/itkTransformToDream3DTransformContainer.h
@@ -1,0 +1,79 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "itkProcessObject.h"
+#include "itkSimpleDataObjectDecorator.h"
+
+#include "SIMPLib/Geometry/TransformContainer.h"
+
+namespace itk
+{
+template <typename ITKTransformType> class TransformToDream3DTransformContainer : public ProcessObject
+{
+public:
+  /** Standard class typedefs. */
+  using Self = TransformToDream3DTransformContainer;
+  using Pointer = SmartPointer<Self>;
+  using Superclass = ProcessObject;
+
+  using DecoratorType = typename itk::SimpleDataObjectDecorator<::TransformContainer::Pointer>;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+  itkTypeMacro(TransformToDream3DTransformContainer, ProcessObject);
+
+  virtual void SetInput(const typename ITKTransformType::Pointer& transform);
+  DecoratorType* GetOutput();
+
+protected:
+  TransformToDream3DTransformContainer();
+  virtual ~TransformToDream3DTransformContainer();
+
+  virtual void VerifyPreconditions() override;
+
+  virtual void GenerateData() override;
+  ProcessObject::DataObjectPointer MakeOutput(ProcessObject::DataObjectPointerArraySizeType);
+  typename ITKTransformType::Pointer m_Transform;
+
+private:
+  TransformToDream3DTransformContainer(const TransformToDream3DTransformContainer&) = delete; // Copy Constructor Not Implemented
+  void operator=(const TransformToDream3DTransformContainer&) = delete;                       // Move assignment Not Implemented
+  using Superclass::SetInput;
+};
+} // end of itk namespace
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkTransformToDream3DTransformContainer.hxx"
+#endif

--- a/Source/SIMPLib/ITK/itkTransformToDream3DTransformContainer.hxx
+++ b/Source/SIMPLib/ITK/itkTransformToDream3DTransformContainer.hxx
@@ -1,0 +1,109 @@
+/* ============================================================================
+* Copyright (c) 2009-2018 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-15-D-5231
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "itkTransformToDream3DTransformContainer.h"
+
+namespace itk
+{
+
+template <typename ITKTransformType> TransformToDream3DTransformContainer<ITKTransformType>::TransformToDream3DTransformContainer()
+{
+  // Create the output. We use static_cast<> here because we know the default
+  // output must be of type DecoratorType
+  typename DecoratorType::Pointer output = static_cast<DecoratorType*>(this->MakeOutput(0).GetPointer());
+  this->ProcessObject::SetNumberOfRequiredOutputs(1);
+  this->ProcessObject::SetNthOutput(0, output.GetPointer());
+  m_Transform = nullptr;
+}
+
+template <typename ITKTransformType> TransformToDream3DTransformContainer<ITKTransformType>::~TransformToDream3DTransformContainer() = default;
+
+template <typename ITKTransformType> void TransformToDream3DTransformContainer<ITKTransformType>::SetInput(const typename ITKTransformType::Pointer& transform)
+{
+  if(!(transform == m_Transform))
+  {
+    m_Transform = transform;
+    this->Modified();
+  }
+}
+
+template <typename ITKTransformType> ProcessObject::DataObjectPointer TransformToDream3DTransformContainer<ITKTransformType>::MakeOutput(ProcessObject::DataObjectPointerArraySizeType)
+{
+  typename DecoratorType::Pointer output = DecoratorType::New();
+  ::TransformContainer::Pointer transformContainer = ::TransformContainer::New();
+  output->Set(transformContainer);
+  return output.GetPointer();
+}
+
+template <typename ITKTransformType> void TransformToDream3DTransformContainer<ITKTransformType>::VerifyPreconditions()
+{
+  if(!m_Transform)
+  {
+    itkExceptionMacro("Input transform is empty");
+  }
+  Superclass::VerifyPreconditions();
+}
+
+template <typename ITKTransformType> void TransformToDream3DTransformContainer<ITKTransformType>::GenerateData()
+{
+  DecoratorType* outputPtr = this->GetOutput();
+  typename ::TransformContainer::Pointer transformContainer = outputPtr->Get();
+
+  auto itkParameters = m_Transform->GetParameters();
+  auto itkFixedParameters = m_Transform->GetFixedParameters();
+
+  typename ::TransformContainer::TransformParametersType dream3DParameters(itkParameters.size());
+  typename ::TransformContainer::TransformFixedParametersType dream3DFixedParameters(itkFixedParameters.size());
+
+  for(size_t p = 0; p < itkParameters.size(); p++)
+  {
+    dream3DParameters[p] = static_cast<typename ::TransformContainer::ParametersValueType>(itkParameters[p]);
+  }
+  for(size_t p = 0; p < itkFixedParameters.size(); p++)
+  {
+    dream3DFixedParameters[p] = static_cast<typename ::TransformContainer::ParametersValueType>(itkFixedParameters[p]);
+  }
+
+  transformContainer->setParameters(dream3DParameters);
+  transformContainer->setFixedParameters(dream3DFixedParameters);
+  transformContainer->setTransformTypeAsString(m_Transform->GetTransformTypeAsString());
+}
+
+template <typename ITKTransformType> typename TransformToDream3DTransformContainer<ITKTransformType>::DecoratorType* TransformToDream3DTransformContainer<ITKTransformType>::GetOutput()
+{
+  return itkDynamicCastInDebugMode<DecoratorType*>(this->GetPrimaryOutput());
+}
+
+} // end of itk namespace

--- a/Source/SIMPLib/Testing/CMakeLists.txt
+++ b/Source/SIMPLib/Testing/CMakeLists.txt
@@ -37,8 +37,6 @@ set(QT_APPLICATION_CLASS "QCoreApplication")
 configure_file(${SIMPLTest_SOURCE_DIR}/TestMain.cpp.in
           ${SIMPLTest_BINARY_DIR}/SIMPLUnitTest.cpp @ONLY)
 
-
-
 # Set the source files properties on each source file.
 foreach(f ${${SIMPL_UNIT_TEST}_TEST_SRCS})
   set_source_files_properties( ${f} PROPERTIES HEADER_FILE_ONLY TRUE)
@@ -47,7 +45,7 @@ endforeach()
 AddSIMPLUnitTest(TESTNAME SIMPLUnitTest
   SOURCES ${SIMPLTest_BINARY_DIR}/SIMPLUnitTest.cpp ${${SIMPL_UNIT_TEST}_TEST_SRCS}
   FOLDER "SIMPLibProj/Test"
-  LINK_LIBRARIES Qt5::Core H5Support SIMPLib
+  LINK_LIBRARIES Qt5::Core H5Support SIMPLib ${ITK_LIBRARIES}
   INCLUDE_DIRS 
 			${${PLUGIN_NAME}Test_SOURCE_DIR}
 			${${PLUGIN_NAME}Test_BINARY_DIR}


### PR DESCRIPTION
Transforms are added a part of the geomtry object.
Transforms can be simple transforms objects. They contain the following
data:
-Parameters: Parameters describing the transform.
-FixedParameters: Additional parameters, such as the center of rotation.
-TransformTypeAsString: String describing the transform type and its parameters types.
-MovingName: String saving the moving space name.
-ReferenceName: String saving the target space name.

Transforms are saved as part of the DREAM3D HDF5 file.