### PR TITLE
Feature/hdf5_10

### DIFF
--- a/Source/H5Support/CMakeLists.txt
+++ b/Source/H5Support/CMakeLists.txt
@@ -170,7 +170,7 @@ TARGET_INCLUDE_DIRECTORIES( ${PROJECT_NAME} PUBLIC
 
 if(BUILD_SHARED_LIBS)
   if(WIN32)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC "-DH5Support_BUILT_AS_DYNAMIC_LIB -DH5_USE_18_API")
+    target_compile_definitions(${PROJECT_NAME} PUBLIC "-DH5Support_BUILT_AS_DYNAMIC_LIB")
   endif(WIN32)
 endif(BUILD_SHARED_LIBS)
 target_link_libraries(${PROJECT_NAME} ${HDF5_C_TARGET_NAME} Qt5::Core )

--- a/Source/H5Support/CMakeLists.txt
+++ b/Source/H5Support/CMakeLists.txt
@@ -170,7 +170,7 @@ TARGET_INCLUDE_DIRECTORIES( ${PROJECT_NAME} PUBLIC
 
 if(BUILD_SHARED_LIBS)
   if(WIN32)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC "-DH5Support_BUILT_AS_DYNAMIC_LIB")
+    target_compile_definitions(${PROJECT_NAME} PUBLIC "-DH5Support_BUILT_AS_DYNAMIC_LIB -DH5_USE_18_API")
   endif(WIN32)
 endif(BUILD_SHARED_LIBS)
 target_link_libraries(${PROJECT_NAME} ${HDF5_C_TARGET_NAME} Qt5::Core )

--- a/Source/H5Support/H5Lite.cpp
+++ b/Source/H5Support/H5Lite.cpp
@@ -138,7 +138,7 @@ void H5Lite::disableErrorHandlers()
 // -----------------------------------------------------------------------------
 //  Opens an ID for HDF5 operations
 // -----------------------------------------------------------------------------
-herr_t H5Lite::openId(hid_t loc_id, const std::string& obj_name, H5O_type_t obj_type)
+hid_t H5Lite::openId(hid_t loc_id, const std::string& obj_name, H5O_type_t obj_type)
 {
   H5SUPPORT_MUTEX_LOCK()
 
@@ -451,7 +451,8 @@ herr_t H5Lite::writeStringDataset(hid_t loc_id, const std::string& dsetName, siz
           }
           else
           {
-            retErr = did;
+            //retErr = did;
+            retErr = 0;
           }
           CloseH5D(did, err, retErr);
         }
@@ -570,7 +571,8 @@ herr_t H5Lite::writeStringDataset(hid_t loc_id, const std::string& dsetName, con
           }
           else
           {
-            retErr = did;
+            //retErr = did;
+            retErr = 0;
           }
           CloseH5D(did, err, retErr);
           //          err = H5Dclose(did);
@@ -661,7 +663,7 @@ hsize_t H5Lite::getNumberOfElements(hid_t loc_id, const std::string& dsetName)
     else
     {
       std::cout << "Error Opening SpaceID" << std::endl;
-      retErr = spaceId;
+      //retErr = spaceId;
     }
     err = H5Dclose(did);
     if(err < 0)
@@ -758,7 +760,7 @@ herr_t H5Lite::writeStringAttribute(hid_t loc_id, const std::string& objName, co
       }
       else
       {
-        retErr = attr_type;
+        //retErr = attr_type;
       }
       /* Close the object */
       err = H5Lite::closeId(obj_id, statbuf.type);
@@ -1032,7 +1034,7 @@ herr_t H5Lite::readStringAttribute(hid_t loc_id, const std::string& objName, con
     }
     else
     {
-      retErr = attr_id;
+      //retErr = attr_id;
     }
     err = H5Lite::closeId(obj_id, statbuf.type);
     if(err < 0)
@@ -1091,7 +1093,7 @@ herr_t H5Lite::readStringAttribute(hid_t loc_id, const std::string& objName, con
     }
     else
     {
-      retErr = attr_id;
+      //retErr = attr_id;
     }
     err = H5Lite::closeId(obj_id, statbuf.type);
     if(err < 0)
