### PR TITLE
Feature/Import HDF5 Datasets with Component Dimensions

### DIFF
--- a/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.cpp
@@ -759,6 +759,7 @@ herr_t ImportHDF5DatasetWidget::updateComponentDimensions(const QString& path)
     if(am != nullptr)
     {
       QVector<size_t> amTupleDims = am->getTupleDimensions();
+      int fileDimsSize = fileDims.size();
 
       //      // Calculate the prime factors of the attribute matrix tuple dimensions
       //      QVector<int> amTupleDimsPFs;
@@ -801,12 +802,120 @@ herr_t ImportHDF5DatasetWidget::updateComponentDimensions(const QString& path)
         cDimsLE->setText(cDimsStr);
         m_ComponentDimsMap.insert(path, cDimsStr);
       }
+      else if(fileDimsSize == amTupleDims.size() && amTupleDims.size() != 0)
+      {
+        // If no dimensions remain, and the starting dimension sizes were the same, set component dimension to 1
+        QString cDimsStr = QString::number(1);
+        m_ComponentDimsMap.insert(path, cDimsStr);
+        cDimsLE->setText(cDimsStr);
+      }
     }
 
     QH5Utilities::closeHDF5Object(parentLoc);
   }
 
   return err;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+std::tuple<herr_t, QString> ImportHDF5DatasetWidget::bestGuessCDims(const QString& path)
+{
+  herr_t err = 0;
+  QString cDimsStr = "";
+  QString objName = QH5Utilities::extractObjectName(path);
+
+  if(m_FileId < 0)
+  {
+    std::cout << "Error: FileId is Invalid: " << m_FileId << std::endl;
+    return std::make_tuple(m_FileId, cDimsStr);
+  }
+
+  // Test for Dataset Existance
+  H5O_info_t statbuf;
+  err = H5Oget_info_by_name(m_FileId, path.toStdString().c_str(), &statbuf, H5P_DEFAULT);
+  if(err < 0)
+  {
+    std::cout << "Data Set Does NOT exist at Path given: FileId: " << m_FileId << std::endl;
+    return std::make_tuple(err, cDimsStr);
+  }
+
+  QString parentPath = "";
+  if(path == "/")
+  {
+    parentPath = path;
+  }
+  else
+  {
+    parentPath = QH5Utilities::getParentPath(path);
+  }
+
+  hid_t parentLoc = QH5Utilities::openHDF5Object(m_FileId, parentPath);
+
+  QVector<hsize_t> fileDims;
+  H5T_class_t type_class;
+  size_t type_size;
+  QH5Lite::getDatasetInfo(parentLoc, objName, fileDims, type_class, type_size);
+
+  DataArrayPath amPath = m_Filter->getSelectedAttributeMatrix();
+  AttributeMatrix::Pointer am = m_Filter->getDataContainerArray()->getAttributeMatrix(amPath);
+  if(am != nullptr)
+  {
+    QVector<size_t> amTupleDims = am->getTupleDimensions();
+    int fileDimsSize = fileDims.size();
+
+    //      // Calculate the prime factors of the attribute matrix tuple dimensions
+    //      QVector<int> amTupleDimsPFs;
+    //      for (int i = 0; i < amTupleDims.size(); i++)
+    //      {
+    //        calculatePrimeFactors(amTupleDims[i], amTupleDimsPFs);
+    //      }
+
+    //      // Calculate the prime factors of the file dimensions
+    //      QVector<int> fileDimsPFs;
+    //      for (int i = 0; i < fileDims.size(); i++)
+    //      {
+    //        calculatePrimeFactors(fileDims[i], fileDimsPFs);
+    //      }
+
+    // If an attribute matrix tuple dimensions prime factor exists in the file dimensions prime factor list, remove it.
+    for(int i = 0; i < amTupleDims.size(); i++)
+    {
+      int amTupleDim = amTupleDims[i];
+      if(fileDims.contains(amTupleDim))
+      {
+        fileDims.removeOne(amTupleDim);
+      }
+      else
+      {
+        QH5Utilities::closeHDF5Object(parentLoc);
+        return std::make_tuple(-1, "");
+      }
+    }
+
+    if(fileDims.size() > 0)
+    {
+      cDimsStr = QString::number(fileDims[0]);
+      for(int i = 1; i < fileDims.size(); i++)
+      {
+        cDimsStr.append(", ");
+        cDimsStr.append(QString::number(fileDims[i]));
+      }
+
+      m_ComponentDimsMap.insert(path, cDimsStr);
+    }
+    else if(fileDimsSize == amTupleDims.size() && amTupleDims.size() != 0)
+    {
+      // If no dimensions remain, and the starting dimension sizes were the same, set component dimension to 1
+      cDimsStr = QString::number(1);
+      m_ComponentDimsMap.insert(path, cDimsStr);
+    }
+  }
+
+  QH5Utilities::closeHDF5Object(parentLoc);
+
+  return std::make_tuple(err, cDimsStr);
 }
 
 // -----------------------------------------------------------------------------
