### PR TITLE
Import ASCII Data Import Wizard resets data types when "Start Import at Row" is changed. #253

### DIFF
--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.cpp
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.cpp
@@ -691,7 +691,7 @@ void DataFormatPage::on_startRowSpin_valueChanged(int value)
 
   wizard()->button(QWizard::FinishButton)->setEnabled(true);
 
-  m_ASCIIDataModel->clear();
+  m_ASCIIDataModel->clearContents();
 
   bool tabAsDelimiter = field("tabAsDelimiter").toBool();
   bool semicolonAsDelimiter = field("semicolonAsDelimiter").toBool();


### PR DESCRIPTION
Fixing bug where changing "Start Import at Row" resets the data types in the Import ASCII Data wizard.