@@ -1132,7 +1134,7 @@ herr_t H5Lite::getDatasetNDims(hid_t loc_id, const std::string& dsetName, hid_t&
     rank = H5Sget_simple_extent_ndims(sid);
     if(rank < 0)
     {
-      retErr = rank;
+      //retErr = rank;
       rank = 0;
       std::cout << "Error Getting the rank of the dataset:" << std::endl;
     }
@@ -1189,7 +1191,7 @@ herr_t H5Lite::getAttributeNDims(hid_t loc_id, const std::string& objName, const
     }
     else
     {
-      retErr = attr_id;
+      //retErr = attr_id;
     }
     err = H5Lite::closeId(obj_id, statbuf.type);
     if(err < 0)

--- a/Source/H5Support/H5Lite.h
+++ b/Source/H5Support/H5Lite.h
@@ -77,7 +77,7 @@ namespace H5Support_NAMESPACE
        * @param obj_type The HDF5_TYPE of object
        * @return Standard HDF5 Error Conditions
        */
-      static H5Support_EXPORT herr_t openId( hid_t loc_id, const std::string& obj_name, H5O_type_t obj_type);
+      static H5Support_EXPORT hid_t openId( hid_t loc_id, const std::string& obj_name, H5O_type_t obj_type);
 
       /**
        * @brief Opens an HDF5 Object

--- a/Source/H5Support/H5Utilities.cpp
+++ b/Source/H5Support/H5Utilities.cpp
@@ -395,7 +395,7 @@ hid_t H5Utilities::createGroup(hid_t loc_id, const std::string& group)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-int32_t H5Utilities::createGroupsForDataset(const std::string& datasetPath, hid_t parent)
+hid_t H5Utilities::createGroupsForDataset(const std::string& datasetPath, hid_t parent)
 {
   H5SUPPORT_MUTEX_LOCK()
 
@@ -415,7 +415,7 @@ int32_t H5Utilities::createGroupsForDataset(const std::string& datasetPath, hid_
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-int32_t H5Utilities::createGroupsFromPath(const std::string& pathToCheck, hid_t parent)
+hid_t H5Utilities::createGroupsFromPath(const std::string& pathToCheck, hid_t parent)
 {
   H5SUPPORT_MUTEX_LOCK()
 
@@ -580,7 +580,7 @@ herr_t H5Utilities::getAllAttributeNames(hid_t loc_id, const std::string& obj_na
   obj_id = openHDF5Object(loc_id, obj_name);
   if(obj_id < 0)
   {
-    return obj_id;
+    return static_cast<herr_t>(obj_id);
   }
   err = getAllAttributeNames(obj_id, names);
   err = closeHDF5Object(obj_id);

--- a/Source/H5Support/H5Utilities.h
+++ b/Source/H5Support/H5Utilities.h
@@ -169,7 +169,7 @@ namespace H5Support_NAMESPACE
        * @param parent The HDF unique id for the parent
        * @return Error Condition: Negative is error. Positive is success.
        */
-      static H5Support_EXPORT herr_t  createGroupsFromPath(const std::string& pathToCheck, hid_t parent);
+      static H5Support_EXPORT hid_t  createGroupsFromPath(const std::string& pathToCheck, hid_t parent);
 
       /**
        * @brief Given a path relative to the Parent ID, this method will create all
@@ -178,7 +178,7 @@ namespace H5Support_NAMESPACE
        * @param parent The HDF unique id for the parent
        * @return Error Condition: Negative is error. Positive is success.
        */
-      static H5Support_EXPORT herr_t createGroupsForDataset(const std::string& datasetPath, hid_t parent);
+      static H5Support_EXPORT hid_t createGroupsForDataset(const std::string& datasetPath, hid_t parent);
 
       /**
       * @brief Extracts the object name from a given path

--- a/Source/H5Support/QH5Lite.cpp
+++ b/Source/H5Support/QH5Lite.cpp
@@ -343,7 +343,7 @@ herr_t QH5Lite::readStringAttribute(hid_t loc_id, const QString& objName, const 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-hid_t QH5Lite::getDatasetNDims(hid_t loc_id, const QString& dsetName, hid_t& rank)
+herr_t QH5Lite::getDatasetNDims(hid_t loc_id, const QString& dsetName, hid_t& rank)
 {
   return H5Lite::getDatasetNDims(loc_id, dsetName.toStdString(), rank);
 }
@@ -351,7 +351,7 @@ hid_t QH5Lite::getDatasetNDims(hid_t loc_id, const QString& dsetName, hid_t& ran
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-hid_t QH5Lite::getAttributeNDims(hid_t loc_id, const QString& objName, const QString& attrName, hid_t& rank)
+herr_t QH5Lite::getAttributeNDims(hid_t loc_id, const QString& objName, const QString& attrName, hid_t& rank)
 {
   return H5Lite::getAttributeNDims(loc_id, objName.toStdString(), attrName.toStdString(), rank);
 }

--- a/Source/H5Support/QH5Lite.cpp
+++ b/Source/H5Support/QH5Lite.cpp
@@ -343,7 +343,7 @@ herr_t QH5Lite::readStringAttribute(hid_t loc_id, const QString& objName, const 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-herr_t QH5Lite::getDatasetNDims(hid_t loc_id, const QString& dsetName, hid_t& rank)
+hid_t QH5Lite::getDatasetNDims(hid_t loc_id, const QString& dsetName, hid_t& rank)
 {
   return H5Lite::getDatasetNDims(loc_id, dsetName.toStdString(), rank);
 }

--- a/Source/H5Support/QH5Lite.cpp
+++ b/Source/H5Support/QH5Lite.cpp
@@ -65,7 +65,7 @@ void QH5Lite::disableErrorHandlers()
 // -----------------------------------------------------------------------------
 //  Opens an ID for HDF5 operations
 // -----------------------------------------------------------------------------
-herr_t QH5Lite::openId(hid_t loc_id, const QString& obj_name, H5O_type_t obj_type)
+hid_t QH5Lite::openId(hid_t loc_id, const QString& obj_name, H5O_type_t obj_type)
 {
   return H5Lite::openId(loc_id, obj_name.toStdString(), obj_type);
 }

--- a/Source/H5Support/QH5Lite.h
+++ b/Source/H5Support/QH5Lite.h
@@ -92,7 +92,7 @@ namespace H5Support_NAMESPACE
        * @param obj_type The HDF5_TYPE of object
        * @return Standard HDF5 Error Conditions
        */
-      static H5Support_EXPORT herr_t openId(hid_t loc_id, const QString& obj_name, H5O_type_t obj_type);
+      static H5Support_EXPORT hid_t openId(hid_t loc_id, const QString& obj_name, H5O_type_t obj_type);
 
       /**
        * @brief Opens an HDF5 Object
@@ -865,7 +865,7 @@ namespace H5Support_NAMESPACE
           }
           else
           {
-            retErr = attr_id;
+            //retErr = attr_id;
           }
           err = QH5Lite::closeId( obj_id, statbuf.type );
           if ( err < 0 )

--- a/Source/H5Support/QH5Lite.h
+++ b/Source/H5Support/QH5Lite.h
@@ -909,7 +909,7 @@ namespace H5Support_NAMESPACE
        * @param attrName The name of the attribute
        * @param rank (out) Number of dimensions is store into this variable
        */
-      static H5Support_EXPORT hid_t getAttributeNDims(hid_t loc_id, const QString& objName, const QString& attrName, hid_t& rank);
+      static H5Support_EXPORT herr_t getAttributeNDims(hid_t loc_id, const QString& objName, const QString& attrName, hid_t& rank);
 
       /**
        * @brief Returns the number of dimensions for a given dataset
@@ -917,7 +917,7 @@ namespace H5Support_NAMESPACE
        * @param objName The name of the dataset
        * @param rank (out) Number of dimensions is store into this variable
        */
-      static H5Support_EXPORT hid_t getDatasetNDims(hid_t loc_id, const QString& dsetName, hid_t& rank);
+      static H5Support_EXPORT herr_t getDatasetNDims(hid_t loc_id, const QString& dsetName, hid_t& rank);
 
       /**
        * @brief Returns the H5T value for a given dataset.


### PR DESCRIPTION
* Fixed inconsistent uses of herr_t and hid_t between method declaration and definitions.
* Methods that would return either an herr_t or an hid_t depending on the presence of errors now only return the herr_t.
* Fixed two cases where int32_t was used instead of hid_t.  hid_t no longer maps to int32_t in HDF5 1.10
* Upgrades SIMPL to handle HDF5 1.10.3 while maintaining 1.8.20 compatibility.