@@ -876,6 +985,23 @@ void ImportHDF5DatasetWidget::beforePreflight()
     {
       QModelIndex index = treeModel->hdf5PathToIndex(m_CurrentPathsWithErrors[i]);
       treeModel->setData(index, false, ImportHDF5TreeModel::Roles::HasErrorsRole);
+    }
+
+    // Check for unspecified component dimensions and fill it in with the best guess
+    QStringList selectedPaths = treeModel->getSelectedHDF5Paths();
+    for(QString selectedPath : selectedPaths)
+    {
+      if(false == m_ComponentDimsMap.contains(selectedPath))
+      {
+        herr_t err;
+        QString bestCDimGuess;
+        std::tie(err, bestCDimGuess) = bestGuessCDims(selectedPath);
+
+        if(!bestCDimGuess.isEmpty() && !err)
+        {
+          m_ComponentDimsMap[selectedPath] = bestCDimGuess;
+        }
+      }
     }
   }
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.h
@@ -122,6 +122,13 @@ protected:
    */
   bool initWithFile(QString hdf5File);
 
+  /**
+  * @brief Returns the best guess at component dimensions for the given path.  This requires a valid AttributeMatrix, ImageGeometry, and HDF5 path
+  * @param path
+  * @return
+  */
+  std::tuple<herr_t, QString> bestGuessCDims(const QString& path);
+
 protected slots:
   void on_cDimsLE_valueChanged(QString text);
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/ImportHDF5DatasetWidget.ui
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/ImportHDF5DatasetWidget.ui
@@ -168,7 +168,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QTabWidget" name="importHDF5DatasetTabWidget">
+        <widget class="SVTabWidget" name="importHDF5DatasetTabWidget">
          <property name="currentIndex">
           <number>0</number>
          </property>
@@ -297,6 +297,12 @@
    <class>QtSStringEdit</class>
    <extends>QWidget</extends>
    <header>QtSStringEdit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>SVTabWidget</class>
+   <extends>QTabWidget</extends>
+   <header location="global">SVControlWidgets.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/ImportHDF5DatasetWidget.ui
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/ImportHDF5DatasetWidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0">
    <property name="leftMargin">
     <number>3</number>
    </property>
@@ -114,165 +114,198 @@
     </layout>
    </item>
    <item>
-    <widget class="QSplitter" name="splitter">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <widget class="SVTreeView" name="hdfTreeView">
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>0</height>
-       </size>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>1</number>
       </property>
-      <property name="maximumSize">
-       <size>
-        <width>65654</width>
-        <height>16777215</height>
-       </size>
+      <property name="topMargin">
+       <number>1</number>
       </property>
-      <property name="mouseTracking">
-       <bool>true</bool>
+      <property name="rightMargin">
+       <number>1</number>
       </property>
-      <property name="contextMenuPolicy">
-       <enum>Qt::ActionsContextMenu</enum>
+      <property name="bottomMargin">
+       <number>1</number>
       </property>
-      <property name="editTriggers">
-       <set>QAbstractItemView::EditKeyPressed</set>
+      <property name="spacing">
+       <number>4</number>
       </property>
-      <property name="alternatingRowColors">
-       <bool>true</bool>
-      </property>
-      <property name="verticalScrollMode">
-       <enum>QAbstractItemView::ScrollPerPixel</enum>
-      </property>
-      <property name="horizontalScrollMode">
-       <enum>QAbstractItemView::ScrollPerPixel</enum>
-      </property>
-      <property name="uniformRowHeights">
-       <bool>true</bool>
-      </property>
-      <property name="animated">
-       <bool>false</bool>
-      </property>
-      <property name="headerHidden">
-       <bool>true</bool>
-      </property>
-     </widget>
-     <widget class="QWidget" name="verticalLayoutWidget">
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="spacing">
-        <number>3</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="SVTabWidget" name="importHDF5DatasetTabWidget">
-         <property name="currentIndex">
-          <number>0</number>
+      <item row="0" column="0">
+       <widget class="QSplitter" name="splitter">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <widget class="SVTreeView" name="hdfTreeView">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
          </property>
