### PR TITLE
Fixed crash on removing a filter from the pipeline view

### DIFF
--- a/Source/SIMPLib/Filtering/AbstractFilter.cpp
+++ b/Source/SIMPLib/Filtering/AbstractFilter.cpp
@@ -52,6 +52,7 @@ AbstractFilter::AbstractFilter()
 , m_WarningCondition(0)
 , m_InPreflight(false)
 , m_Enabled(true)
+, m_Removing(false)
 , m_PipelineIndex(0)
 , m_Cancel(false)
 

--- a/Source/SIMPLib/Filtering/AbstractFilter.h
+++ b/Source/SIMPLib/Filtering/AbstractFilter.h
@@ -72,6 +72,7 @@ class SIMPLib_EXPORT AbstractFilter : public Observable
   Q_PROPERTY(QString CompiledLibraryName READ getCompiledLibraryName CONSTANT)
   Q_PROPERTY(int Cancel READ getCancel WRITE setCancel)
   Q_PROPERTY(bool Enabled READ getEnabled WRITE setEnabled)
+  Q_PROPERTY(bool Removing READ getRemoving WRITE setRemoving)
   
   // This line MUST be first when exposing a class and properties to Python
   PYB11_CREATE_BINDINGS(AbstractFilter)
@@ -247,6 +248,8 @@ public:
   SIMPL_INSTANCE_PROPERTY(bool, InPreflight)
 
   SIMPL_INSTANCE_PROPERTY(bool, Enabled)
+
+  SIMPL_INSTANCE_PROPERTY(bool, Removing)
 
   // ------------------------------
   // These functions allow interogating the position the filter is in the pipeline and the previous and next filters

--- a/Source/SVWidgetsLib/Widgets/PipelineModel.cpp
+++ b/Source/SVWidgetsLib/Widgets/PipelineModel.cpp
@@ -452,6 +452,11 @@ bool PipelineModel::insertRows(int position, int rows, const QModelIndex& parent
 // -----------------------------------------------------------------------------
 bool PipelineModel::removeRows(int position, int rows, const QModelIndex& parent)
 {
+  if(position < 0)
+  {
+    return false;
+  }
+
   PipelineItem* parentItem = getItem(parent);
   bool success = true;
 

--- a/Source/SVWidgetsLib/Widgets/util/RemoveFilterCommand.cpp
+++ b/Source/SVWidgetsLib/Widgets/util/RemoveFilterCommand.cpp
@@ -187,6 +187,8 @@ void RemoveFilterCommand::redo()
 // -----------------------------------------------------------------------------
 void RemoveFilterCommand::addFilter(AbstractFilter::Pointer filter, int insertionIndex)
 {
+  filter->setRemoving(false);
+
   PipelineModel* model = m_PipelineView->getPipelineModel();
 
   model->insertRow(insertionIndex);
@@ -216,6 +218,14 @@ void RemoveFilterCommand::addFilter(AbstractFilter::Pointer filter, int insertio
 // -----------------------------------------------------------------------------
 void RemoveFilterCommand::removeFilter(AbstractFilter::Pointer filter)
 {
+  // Check if the given filter is already being removed before removing it again
+  // Multiple calls to remove the same object causes crashes.
+  if(filter->getRemoving())
+  {
+    return;
+  }
+  filter->setRemoving(true);
+
   PipelineModel* model = m_PipelineView->getPipelineModel();
 
   disconnectFilterSignalsSlots(filter);


### PR DESCRIPTION
* Added the Remove property to AbstractFilter.

* RemoveFilterCommand now applies and checks the filter's Remove property before forming lambda connections responsible for removing the filter.

* PipelineModel now checks the position value in the removeRows method before removing the item.  If the position is invalid, the item is not removed to avoid crashing the application.

fixes #219 