-         <widget class="QWidget" name="general_tab">
-          <attribute name="title">
-           <string>General</string>
-          </attribute>
-          <layout class="QGridLayout">
-           <property name="leftMargin">
-            <number>1</number>
-           </property>
-           <property name="topMargin">
-            <number>1</number>
-           </property>
-           <property name="rightMargin">
-            <number>1</number>
-           </property>
-           <property name="bottomMargin">
-            <number>1</number>
-           </property>
-           <item row="0" column="0">
-            <widget class="QTableWidget" name="generalTable">
-             <property name="editTriggers">
-              <set>QAbstractItemView::NoEditTriggers</set>
-             </property>
-             <property name="alternatingRowColors">
-              <bool>true</bool>
-             </property>
-             <property name="cornerButtonEnabled">
-              <bool>false</bool>
-             </property>
-             <property name="columnCount">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="attributes_tab">
-          <attribute name="title">
-           <string>Attributes</string>
-          </attribute>
-          <layout class="QGridLayout" name="_2">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item row="0" column="0">
-            <widget class="QTableWidget" name="attributesTable">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>100</height>
-              </size>
-             </property>
-             <property name="alternatingRowColors">
-              <bool>true</bool>
-             </property>
-             <property name="verticalScrollMode">
-              <enum>QAbstractItemView::ScrollPerPixel</enum>
-             </property>
-             <property name="horizontalScrollMode">
-              <enum>QAbstractItemView::ScrollPerPixel</enum>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
+         <property name="maximumSize">
+          <size>
+           <width>65654</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="mouseTracking">
+          <bool>true</bool>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::ActionsContextMenu</enum>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::EditKeyPressed</set>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="verticalScrollMode">
+          <enum>QAbstractItemView::ScrollPerPixel</enum>
+         </property>
+         <property name="horizontalScrollMode">
+          <enum>QAbstractItemView::ScrollPerPixel</enum>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
+         <property name="animated">
+          <bool>false</bool>
+         </property>
+         <property name="headerHidden">
+          <bool>true</bool>
+         </property>
         </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="cDimsLabel">
-           <property name="text">
-            <string>Component Dimensions</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QtSStringEdit" name="cDimsLE" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
+        <widget class="QWidget" name="verticalLayoutWidget">
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <property name="spacing">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="SVTabWidget" name="importHDF5DatasetTabWidget">
+            <property name="currentIndex">
+             <number>0</number>
+            </property>
+            <widget class="QWidget" name="general_tab">
+             <attribute name="title">
+              <string>General</string>
+             </attribute>
+             <layout class="QGridLayout">
+              <property name="leftMargin">
+               <number>1</number>
+              </property>
+              <property name="topMargin">
+               <number>1</number>
+              </property>
+              <property name="rightMargin">
+               <number>1</number>
+              </property>
+              <property name="bottomMargin">
+               <number>1</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QTableWidget" name="generalTable">
+                <property name="editTriggers">
+                 <set>QAbstractItemView::NoEditTriggers</set>
+                </property>
+                <property name="alternatingRowColors">
+                 <bool>true</bool>
+                </property>
+                <property name="cornerButtonEnabled">
+                 <bool>false</bool>
+                </property>
+                <property name="columnCount">
+                 <number>0</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="attributes_tab">
+             <attribute name="title">
+              <string>Attributes</string>
+             </attribute>
+             <layout class="QGridLayout" name="_2">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QTableWidget" name="attributesTable">
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>100</height>
+                 </size>
+                </property>
+                <property name="alternatingRowColors">
+                 <bool>true</bool>
+                </property>
+                <property name="verticalScrollMode">
+                 <enum>QAbstractItemView::ScrollPerPixel</enum>
+                </property>
+                <property name="horizontalScrollMode">
+                 <enum>QAbstractItemView::ScrollPerPixel</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="cDimsLabel">
+              <property name="text">
+               <string>Component Dimensions</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QtSStringEdit" name="cDimsLE" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/Source/SVWidgetsLib/Widgets/SVControlWidgets.cpp
+++ b/Source/SVWidgetsLib/Widgets/SVControlWidgets.cpp
@@ -127,3 +127,14 @@ QTreeWidget(parent)
 }
 
 SVTreeWidget::~SVTreeWidget() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+SVTabWidget::SVTabWidget(QWidget* parent) :
+  QTabWidget(parent)
+{
+  setAttribute(Qt::WA_MacShowFocusRect, false);
+}
+
+SVTabWidget::~SVTabWidget() = default;

--- a/Source/SVWidgetsLib/Widgets/SVControlWidgets.h
+++ b/Source/SVWidgetsLib/Widgets/SVControlWidgets.h
@@ -170,3 +170,15 @@ class SVWidgetsLib_EXPORT SVTreeWidget : public QTreeWidget
 
 };
 
+/**
+* @brief The SVTabWidget class
+*/
+class SVWidgetsLib_EXPORT SVTabWidget : public QTabWidget
+{
+  Q_OBJECT
+
+public:
+  SVTabWidget(QWidget* parent = nullptr);
+  virtual ~SVTabWidget();
+
+};


### PR DESCRIPTION
* Improved Import HDF5 Dataset's best guess for cases the target DataArray should only be one component.  If the component dimensions cannot be found, none are assigned.

* Import HDF5 Dataset now performs the best guess during beforePreflight() for items where the component dimension map is missing dimensions.

* Added a border around Import HDF5 Dataset's hdfTreeView and importHDF5DatasetTabWidget.  Created a QTabWidget subclass to fine-tune the styling for importHDF5DatasetTabWidget.