### PR TITLE
Update all classes to properly implement constructors and assignment operators

### DIFF
--- a/Source/Experimental/FilterCallback/IFilter.h
+++ b/Source/Experimental/FilterCallback/IFilter.h
@@ -80,9 +80,12 @@ class IFilter
     
   private:
     std::vector<IFilterParameter::Pointer> m_FilterParameters;
-    
+
+  public:
     IFilter(const IFilter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const IFilter&) = delete; // Move assignment Not Implemented
+    IFilter(IFilter&&) = delete;      // Move Constructor Not Implemented
+    IFilter& operator=(const IFilter&) = delete; // Copy Assignment Not Implemented
+    IFilter& operator=(IFilter&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/H5Support/H5ScopedErrorHandler.h
+++ b/Source/H5Support/H5ScopedErrorHandler.h
@@ -26,10 +26,12 @@ class H5Support_EXPORT H5ScopedErrorHandler
   private:
     herr_t (*_oldHDF_error_func)(hid_t, void *);
     void *_oldHDF_error_client_data;
-    
-    
+
+  public:
     H5ScopedErrorHandler(const H5ScopedErrorHandler&) = delete; // Copy Constructor Not Implemented
-    void operator=(const H5ScopedErrorHandler&) = delete;       // Move assignment Not Implemented
+    H5ScopedErrorHandler(H5ScopedErrorHandler&&) = delete;      // Move Constructor Not Implemented
+    H5ScopedErrorHandler& operator=(const H5ScopedErrorHandler&) = delete; // Copy Assignment Not Implemented
+    H5ScopedErrorHandler& operator=(H5ScopedErrorHandler&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Common/CreatedArrayHelpIndexEntry.h
+++ b/Source/SIMPLib/Common/CreatedArrayHelpIndexEntry.h
@@ -67,10 +67,11 @@ class SIMPLib_EXPORT CreatedArrayHelpIndexEntry
   protected:
     CreatedArrayHelpIndexEntry();
 
-
-  private:
+  public:
     CreatedArrayHelpIndexEntry(const CreatedArrayHelpIndexEntry&) = delete; // Copy Constructor Not Implemented
-    void operator=(const CreatedArrayHelpIndexEntry&) = delete;             // Move assignment Not Implemented
+    CreatedArrayHelpIndexEntry(CreatedArrayHelpIndexEntry&&) = delete;      // Move Constructor Not Implemented
+    CreatedArrayHelpIndexEntry& operator=(const CreatedArrayHelpIndexEntry&) = delete; // Copy Assignment Not Implemented
+    CreatedArrayHelpIndexEntry& operator=(CreatedArrayHelpIndexEntry&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Common/DocRequestManager.h
+++ b/Source/SIMPLib/Common/DocRequestManager.h
@@ -72,7 +72,10 @@ class SIMPLib_EXPORT DocRequestManager : public QObject
 
      static DocRequestManager *self;
 
+   public:
      DocRequestManager(const DocRequestManager&) = delete; // Copy Constructor Not Implemented
-     void operator=(const DocRequestManager&) = delete;    // Move assignment Not Implemented
+     DocRequestManager(DocRequestManager&&) = delete;      // Move Constructor Not Implemented
+     DocRequestManager& operator=(const DocRequestManager&) = delete; // Copy Assignment Not Implemented
+     DocRequestManager& operator=(DocRequestManager&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Common/IObserver.h
+++ b/Source/SIMPLib/Common/IObserver.h
@@ -49,8 +49,10 @@ class SIMPLib_EXPORT IObserver
 
     virtual void processPipelineMessage(const PipelineMessage& pm);
 
-  private:
+  public:
     IObserver(const IObserver&) = delete;      // Copy Constructor Not Implemented
-    void operator=(const IObserver&) = delete; // Move assignment Not Implemented
+    IObserver(IObserver&&) = delete;           // Move Constructor Not Implemented
+    IObserver& operator=(const IObserver&) = delete; // Copy Assignment Not Implemented
+    IObserver& operator=(IObserver&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Common/Observer.h
+++ b/Source/SIMPLib/Common/Observer.h
@@ -67,9 +67,11 @@ class SIMPLib_EXPORT Observer : public QObject, public IObserver
   public slots:
     void processPipelineMessage(const PipelineMessage& pm) override;
 
-  private:
+  public:
     Observer(const Observer&) = delete;       // Copy Constructor Not Implemented
-    void operator=(const Observer&) = delete; // Move assignment Not Implemented
+    Observer(Observer&&) = delete;            // Move Constructor Not Implemented
+    Observer& operator=(const Observer&) = delete; // Copy Assignment Not Implemented
+    Observer& operator=(Observer&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Common/PhaseType.h
+++ b/Source/SIMPLib/Common/PhaseType.h
@@ -156,9 +156,11 @@ public:
 protected:
   PhaseType();
 
-private:
-  PhaseType(const PhaseType&);      // Not Implemented
-  void operator=(const PhaseType&); // Not Implemented
+public:
+  PhaseType(const PhaseType&) = delete;            // Copy Constructor Not Implemented
+  PhaseType(PhaseType&&) = delete;                 // Move Constructor Not Implemented
+  PhaseType& operator=(const PhaseType&) = delete; // Copy Assignment Not Implemented
+  PhaseType& operator=(PhaseType&&) = delete;      // Move Assignment Not Implemented
 };
 
 Q_DECLARE_METATYPE(PhaseType::Type)

--- a/Source/SIMPLib/Common/ShapeType.h
+++ b/Source/SIMPLib/Common/ShapeType.h
@@ -111,9 +111,11 @@ public:
 protected:
   ShapeType();
 
-private:
-  ShapeType(const ShapeType&);      // Not Implemented
-  void operator=(const ShapeType&); // Not Implemented
+public:
+  ShapeType(const ShapeType&) = delete;            // Copy Constructor Not Implemented
+  ShapeType(ShapeType&&) = delete;                 // Move Constructor Not Implemented
+  ShapeType& operator=(const ShapeType&) = delete; // Copy Assignment Not Implemented
+  ShapeType& operator=(ShapeType&&) = delete;      // Move Assignment Not Implemented
 };
 
 Q_DECLARE_METATYPE(ShapeType::Type)

--- a/Source/SIMPLib/CoreFilters/CopyObject.h
+++ b/Source/SIMPLib/CoreFilters/CopyObject.h
@@ -174,8 +174,9 @@ protected:
    */
   void initialize();
 
-private:
-  CopyObject(const CopyObject&);                     // Copy Constructor Not Implemented
+public:
+  CopyObject(const CopyObject&) = delete;            // Copy Constructor Not Implemented
+  CopyObject(CopyObject&&) = delete;                 // Move Constructor Not Implemented
   CopyObject& operator=(const CopyObject&) = delete; // Copy Assignment Not Implemented
   CopyObject& operator=(CopyObject&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/CoreFilters/FeatureCountDecision.h
+++ b/Source/SIMPLib/CoreFilters/FeatureCountDecision.h
@@ -138,7 +138,10 @@ class SIMPLib_EXPORT FeatureCountDecision : public AbstractDecisionFilter
   private:
     DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
 
+  public:
     FeatureCountDecision(const FeatureCountDecision&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FeatureCountDecision&) = delete;       // Move assignment Not Implemented
+    FeatureCountDecision(FeatureCountDecision&&) = delete;      // Move Constructor Not Implemented
+    FeatureCountDecision& operator=(const FeatureCountDecision&) = delete; // Copy Assignment Not Implemented
+    FeatureCountDecision& operator=(FeatureCountDecision&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/MaskCountDecision.h
+++ b/Source/SIMPLib/CoreFilters/MaskCountDecision.h
@@ -138,7 +138,10 @@ class SIMPLib_EXPORT MaskCountDecision : public AbstractDecisionFilter
   private:
     DEFINE_DATAARRAY_VARIABLE(bool, Mask)
 
+  public:
     MaskCountDecision(const MaskCountDecision&) = delete; // Copy Constructor Not Implemented
-    void operator=(const MaskCountDecision&) = delete;    // Move assignment Not Implemented
+    MaskCountDecision(MaskCountDecision&&) = delete;      // Move Constructor Not Implemented
+    MaskCountDecision& operator=(const MaskCountDecision&) = delete; // Copy Assignment Not Implemented
+    MaskCountDecision& operator=(MaskCountDecision&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/PipelineAnnotation.h
+++ b/Source/SIMPLib/CoreFilters/PipelineAnnotation.h
@@ -151,7 +151,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   PipelineAnnotation(const PipelineAnnotation&) = delete; // Copy Constructor Not Implemented
   PipelineAnnotation(PipelineAnnotation&&) = delete;      // Move Constructor Not Implemented

--- a/Source/SIMPLib/CoreFilters/RequiredZThickness.h
+++ b/Source/SIMPLib/CoreFilters/RequiredZThickness.h
@@ -139,7 +139,10 @@ class SIMPLib_EXPORT RequiredZThickness : public AbstractDecisionFilter
   private:
     DEFINE_DATAARRAY_WEAKPTR(int32_t, FeatureIds)
 
+  public:
     RequiredZThickness(const RequiredZThickness&) = delete; // Copy Constructor Not Implemented
-    void operator=(const RequiredZThickness&) = delete;     // Move assignment Not Implemented
+    RequiredZThickness(RequiredZThickness&&) = delete;      // Move Constructor Not Implemented
+    RequiredZThickness& operator=(const RequiredZThickness&) = delete; // Copy Assignment Not Implemented
+    RequiredZThickness& operator=(RequiredZThickness&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RemoveArraysObserver.h
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RemoveArraysObserver.h
@@ -33,8 +33,10 @@ public slots:
     m_ErrorList.push_back(msg);
   }
 
-private:
+public:
   RemoveArraysObserver(const RemoveArraysObserver&) = delete; // Copy Constructor Not Implemented
-  void operator=(const RemoveArraysObserver&);                // Move assignment Not Implemented
+  RemoveArraysObserver(RemoveArraysObserver&&) = delete;      // Move Constructor Not Implemented
+  RemoveArraysObserver& operator=(const RemoveArraysObserver&) = delete; // Copy Assignment Not Implemented
+  RemoveArraysObserver& operator=(RemoveArraysObserver&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/ABSOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/ABSOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT ABSOperator : public UnaryOperator
   protected:
     ABSOperator();
 
-  private:
+  public:
     ABSOperator(const ABSOperator&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const ABSOperator&) = delete; // Move assignment Not Implemented
+    ABSOperator(ABSOperator&&) = delete;         // Move Constructor Not Implemented
+    ABSOperator& operator=(const ABSOperator&) = delete; // Copy Assignment Not Implemented
+    ABSOperator& operator=(ABSOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/ACosOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/ACosOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT ACosOperator : public UnaryOperator
   protected:
     ACosOperator();
 
-  private:
+  public:
     ACosOperator(const ACosOperator&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const ACosOperator&) = delete; // Move assignment Not Implemented
+    ACosOperator(ACosOperator&&) = delete;        // Move Constructor Not Implemented
+    ACosOperator& operator=(const ACosOperator&) = delete; // Copy Assignment Not Implemented
+    ACosOperator& operator=(ACosOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/ASinOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/ASinOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT ASinOperator : public UnaryOperator
   protected:
     ASinOperator();
 
-  private:
+  public:
     ASinOperator(const ASinOperator&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const ASinOperator&) = delete; // Move assignment Not Implemented
+    ASinOperator(ASinOperator&&) = delete;        // Move Constructor Not Implemented
+    ASinOperator& operator=(const ASinOperator&) = delete; // Copy Assignment Not Implemented
+    ASinOperator& operator=(ASinOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/ATanOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/ATanOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT ATanOperator : public UnaryOperator
   protected:
     ATanOperator();
 
-  private:
+  public:
     ATanOperator(const ATanOperator&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const ATanOperator&) = delete; // Move assignment Not Implemented
+    ATanOperator(ATanOperator&&) = delete;        // Move Constructor Not Implemented
+    ATanOperator& operator=(const ATanOperator&) = delete; // Copy Assignment Not Implemented
+    ATanOperator& operator=(ATanOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/AdditionOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/AdditionOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT AdditionOperator : public BinaryOperator
   protected:
     AdditionOperator();
 
-  private:
+  public:
     AdditionOperator(const AdditionOperator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AdditionOperator&) = delete;   // Move assignment Not Implemented
+    AdditionOperator(AdditionOperator&&) = delete;      // Move Constructor Not Implemented
+    AdditionOperator& operator=(const AdditionOperator&) = delete; // Copy Assignment Not Implemented
+    AdditionOperator& operator=(AdditionOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/BinaryOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/BinaryOperator.h
@@ -56,9 +56,11 @@ class SIMPLib_EXPORT BinaryOperator : public CalculatorOperator
   protected:
     BinaryOperator();
 
-  private:
+  public:
     BinaryOperator(const BinaryOperator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const BinaryOperator&) = delete; // Move assignment Not Implemented
+    BinaryOperator(BinaryOperator&&) = delete;      // Move Constructor Not Implemented
+    BinaryOperator& operator=(const BinaryOperator&) = delete; // Copy Assignment Not Implemented
+    BinaryOperator& operator=(BinaryOperator&&) = delete;      // Move Assignment Not Implemented
 };
 
 #define CREATE_NEW_ARRAY_STANDARD_BINARY(filter, calculatedArrayPath, executionStack, op)                                                                                                              \

--- a/Source/SIMPLib/CoreFilters/util/CalculatorItem.h
+++ b/Source/SIMPLib/CoreFilters/util/CalculatorItem.h
@@ -107,7 +107,10 @@ class SIMPLib_EXPORT CalculatorItem
   private:
     QString m_InfixToken = "";
 
+  public:
     CalculatorItem(const CalculatorItem&) = delete; // Copy Constructor Not Implemented
-    void operator=(const CalculatorItem&) = delete; // Move assignment Not Implemented
+    CalculatorItem(CalculatorItem&&) = delete;      // Move Constructor Not Implemented
+    CalculatorItem& operator=(const CalculatorItem&) = delete; // Copy Assignment Not Implemented
+    CalculatorItem& operator=(CalculatorItem&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/CalculatorOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/CalculatorOperator.h
@@ -92,8 +92,11 @@ class SIMPLib_EXPORT CalculatorOperator : public CalculatorItem
     Precedence                                      m_Precedence;
     OperatorType                                    m_OperatorType;
 
+  public:
     CalculatorOperator(const CalculatorOperator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const CalculatorOperator&) = delete;     // Move assignment Not Implemented
+    CalculatorOperator(CalculatorOperator&&) = delete;      // Move Constructor Not Implemented
+    CalculatorOperator& operator=(const CalculatorOperator&) = delete; // Copy Assignment Not Implemented
+    CalculatorOperator& operator=(CalculatorOperator&&) = delete;      // Move Assignment Not Implemented
 };
 
 #define CREATE_NEW_ARRAY_TWO_ARGUMENTS(filter, calculatedArrayPath, executionStack, func)                                                                                                              \

--- a/Source/SIMPLib/CoreFilters/util/CalculatorSeparator.h
+++ b/Source/SIMPLib/CoreFilters/util/CalculatorSeparator.h
@@ -49,8 +49,10 @@ class SIMPLib_EXPORT CalculatorSeparator : public CalculatorItem
   protected:
     CalculatorSeparator();
 
-  private:
+  public:
     CalculatorSeparator(const CalculatorSeparator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const CalculatorSeparator&) = delete;      // Move assignment Not Implemented
+    CalculatorSeparator(CalculatorSeparator&&) = delete;      // Move Constructor Not Implemented
+    CalculatorSeparator& operator=(const CalculatorSeparator&) = delete; // Copy Assignment Not Implemented
+    CalculatorSeparator& operator=(CalculatorSeparator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/CeilOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/CeilOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT CeilOperator : public UnaryOperator
   protected:
     CeilOperator();
 
-  private:
+  public:
     CeilOperator(const CeilOperator&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const CeilOperator&) = delete; // Move assignment Not Implemented
+    CeilOperator(CeilOperator&&) = delete;        // Move Constructor Not Implemented
+    CeilOperator& operator=(const CeilOperator&) = delete; // Copy Assignment Not Implemented
+    CeilOperator& operator=(CeilOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/CommaSeparator.h
+++ b/Source/SIMPLib/CoreFilters/util/CommaSeparator.h
@@ -56,8 +56,10 @@ class SIMPLib_EXPORT CommaSeparator : public CalculatorSeparator
   protected:
     CommaSeparator();
 
-  private:
+  public:
     CommaSeparator(const CommaSeparator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const CommaSeparator&) = delete; // Move assignment Not Implemented
+    CommaSeparator(CommaSeparator&&) = delete;      // Move Constructor Not Implemented
+    CommaSeparator& operator=(const CommaSeparator&) = delete; // Copy Assignment Not Implemented
+    CommaSeparator& operator=(CommaSeparator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/CosOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/CosOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT CosOperator : public UnaryOperator
   protected:
     CosOperator();
 
-  private:
+  public:
     CosOperator(const CosOperator&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const CosOperator&) = delete; // Move assignment Not Implemented
+    CosOperator(CosOperator&&) = delete;         // Move Constructor Not Implemented
+    CosOperator& operator=(const CosOperator&) = delete; // Copy Assignment Not Implemented
+    CosOperator& operator=(CosOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/DivisionOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/DivisionOperator.h
@@ -59,8 +59,10 @@ class SIMPLib_EXPORT DivisionOperator : public BinaryOperator
   protected:
     DivisionOperator();
 
-  private:
+  public:
     DivisionOperator(const DivisionOperator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DivisionOperator&) = delete;   // Move assignment Not Implemented
+    DivisionOperator(DivisionOperator&&) = delete;      // Move Constructor Not Implemented
+    DivisionOperator& operator=(const DivisionOperator&) = delete; // Copy Assignment Not Implemented
+    DivisionOperator& operator=(DivisionOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/ExpOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/ExpOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT ExpOperator : public UnaryOperator
   protected:
     ExpOperator();
 
-  private:
+  public:
     ExpOperator(const ExpOperator&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const ExpOperator&) = delete; // Move assignment Not Implemented
+    ExpOperator(ExpOperator&&) = delete;         // Move Constructor Not Implemented
+    ExpOperator& operator=(const ExpOperator&) = delete; // Copy Assignment Not Implemented
+    ExpOperator& operator=(ExpOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/FloorOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/FloorOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT FloorOperator : public UnaryOperator
   protected:
     FloorOperator();
 
-  private:
+  public:
     FloorOperator(const FloorOperator&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const FloorOperator&) = delete; // Move assignment Not Implemented
+    FloorOperator(FloorOperator&&) = delete;       // Move Constructor Not Implemented
+    FloorOperator& operator=(const FloorOperator&) = delete; // Copy Assignment Not Implemented
+    FloorOperator& operator=(FloorOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/ICalculatorArray.h
+++ b/Source/SIMPLib/CoreFilters/util/ICalculatorArray.h
@@ -66,8 +66,10 @@ class SIMPLib_EXPORT ICalculatorArray : public CalculatorItem
   protected:
     ICalculatorArray();
 
-  private:
+  public:
     ICalculatorArray(const ICalculatorArray&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ICalculatorArray&) = delete;   // Move assignment Not Implemented
+    ICalculatorArray(ICalculatorArray&&) = delete;      // Move Constructor Not Implemented
+    ICalculatorArray& operator=(const ICalculatorArray&) = delete; // Copy Assignment Not Implemented
+    ICalculatorArray& operator=(ICalculatorArray&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/LeftParenthesisItem.h
+++ b/Source/SIMPLib/CoreFilters/util/LeftParenthesisItem.h
@@ -56,8 +56,10 @@ class SIMPLib_EXPORT LeftParenthesisItem : public CalculatorItem
   protected:
     LeftParenthesisItem();
 
-  private:
+  public:
     LeftParenthesisItem(const LeftParenthesisItem&) = delete; // Copy Constructor Not Implemented
-    void operator=(const LeftParenthesisItem&) = delete;      // Move assignment Not Implemented
+    LeftParenthesisItem(LeftParenthesisItem&&) = delete;      // Move Constructor Not Implemented
+    LeftParenthesisItem& operator=(const LeftParenthesisItem&) = delete; // Copy Assignment Not Implemented
+    LeftParenthesisItem& operator=(LeftParenthesisItem&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/LnOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/LnOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT LnOperator : public UnaryOperator
   protected:
     LnOperator();
 
-  private:
+  public:
     LnOperator(const LnOperator&) = delete;     // Copy Constructor Not Implemented
-    void operator=(const LnOperator&) = delete; // Move assignment Not Implemented
+    LnOperator(LnOperator&&) = delete;          // Move Constructor Not Implemented
+    LnOperator& operator=(const LnOperator&) = delete; // Copy Assignment Not Implemented
+    LnOperator& operator=(LnOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/Log10Operator.h
+++ b/Source/SIMPLib/CoreFilters/util/Log10Operator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT Log10Operator : public UnaryOperator
   protected:
     Log10Operator();
 
-  private:
+  public:
     Log10Operator(const Log10Operator&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const Log10Operator&) = delete; // Move assignment Not Implemented
+    Log10Operator(Log10Operator&&) = delete;       // Move Constructor Not Implemented
+    Log10Operator& operator=(const Log10Operator&) = delete; // Copy Assignment Not Implemented
+    Log10Operator& operator=(Log10Operator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/LogOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/LogOperator.h
@@ -64,7 +64,10 @@ class SIMPLib_EXPORT LogOperator : public UnaryOperator
   private:
     double log_arbitrary_base(double base, double value);
 
+  public:
     LogOperator(const LogOperator&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const LogOperator&) = delete; // Move assignment Not Implemented
+    LogOperator(LogOperator&&) = delete;         // Move Constructor Not Implemented
+    LogOperator& operator=(const LogOperator&) = delete; // Copy Assignment Not Implemented
+    LogOperator& operator=(LogOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/MultiplicationOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/MultiplicationOperator.h
@@ -59,8 +59,10 @@ class SIMPLib_EXPORT MultiplicationOperator : public BinaryOperator
   protected:
     MultiplicationOperator();
 
-  private:
+  public:
     MultiplicationOperator(const MultiplicationOperator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const MultiplicationOperator&) = delete;         // Move assignment Not Implemented
+    MultiplicationOperator(MultiplicationOperator&&) = delete;      // Move Constructor Not Implemented
+    MultiplicationOperator& operator=(const MultiplicationOperator&) = delete; // Copy Assignment Not Implemented
+    MultiplicationOperator& operator=(MultiplicationOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/NegativeOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/NegativeOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT NegativeOperator : public CalculatorOperator
   protected:
     NegativeOperator();
 
-  private:
+  public:
     NegativeOperator(const NegativeOperator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const NegativeOperator&) = delete;   // Move assignment Not Implemented
+    NegativeOperator(NegativeOperator&&) = delete;      // Move Constructor Not Implemented
+    NegativeOperator& operator=(const NegativeOperator&) = delete; // Copy Assignment Not Implemented
+    NegativeOperator& operator=(NegativeOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/PowOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/PowOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT PowOperator : public BinaryOperator
   protected:
     PowOperator();
 
-  private:
+  public:
     PowOperator(const PowOperator&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const PowOperator&) = delete; // Move assignment Not Implemented
+    PowOperator(PowOperator&&) = delete;         // Move Constructor Not Implemented
+    PowOperator& operator=(const PowOperator&) = delete; // Copy Assignment Not Implemented
+    PowOperator& operator=(PowOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/RightParenthesisItem.h
+++ b/Source/SIMPLib/CoreFilters/util/RightParenthesisItem.h
@@ -56,8 +56,10 @@ class SIMPLib_EXPORT RightParenthesisItem : public CalculatorItem
   protected:
     RightParenthesisItem();
 
-  private:
+  public:
     RightParenthesisItem(const RightParenthesisItem&) = delete; // Copy Constructor Not Implemented
-    void operator=(const RightParenthesisItem&) = delete;       // Move assignment Not Implemented
+    RightParenthesisItem(RightParenthesisItem&&) = delete;      // Move Constructor Not Implemented
+    RightParenthesisItem& operator=(const RightParenthesisItem&) = delete; // Copy Assignment Not Implemented
+    RightParenthesisItem& operator=(RightParenthesisItem&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/RootOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/RootOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT RootOperator : public UnaryOperator
   protected:
     RootOperator();
 
-  private:
+  public:
     RootOperator(const RootOperator&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const RootOperator&) = delete; // Move assignment Not Implemented
+    RootOperator(RootOperator&&) = delete;        // Move Constructor Not Implemented
+    RootOperator& operator=(const RootOperator&) = delete; // Copy Assignment Not Implemented
+    RootOperator& operator=(RootOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/SinOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/SinOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT SinOperator : public UnaryOperator
   protected:
     SinOperator();
 
-  private:
+  public:
     SinOperator(const SinOperator&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const SinOperator&) = delete; // Move assignment Not Implemented
+    SinOperator(SinOperator&&) = delete;         // Move Constructor Not Implemented
+    SinOperator& operator=(const SinOperator&) = delete; // Copy Assignment Not Implemented
+    SinOperator& operator=(SinOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/SqrtOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/SqrtOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT SqrtOperator : public UnaryOperator
   protected:
     SqrtOperator();
 
-  private:
+  public:
     SqrtOperator(const SqrtOperator&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const SqrtOperator&) = delete; // Move assignment Not Implemented
+    SqrtOperator(SqrtOperator&&) = delete;        // Move Constructor Not Implemented
+    SqrtOperator& operator=(const SqrtOperator&) = delete; // Copy Assignment Not Implemented
+    SqrtOperator& operator=(SqrtOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/SubtractionOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/SubtractionOperator.h
@@ -59,8 +59,10 @@ class SIMPLib_EXPORT SubtractionOperator : public BinaryOperator
   protected:
     SubtractionOperator();
 
-  private:
+  public:
     SubtractionOperator(const SubtractionOperator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SubtractionOperator&) = delete;      // Move assignment Not Implemented
+    SubtractionOperator(SubtractionOperator&&) = delete;      // Move Constructor Not Implemented
+    SubtractionOperator& operator=(const SubtractionOperator&) = delete; // Copy Assignment Not Implemented
+    SubtractionOperator& operator=(SubtractionOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/TanOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/TanOperator.h
@@ -61,8 +61,10 @@ class SIMPLib_EXPORT TanOperator : public UnaryOperator
   protected:
     TanOperator();
 
-  private:
+  public:
     TanOperator(const TanOperator&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const TanOperator&) = delete; // Move assignment Not Implemented
+    TanOperator(TanOperator&&) = delete;         // Move Constructor Not Implemented
+    TanOperator& operator=(const TanOperator&) = delete; // Copy Assignment Not Implemented
+    TanOperator& operator=(TanOperator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/util/UnaryOperator.h
+++ b/Source/SIMPLib/CoreFilters/util/UnaryOperator.h
@@ -63,8 +63,11 @@ class SIMPLib_EXPORT UnaryOperator : public CalculatorOperator
   private:
     int                                           m_NumOfArguments;
 
+  public:
     UnaryOperator(const UnaryOperator&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const UnaryOperator&) = delete; // Move assignment Not Implemented
+    UnaryOperator(UnaryOperator&&) = delete;       // Move Constructor Not Implemented
+    UnaryOperator& operator=(const UnaryOperator&) = delete; // Copy Assignment Not Implemented
+    UnaryOperator& operator=(UnaryOperator&&) = delete;      // Move Assignment Not Implemented
 };
 
 #define CREATE_NEW_ARRAY_STANDARD_UNARY(filter, calculatedArrayPath, executionStack, func)                                                                                                             \

--- a/Source/SIMPLib/DataArrays/IDataArrayFilter.h
+++ b/Source/SIMPLib/DataArrays/IDataArrayFilter.h
@@ -50,8 +50,10 @@ public:
 
   int execute(IDataArray* input, IDataArray* output);
 
-private:
+public:
   IDataArrayFilter(const IDataArrayFilter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const IDataArrayFilter&);            // Move assignment Not Implemented
+  IDataArrayFilter(IDataArrayFilter&&) = delete;      // Move Constructor Not Implemented
+  IDataArrayFilter& operator=(const IDataArrayFilter&) = delete; // Copy Assignment Not Implemented
+  IDataArrayFilter& operator=(IDataArrayFilter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/DataArrays/StatsDataArray.h
+++ b/Source/SIMPLib/DataArrays/StatsDataArray.h
@@ -375,8 +375,11 @@ class SIMPLib_EXPORT StatsDataArray : public IDataArray
     QString m_Name;
     bool m_IsAllocated;
 
+  public:
     StatsDataArray(const StatsDataArray&) = delete; // Copy Constructor Not Implemented
-    void operator=(const StatsDataArray&) = delete; // Move assignment Not Implemented
+    StatsDataArray(StatsDataArray&&) = delete;      // Move Constructor Not Implemented
+    StatsDataArray& operator=(const StatsDataArray&) = delete; // Copy Assignment Not Implemented
+    StatsDataArray& operator=(StatsDataArray&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/DataContainers/DataContainer.h
+++ b/Source/SIMPLib/DataContainers/DataContainer.h
@@ -384,8 +384,11 @@ public:
     IGeometry::Pointer m_Geometry;
     QString m_Name;
 
+  public:
     DataContainer(const DataContainer&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const DataContainer&) = delete; // Move assignment Not Implemented
+    DataContainer(DataContainer&&) = delete;       // Move Constructor Not Implemented
+    DataContainer& operator=(const DataContainer&) = delete; // Copy Assignment Not Implemented
+    DataContainer& operator=(DataContainer&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/DataContainers/DataContainerArray.h
+++ b/Source/SIMPLib/DataContainers/DataContainerArray.h
@@ -742,8 +742,11 @@ class SIMPLib_EXPORT DataContainerArray : public QObject
     QList<DataContainerShPtr>  m_Array;
     QMap<QString, IDataContainerBundle::Pointer> m_DataContainerBundles;
 
+  public:
     DataContainerArray(const DataContainerArray&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerArray&) = delete;     // Move assignment Not Implemented
+    DataContainerArray(DataContainerArray&&) = delete;      // Move Constructor Not Implemented
+    DataContainerArray& operator=(const DataContainerArray&) = delete; // Copy Assignment Not Implemented
+    DataContainerArray& operator=(DataContainerArray&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/DataContainers/DataContainerBundle.h
+++ b/Source/SIMPLib/DataContainers/DataContainerBundle.h
@@ -165,7 +165,10 @@ class SIMPLib_EXPORT DataContainerBundle : public IDataContainerBundle
     QVector<DataContainer::Pointer>  m_DataContainers;
     QString m_MetaDataAMName;
 
+  public:
     DataContainerBundle(const DataContainerBundle&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerBundle&) = delete;      // Move assignment Not Implemented
+    DataContainerBundle(DataContainerBundle&&) = delete;      // Move Constructor Not Implemented
+    DataContainerBundle& operator=(const DataContainerBundle&) = delete; // Copy Assignment Not Implemented
+    DataContainerBundle& operator=(DataContainerBundle&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/DataContainers/IDataContainerBundle.h
+++ b/Source/SIMPLib/DataContainers/IDataContainerBundle.h
@@ -77,8 +77,10 @@ class SIMPLib_EXPORT IDataContainerBundle : public QObject
   protected:
     IDataContainerBundle();
 
-  private:
+  public:
     IDataContainerBundle(const IDataContainerBundle&) = delete; // Copy Constructor Not Implemented
-    void operator=(const IDataContainerBundle&) = delete;       // Move assignment Not Implemented
+    IDataContainerBundle(IDataContainerBundle&&) = delete;      // Move Constructor Not Implemented
+    IDataContainerBundle& operator=(const IDataContainerBundle&) = delete; // Copy Assignment Not Implemented
+    IDataContainerBundle& operator=(IDataContainerBundle&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/AbstractFilterParametersReader.h
+++ b/Source/SIMPLib/FilterParameters/AbstractFilterParametersReader.h
@@ -134,9 +134,11 @@ class SIMPLib_EXPORT AbstractFilterParametersReader
   protected:
     AbstractFilterParametersReader();
 
-  private:
+  public:
     AbstractFilterParametersReader(const AbstractFilterParametersReader&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AbstractFilterParametersReader&) = delete;                 // Move assignment Not Implemented
+    AbstractFilterParametersReader(AbstractFilterParametersReader&&) = delete;      // Move Constructor Not Implemented
+    AbstractFilterParametersReader& operator=(const AbstractFilterParametersReader&) = delete; // Copy Assignment Not Implemented
+    AbstractFilterParametersReader& operator=(AbstractFilterParametersReader&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/FilterParameters/AbstractFilterParametersWriter.h
+++ b/Source/SIMPLib/FilterParameters/AbstractFilterParametersWriter.h
@@ -142,11 +142,11 @@ class SIMPLib_EXPORT AbstractFilterParametersWriter
 
     virtual int writeValue(const QString name, AxisAngleInput_t v, int vectorPos);
 
-
-
-  private:
+  public:
     AbstractFilterParametersWriter(const AbstractFilterParametersWriter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AbstractFilterParametersWriter&) = delete;                 // Move assignment Not Implemented
+    AbstractFilterParametersWriter(AbstractFilterParametersWriter&&) = delete;      // Move Constructor Not Implemented
+    AbstractFilterParametersWriter& operator=(const AbstractFilterParametersWriter&) = delete; // Copy Assignment Not Implemented
+    AbstractFilterParametersWriter& operator=(AbstractFilterParametersWriter&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/FilterParameters/AttributeMatrixCreationFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/AttributeMatrixCreationFilterParameter.h
@@ -153,8 +153,10 @@ class SIMPLib_EXPORT AttributeMatrixCreationFilterParameter : public FilterParam
        */
     AttributeMatrixCreationFilterParameter();
 
-  private:
+  public:
     AttributeMatrixCreationFilterParameter(const AttributeMatrixCreationFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AttributeMatrixCreationFilterParameter&) = delete;                         // Move assignment Not Implemented
+    AttributeMatrixCreationFilterParameter(AttributeMatrixCreationFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    AttributeMatrixCreationFilterParameter& operator=(const AttributeMatrixCreationFilterParameter&) = delete; // Copy Assignment Not Implemented
+    AttributeMatrixCreationFilterParameter& operator=(AttributeMatrixCreationFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.h
@@ -181,8 +181,10 @@ class SIMPLib_EXPORT AttributeMatrixSelectionFilterParameter : public FilterPara
        */
     AttributeMatrixSelectionFilterParameter();
 
-  private:
+  public:
     AttributeMatrixSelectionFilterParameter(const AttributeMatrixSelectionFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AttributeMatrixSelectionFilterParameter&) = delete;                          // Move assignment Not Implemented
+    AttributeMatrixSelectionFilterParameter(AttributeMatrixSelectionFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    AttributeMatrixSelectionFilterParameter& operator=(const AttributeMatrixSelectionFilterParameter&) = delete; // Copy Assignment Not Implemented
+    AttributeMatrixSelectionFilterParameter& operator=(AttributeMatrixSelectionFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/AxisAngleFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/AxisAngleFilterParameter.h
@@ -135,8 +135,10 @@ class SIMPLib_EXPORT AxisAngleFilterParameter : public FilterParameter
        */
     AxisAngleFilterParameter();
 
-  private:
+  public:
     AxisAngleFilterParameter(const AxisAngleFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AxisAngleFilterParameter&) = delete;           // Move assignment Not Implemented
+    AxisAngleFilterParameter(AxisAngleFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    AxisAngleFilterParameter& operator=(const AxisAngleFilterParameter&) = delete; // Copy Assignment Not Implemented
+    AxisAngleFilterParameter& operator=(AxisAngleFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/BooleanFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/BooleanFilterParameter.h
@@ -132,8 +132,10 @@ protected:
        */
   BooleanFilterParameter();
 
-private:
+public:
   BooleanFilterParameter(const BooleanFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const BooleanFilterParameter&) = delete;         // Move assignment Not Implemented
+  BooleanFilterParameter(BooleanFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  BooleanFilterParameter& operator=(const BooleanFilterParameter&) = delete; // Copy Assignment Not Implemented
+  BooleanFilterParameter& operator=(BooleanFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/CalculatorFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/CalculatorFilterParameter.h
@@ -139,8 +139,10 @@ public:
      */
   CalculatorFilterParameter();
 
-private:
+public:
   CalculatorFilterParameter(const CalculatorFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const CalculatorFilterParameter&) = delete;            // Move assignment Not Implemented
+  CalculatorFilterParameter(CalculatorFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  CalculatorFilterParameter& operator=(const CalculatorFilterParameter&) = delete; // Copy Assignment Not Implemented
+  CalculatorFilterParameter& operator=(CalculatorFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/ChoiceFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ChoiceFilterParameter.h
@@ -139,8 +139,10 @@ class SIMPLib_EXPORT ChoiceFilterParameter : public FilterParameter
        */
     ChoiceFilterParameter();
 
-  private:
+  public:
     ChoiceFilterParameter(const ChoiceFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ChoiceFilterParameter&) = delete;        // Move assignment Not Implemented
+    ChoiceFilterParameter(ChoiceFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    ChoiceFilterParameter& operator=(const ChoiceFilterParameter&) = delete; // Copy Assignment Not Implemented
+    ChoiceFilterParameter& operator=(ChoiceFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionAdvancedFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionAdvancedFilterParameter.h
@@ -152,8 +152,10 @@ class SIMPLib_EXPORT ComparisonSelectionAdvancedFilterParameter : public FilterP
      */
     ComparisonSelectionAdvancedFilterParameter();
 
-  private:
+  public:
     ComparisonSelectionAdvancedFilterParameter(const ComparisonSelectionAdvancedFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ComparisonSelectionAdvancedFilterParameter&) = delete;                             // Move assignment Not Implemented
+    ComparisonSelectionAdvancedFilterParameter(ComparisonSelectionAdvancedFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    ComparisonSelectionAdvancedFilterParameter& operator=(const ComparisonSelectionAdvancedFilterParameter&) = delete; // Copy Assignment Not Implemented
+    ComparisonSelectionAdvancedFilterParameter& operator=(ComparisonSelectionAdvancedFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.h
@@ -151,8 +151,10 @@ class SIMPLib_EXPORT ComparisonSelectionFilterParameter : public FilterParameter
        */
     ComparisonSelectionFilterParameter();
 
-  private:
+  public:
     ComparisonSelectionFilterParameter(const ComparisonSelectionFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ComparisonSelectionFilterParameter&) = delete;                     // Move assignment Not Implemented
+    ComparisonSelectionFilterParameter(ComparisonSelectionFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    ComparisonSelectionFilterParameter& operator=(const ComparisonSelectionFilterParameter&) = delete; // Copy Assignment Not Implemented
+    ComparisonSelectionFilterParameter& operator=(ComparisonSelectionFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/ConstrainedDoubleFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ConstrainedDoubleFilterParameter.h
@@ -134,8 +134,10 @@ class SIMPLib_EXPORT ConstrainedDoubleFilterParameter : public FilterParameter
        */
       ConstrainedDoubleFilterParameter();
 
-  private:
-    ConstrainedDoubleFilterParameter(const ConstrainedDoubleFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ConstrainedDoubleFilterParameter&) = delete;                   // Move assignment Not Implemented
+    public:
+      ConstrainedDoubleFilterParameter(const ConstrainedDoubleFilterParameter&) = delete;            // Copy Constructor Not Implemented
+      ConstrainedDoubleFilterParameter(ConstrainedDoubleFilterParameter&&) = delete;                 // Move Constructor Not Implemented
+      ConstrainedDoubleFilterParameter& operator=(const ConstrainedDoubleFilterParameter&) = delete; // Copy Assignment Not Implemented
+      ConstrainedDoubleFilterParameter& operator=(ConstrainedDoubleFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/ConstrainedFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ConstrainedFilterParameter.h
@@ -60,8 +60,10 @@ class SIMPLib_EXPORT ConstrainedFilterParameter : public FilterParameter
   protected:
     ConstrainedFilterParameter() {}
 
-  private:
+  public:
     ConstrainedFilterParameter(const ConstrainedFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ConstrainedFilterParameter&) = delete;             // Move assignment Not Implemented
+    ConstrainedFilterParameter(ConstrainedFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    ConstrainedFilterParameter& operator=(const ConstrainedFilterParameter&) = delete; // Copy Assignment Not Implemented
+    ConstrainedFilterParameter& operator=(ConstrainedFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/ConstrainedIntFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ConstrainedIntFilterParameter.h
@@ -133,8 +133,10 @@ class SIMPLib_EXPORT ConstrainedIntFilterParameter : public FilterParameter
        */
       ConstrainedIntFilterParameter();
 
-  private:
-    ConstrainedIntFilterParameter(const ConstrainedIntFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ConstrainedIntFilterParameter&) = delete;                // Move assignment Not Implemented
+    public:
+      ConstrainedIntFilterParameter(const ConstrainedIntFilterParameter&) = delete;            // Copy Constructor Not Implemented
+      ConstrainedIntFilterParameter(ConstrainedIntFilterParameter&&) = delete;                 // Move Constructor Not Implemented
+      ConstrainedIntFilterParameter& operator=(const ConstrainedIntFilterParameter&) = delete; // Copy Assignment Not Implemented
+      ConstrainedIntFilterParameter& operator=(ConstrainedIntFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/DataArrayCreationFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataArrayCreationFilterParameter.h
@@ -175,9 +175,11 @@ class SIMPLib_EXPORT DataArrayCreationFilterParameter : public FilterParameter
        */
     DataArrayCreationFilterParameter();
 
-  private:
+  public:
     DataArrayCreationFilterParameter(const DataArrayCreationFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataArrayCreationFilterParameter&) = delete;                   // Move assignment Not Implemented
+    DataArrayCreationFilterParameter(DataArrayCreationFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    DataArrayCreationFilterParameter& operator=(const DataArrayCreationFilterParameter&) = delete; // Copy Assignment Not Implemented
+    DataArrayCreationFilterParameter& operator=(DataArrayCreationFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
@@ -204,9 +204,11 @@ class SIMPLib_EXPORT DataArraySelectionFilterParameter : public FilterParameter
        */
     DataArraySelectionFilterParameter();
 
-  private:
+  public:
     DataArraySelectionFilterParameter(const DataArraySelectionFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataArraySelectionFilterParameter&) = delete;                    // Move assignment Not Implemented
+    DataArraySelectionFilterParameter(DataArraySelectionFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    DataArraySelectionFilterParameter& operator=(const DataArraySelectionFilterParameter&) = delete; // Copy Assignment Not Implemented
+    DataArraySelectionFilterParameter& operator=(DataArraySelectionFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/FilterParameters/DataContainerArrayProxyFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerArrayProxyFilterParameter.h
@@ -145,8 +145,10 @@ class SIMPLib_EXPORT DataContainerArrayProxyFilterParameter : public FilterParam
        */
     DataContainerArrayProxyFilterParameter();
 
-  private:
+  public:
     DataContainerArrayProxyFilterParameter(const DataContainerArrayProxyFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerArrayProxyFilterParameter&) = delete;                         // Move assignment Not Implemented
+    DataContainerArrayProxyFilterParameter(DataContainerArrayProxyFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    DataContainerArrayProxyFilterParameter& operator=(const DataContainerArrayProxyFilterParameter&) = delete; // Copy Assignment Not Implemented
+    DataContainerArrayProxyFilterParameter& operator=(DataContainerArrayProxyFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/DataContainerCreationFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerCreationFilterParameter.h
@@ -132,8 +132,10 @@ public:
      */
   DataContainerCreationFilterParameter();
 
-private:
+public:
   DataContainerCreationFilterParameter(const DataContainerCreationFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const DataContainerCreationFilterParameter&) = delete;                       // Move assignment Not Implemented
+  DataContainerCreationFilterParameter(DataContainerCreationFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  DataContainerCreationFilterParameter& operator=(const DataContainerCreationFilterParameter&) = delete; // Copy Assignment Not Implemented
+  DataContainerCreationFilterParameter& operator=(DataContainerCreationFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/DataContainerReaderFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerReaderFilterParameter.h
@@ -101,8 +101,10 @@ class SIMPLib_EXPORT DataContainerReaderFilterParameter : public FilterParameter
      */
     DataContainerReaderFilterParameter();
 
-  private:
+  public:
     DataContainerReaderFilterParameter(const DataContainerReaderFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerReaderFilterParameter&) = delete;                     // Move assignment Not Implemented
+    DataContainerReaderFilterParameter(DataContainerReaderFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    DataContainerReaderFilterParameter& operator=(const DataContainerReaderFilterParameter&) = delete; // Copy Assignment Not Implemented
+    DataContainerReaderFilterParameter& operator=(DataContainerReaderFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
@@ -159,8 +159,10 @@ class SIMPLib_EXPORT DataContainerSelectionFilterParameter : public FilterParame
        */
     DataContainerSelectionFilterParameter();
 
-  private:
+  public:
     DataContainerSelectionFilterParameter(const DataContainerSelectionFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerSelectionFilterParameter&) = delete;                        // Move assignment Not Implemented
+    DataContainerSelectionFilterParameter(DataContainerSelectionFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    DataContainerSelectionFilterParameter& operator=(const DataContainerSelectionFilterParameter&) = delete; // Copy Assignment Not Implemented
+    DataContainerSelectionFilterParameter& operator=(DataContainerSelectionFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/DoubleFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DoubleFilterParameter.h
@@ -154,8 +154,10 @@ class SIMPLib_EXPORT DoubleFilterParameter : public FilterParameter
        */
       DoubleFilterParameter();
 
-  private:
-    DoubleFilterParameter(const DoubleFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DoubleFilterParameter&) = delete;        // Move assignment Not Implemented
+    public:
+      DoubleFilterParameter(const DoubleFilterParameter&) = delete;            // Copy Constructor Not Implemented
+      DoubleFilterParameter(DoubleFilterParameter&&) = delete;                 // Move Constructor Not Implemented
+      DoubleFilterParameter& operator=(const DoubleFilterParameter&) = delete; // Copy Assignment Not Implemented
+      DoubleFilterParameter& operator=(DoubleFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/DynamicChoiceFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DynamicChoiceFilterParameter.h
@@ -139,8 +139,10 @@ class SIMPLib_EXPORT DynamicChoiceFilterParameter : public FilterParameter
        */
     DynamicChoiceFilterParameter();
 
-  private:
+  public:
     DynamicChoiceFilterParameter(const DynamicChoiceFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DynamicChoiceFilterParameter&) = delete;               // Move assignment Not Implemented
+    DynamicChoiceFilterParameter(DynamicChoiceFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    DynamicChoiceFilterParameter& operator=(const DynamicChoiceFilterParameter&) = delete; // Copy Assignment Not Implemented
+    DynamicChoiceFilterParameter& operator=(DynamicChoiceFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/DynamicTableFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DynamicTableFilterParameter.h
@@ -144,8 +144,10 @@ class SIMPLib_EXPORT DynamicTableFilterParameter : public FilterParameter
        */
     DynamicTableFilterParameter();
 
-  private:
+  public:
     DynamicTableFilterParameter(const DynamicTableFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DynamicTableFilterParameter&) = delete;              // Move assignment Not Implemented
+    DynamicTableFilterParameter(DynamicTableFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    DynamicTableFilterParameter& operator=(const DynamicTableFilterParameter&) = delete; // Copy Assignment Not Implemented
+    DynamicTableFilterParameter& operator=(DynamicTableFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/FileListInfoFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FileListInfoFilterParameter.h
@@ -178,8 +178,10 @@ protected:
    */
   FileListInfoFilterParameter();
 
-private:
+public:
   FileListInfoFilterParameter(const FileListInfoFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const FileListInfoFilterParameter&) = delete;              // Move assignment Not Implemented
+  FileListInfoFilterParameter(FileListInfoFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  FileListInfoFilterParameter& operator=(const FileListInfoFilterParameter&) = delete; // Copy Assignment Not Implemented
+  FileListInfoFilterParameter& operator=(FileListInfoFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FilterParameter.h
@@ -110,9 +110,11 @@ class SIMPLib_EXPORT FilterParameter
   protected:
     FilterParameter();
 
-  private:
+  public:
     FilterParameter(const FilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FilterParameter&) = delete;  // Move assignment Not Implemented
+    FilterParameter(FilterParameter&&) = delete;      // Move Constructor Not Implemented
+    FilterParameter& operator=(const FilterParameter&) = delete; // Copy Assignment Not Implemented
+    FilterParameter& operator=(FilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 
 typedef QVector<FilterParameter::Pointer> FilterParameterVector;

--- a/Source/SIMPLib/FilterParameters/FloatFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FloatFilterParameter.h
@@ -134,8 +134,10 @@ class SIMPLib_EXPORT FloatFilterParameter : public FilterParameter
        */
       FloatFilterParameter();
 
-  private:
-    FloatFilterParameter(const FloatFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FloatFilterParameter&) = delete;       // Move assignment Not Implemented
+    public:
+      FloatFilterParameter(const FloatFilterParameter&) = delete;            // Copy Constructor Not Implemented
+      FloatFilterParameter(FloatFilterParameter&&) = delete;                 // Move Constructor Not Implemented
+      FloatFilterParameter& operator=(const FloatFilterParameter&) = delete; // Copy Assignment Not Implemented
+      FloatFilterParameter& operator=(FloatFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/FloatVec2FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FloatVec2FilterParameter.h
@@ -165,8 +165,10 @@ public:
      */
   FloatVec2FilterParameter();
 
-private:
+public:
   FloatVec2FilterParameter(const FloatVec2FilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const FloatVec2FilterParameter&) = delete;           // Move assignment Not Implemented
+  FloatVec2FilterParameter(FloatVec2FilterParameter&&) = delete;      // Move Constructor Not Implemented
+  FloatVec2FilterParameter& operator=(const FloatVec2FilterParameter&) = delete; // Copy Assignment Not Implemented
+  FloatVec2FilterParameter& operator=(FloatVec2FilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/FloatVec3FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FloatVec3FilterParameter.h
@@ -177,8 +177,10 @@ public:
      */
   FloatVec3FilterParameter();
 
-private:
+public:
   FloatVec3FilterParameter(const FloatVec3FilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const FloatVec3FilterParameter&) = delete;           // Move assignment Not Implemented
+  FloatVec3FilterParameter(FloatVec3FilterParameter&&) = delete;      // Move Constructor Not Implemented
+  FloatVec3FilterParameter& operator=(const FloatVec3FilterParameter&) = delete; // Copy Assignment Not Implemented
+  FloatVec3FilterParameter& operator=(FloatVec3FilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/FourthOrderPolynomialFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FourthOrderPolynomialFilterParameter.h
@@ -215,8 +215,10 @@ public:
      */
   FourthOrderPolynomialFilterParameter();
 
-private:
+public:
   FourthOrderPolynomialFilterParameter(const FourthOrderPolynomialFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const FourthOrderPolynomialFilterParameter&) = delete;                       // Move assignment Not Implemented
+  FourthOrderPolynomialFilterParameter(FourthOrderPolynomialFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  FourthOrderPolynomialFilterParameter& operator=(const FourthOrderPolynomialFilterParameter&) = delete; // Copy Assignment Not Implemented
+  FourthOrderPolynomialFilterParameter& operator=(FourthOrderPolynomialFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/GenerateColorTableFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/GenerateColorTableFilterParameter.h
@@ -97,8 +97,10 @@ class SIMPLib_EXPORT GenerateColorTableFilterParameter : public FilterParameter
      */
     GenerateColorTableFilterParameter();
 
-  private:
+  public:
     GenerateColorTableFilterParameter(const GenerateColorTableFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const GenerateColorTableFilterParameter&) = delete;                    // Move assignment Not Implemented
+    GenerateColorTableFilterParameter(GenerateColorTableFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    GenerateColorTableFilterParameter& operator=(const GenerateColorTableFilterParameter&) = delete; // Copy Assignment Not Implemented
+    GenerateColorTableFilterParameter& operator=(GenerateColorTableFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/ImportHDF5DatasetFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ImportHDF5DatasetFilterParameter.h
@@ -68,7 +68,9 @@ public:
 protected:
   ImportHDF5DatasetFilterParameter();
 
-private:
+public:
   ImportHDF5DatasetFilterParameter(const ImportHDF5DatasetFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ImportHDF5DatasetFilterParameter&);                            // Move assignment Not Implemented
+  ImportHDF5DatasetFilterParameter(ImportHDF5DatasetFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  ImportHDF5DatasetFilterParameter& operator=(const ImportHDF5DatasetFilterParameter&) = delete; // Copy Assignment Not Implemented
+  ImportHDF5DatasetFilterParameter& operator=(ImportHDF5DatasetFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/FilterParameters/InputFileFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/InputFileFilterParameter.h
@@ -138,8 +138,10 @@ public:
        */
   InputFileFilterParameter();
 
-private:
+public:
   InputFileFilterParameter(const InputFileFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const InputFileFilterParameter&) = delete;           // Move assignment Not Implemented
+  InputFileFilterParameter(InputFileFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  InputFileFilterParameter& operator=(const InputFileFilterParameter&) = delete; // Copy Assignment Not Implemented
+  InputFileFilterParameter& operator=(InputFileFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/InputPathFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/InputPathFilterParameter.h
@@ -138,8 +138,10 @@ public:
        */
   InputPathFilterParameter();
 
-private:
+public:
   InputPathFilterParameter(const InputPathFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const InputPathFilterParameter&) = delete;           // Move assignment Not Implemented
+  InputPathFilterParameter(InputPathFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  InputPathFilterParameter& operator=(const InputPathFilterParameter&) = delete; // Copy Assignment Not Implemented
+  InputPathFilterParameter& operator=(InputPathFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/IntFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/IntFilterParameter.h
@@ -133,8 +133,10 @@ class SIMPLib_EXPORT IntFilterParameter : public FilterParameter
        */
       IntFilterParameter();
 
-  private:
-    IntFilterParameter(const IntFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const IntFilterParameter&) = delete;     // Move assignment Not Implemented
+    public:
+      IntFilterParameter(const IntFilterParameter&) = delete;            // Copy Constructor Not Implemented
+      IntFilterParameter(IntFilterParameter&&) = delete;                 // Move Constructor Not Implemented
+      IntFilterParameter& operator=(const IntFilterParameter&) = delete; // Copy Assignment Not Implemented
+      IntFilterParameter& operator=(IntFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/IntVec3FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/IntVec3FilterParameter.h
@@ -162,8 +162,10 @@ public:
      */
   IntVec3FilterParameter();
 
-private:
+public:
   IntVec3FilterParameter(const IntVec3FilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const IntVec3FilterParameter&) = delete;         // Move assignment Not Implemented
+  IntVec3FilterParameter(IntVec3FilterParameter&&) = delete;      // Move Constructor Not Implemented
+  IntVec3FilterParameter& operator=(const IntVec3FilterParameter&) = delete; // Copy Assignment Not Implemented
+  IntVec3FilterParameter& operator=(IntVec3FilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/LinkedBooleanFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/LinkedBooleanFilterParameter.h
@@ -137,8 +137,10 @@ class SIMPLib_EXPORT LinkedBooleanFilterParameter : public FilterParameter
        */
     LinkedBooleanFilterParameter();
 
-  private:
+  public:
     LinkedBooleanFilterParameter(const LinkedBooleanFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const LinkedBooleanFilterParameter&) = delete;               // Move assignment Not Implemented
+    LinkedBooleanFilterParameter(LinkedBooleanFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    LinkedBooleanFilterParameter& operator=(const LinkedBooleanFilterParameter&) = delete; // Copy Assignment Not Implemented
+    LinkedBooleanFilterParameter& operator=(LinkedBooleanFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/LinkedChoicesFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/LinkedChoicesFilterParameter.h
@@ -123,8 +123,10 @@ class SIMPLib_EXPORT LinkedChoicesFilterParameter : public ChoiceFilterParameter
        */
     LinkedChoicesFilterParameter();
 
-  private:
+  public:
     LinkedChoicesFilterParameter(const LinkedChoicesFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const LinkedChoicesFilterParameter&) = delete;               // Move assignment Not Implemented
+    LinkedChoicesFilterParameter(LinkedChoicesFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    LinkedChoicesFilterParameter& operator=(const LinkedChoicesFilterParameter&) = delete; // Copy Assignment Not Implemented
+    LinkedChoicesFilterParameter& operator=(LinkedChoicesFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/LinkedDataContainerSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/LinkedDataContainerSelectionFilterParameter.h
@@ -142,8 +142,10 @@ class SIMPLib_EXPORT LinkedDataContainerSelectionFilterParameter : public Filter
        */
     LinkedDataContainerSelectionFilterParameter();
 
-  private:
+  public:
     LinkedDataContainerSelectionFilterParameter(const LinkedDataContainerSelectionFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const LinkedDataContainerSelectionFilterParameter&) = delete;                              // Move assignment Not Implemented
+    LinkedDataContainerSelectionFilterParameter(LinkedDataContainerSelectionFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    LinkedDataContainerSelectionFilterParameter& operator=(const LinkedDataContainerSelectionFilterParameter&) = delete; // Copy Assignment Not Implemented
+    LinkedDataContainerSelectionFilterParameter& operator=(LinkedDataContainerSelectionFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.h
@@ -187,8 +187,10 @@ class SIMPLib_EXPORT MultiAttributeMatrixSelectionFilterParameter : public Filte
        */
     MultiAttributeMatrixSelectionFilterParameter();
 
-  private:
+  public:
     MultiAttributeMatrixSelectionFilterParameter(const MultiAttributeMatrixSelectionFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const MultiAttributeMatrixSelectionFilterParameter&) = delete;                               // Move assignment Not Implemented
+    MultiAttributeMatrixSelectionFilterParameter(MultiAttributeMatrixSelectionFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    MultiAttributeMatrixSelectionFilterParameter& operator=(const MultiAttributeMatrixSelectionFilterParameter&) = delete; // Copy Assignment Not Implemented
+    MultiAttributeMatrixSelectionFilterParameter& operator=(MultiAttributeMatrixSelectionFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.h
@@ -187,8 +187,10 @@ class SIMPLib_EXPORT MultiDataArraySelectionFilterParameter : public FilterParam
        */
     MultiDataArraySelectionFilterParameter();
 
-  private:
+  public:
     MultiDataArraySelectionFilterParameter(const MultiDataArraySelectionFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const MultiDataArraySelectionFilterParameter&) = delete;                         // Move assignment Not Implemented
+    MultiDataArraySelectionFilterParameter(MultiDataArraySelectionFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    MultiDataArraySelectionFilterParameter& operator=(const MultiDataArraySelectionFilterParameter&) = delete; // Copy Assignment Not Implemented
+    MultiDataArraySelectionFilterParameter& operator=(MultiDataArraySelectionFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/NumericTypeFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/NumericTypeFilterParameter.h
@@ -133,8 +133,10 @@ protected:
   */
   NumericTypeFilterParameter();
 
-private:
+public:
   NumericTypeFilterParameter(const NumericTypeFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const NumericTypeFilterParameter&);                      // Move assignment Not Implemented
+  NumericTypeFilterParameter(NumericTypeFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  NumericTypeFilterParameter& operator=(const NumericTypeFilterParameter&) = delete; // Copy Assignment Not Implemented
+  NumericTypeFilterParameter& operator=(NumericTypeFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/OutputFileFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/OutputFileFilterParameter.h
@@ -141,8 +141,10 @@ class SIMPLib_EXPORT OutputFileFilterParameter : public FilterParameter
          */
       OutputFileFilterParameter();
 
-  private:
-    OutputFileFilterParameter(const OutputFileFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const OutputFileFilterParameter&) = delete;            // Move assignment Not Implemented
+    public:
+      OutputFileFilterParameter(const OutputFileFilterParameter&) = delete;            // Copy Constructor Not Implemented
+      OutputFileFilterParameter(OutputFileFilterParameter&&) = delete;                 // Move Constructor Not Implemented
+      OutputFileFilterParameter& operator=(const OutputFileFilterParameter&) = delete; // Copy Assignment Not Implemented
+      OutputFileFilterParameter& operator=(OutputFileFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/OutputPathFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/OutputPathFilterParameter.h
@@ -140,8 +140,10 @@ public:
        */
   OutputPathFilterParameter();
 
-private:
+public:
   OutputPathFilterParameter(const OutputPathFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const OutputPathFilterParameter&) = delete;            // Move assignment Not Implemented
+  OutputPathFilterParameter(OutputPathFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  OutputPathFilterParameter& operator=(const OutputPathFilterParameter&) = delete; // Copy Assignment Not Implemented
+  OutputPathFilterParameter& operator=(OutputPathFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/ParagraphFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ParagraphFilterParameter.h
@@ -129,8 +129,10 @@ protected:
    */
   ParagraphFilterParameter();
 
-private:
+public:
   ParagraphFilterParameter(const ParagraphFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ParagraphFilterParameter&);                    // Move assignment Not Implemented
+  ParagraphFilterParameter(ParagraphFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  ParagraphFilterParameter& operator=(const ParagraphFilterParameter&) = delete; // Copy Assignment Not Implemented
+  ParagraphFilterParameter& operator=(ParagraphFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/PhaseTypeSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/PhaseTypeSelectionFilterParameter.h
@@ -143,8 +143,10 @@ protected:
   */
   PhaseTypeSelectionFilterParameter();
 
-private:
+public:
   PhaseTypeSelectionFilterParameter(const PhaseTypeSelectionFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const PhaseTypeSelectionFilterParameter&);                             // Move assignment Not Implemented
+  PhaseTypeSelectionFilterParameter(PhaseTypeSelectionFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  PhaseTypeSelectionFilterParameter& operator=(const PhaseTypeSelectionFilterParameter&) = delete; // Copy Assignment Not Implemented
+  PhaseTypeSelectionFilterParameter& operator=(PhaseTypeSelectionFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/PreflightUpdatedValueFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/PreflightUpdatedValueFilterParameter.h
@@ -119,8 +119,10 @@ class SIMPLib_EXPORT PreflightUpdatedValueFilterParameter : public FilterParamet
        */
     PreflightUpdatedValueFilterParameter();
 
-  private:
+  public:
     PreflightUpdatedValueFilterParameter(const PreflightUpdatedValueFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PreflightUpdatedValueFilterParameter&) = delete;                       // Move assignment Not Implemented
+    PreflightUpdatedValueFilterParameter(PreflightUpdatedValueFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    PreflightUpdatedValueFilterParameter& operator=(const PreflightUpdatedValueFilterParameter&) = delete; // Copy Assignment Not Implemented
+    PreflightUpdatedValueFilterParameter& operator=(PreflightUpdatedValueFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/RangeFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/RangeFilterParameter.h
@@ -138,8 +138,10 @@ public:
      */
   RangeFilterParameter();
 
-private:
+public:
   RangeFilterParameter(const RangeFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const RangeFilterParameter&) = delete;       // Move assignment Not Implemented
+  RangeFilterParameter(RangeFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  RangeFilterParameter& operator=(const RangeFilterParameter&) = delete; // Copy Assignment Not Implemented
+  RangeFilterParameter& operator=(RangeFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/ReadASCIIDataFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ReadASCIIDataFilterParameter.h
@@ -62,8 +62,10 @@ public:
   protected:
     ReadASCIIDataFilterParameter();
 
-  private:
+  public:
     ReadASCIIDataFilterParameter(const ReadASCIIDataFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ReadASCIIDataFilterParameter&) = delete;               // Move assignment Not Implemented
+    ReadASCIIDataFilterParameter(ReadASCIIDataFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    ReadASCIIDataFilterParameter& operator=(const ReadASCIIDataFilterParameter&) = delete; // Copy Assignment Not Implemented
+    ReadASCIIDataFilterParameter& operator=(ReadASCIIDataFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/ScalarTypeFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ScalarTypeFilterParameter.h
@@ -133,8 +133,10 @@ protected:
   */
   ScalarTypeFilterParameter();
 
-private:
+public:
   ScalarTypeFilterParameter(const ScalarTypeFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ScalarTypeFilterParameter&);                     // Move assignment Not Implemented
+  ScalarTypeFilterParameter(ScalarTypeFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  ScalarTypeFilterParameter& operator=(const ScalarTypeFilterParameter&) = delete; // Copy Assignment Not Implemented
+  ScalarTypeFilterParameter& operator=(ScalarTypeFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/SecondOrderPolynomialFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/SecondOrderPolynomialFilterParameter.h
@@ -166,8 +166,10 @@ public:
      */
   SecondOrderPolynomialFilterParameter();
 
-private:
+public:
   SecondOrderPolynomialFilterParameter(const SecondOrderPolynomialFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SecondOrderPolynomialFilterParameter&) = delete;                       // Move assignment Not Implemented
+  SecondOrderPolynomialFilterParameter(SecondOrderPolynomialFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  SecondOrderPolynomialFilterParameter& operator=(const SecondOrderPolynomialFilterParameter&) = delete; // Copy Assignment Not Implemented
+  SecondOrderPolynomialFilterParameter& operator=(SecondOrderPolynomialFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/SeparatorFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/SeparatorFilterParameter.h
@@ -74,8 +74,10 @@ class SIMPLib_EXPORT SeparatorFilterParameter : public FilterParameter
      */
     SeparatorFilterParameter();
 
-  private:
+  public:
     SeparatorFilterParameter(const SeparatorFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SeparatorFilterParameter&) = delete;           // Move assignment Not Implemented
+    SeparatorFilterParameter(SeparatorFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    SeparatorFilterParameter& operator=(const SeparatorFilterParameter&) = delete; // Copy Assignment Not Implemented
+    SeparatorFilterParameter& operator=(SeparatorFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/ShapeTypeSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ShapeTypeSelectionFilterParameter.h
@@ -136,8 +136,10 @@ protected:
   */
   ShapeTypeSelectionFilterParameter();
 
-private:
+public:
   ShapeTypeSelectionFilterParameter(const ShapeTypeSelectionFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ShapeTypeSelectionFilterParameter&);                             // Move assignment Not Implemented
+  ShapeTypeSelectionFilterParameter(ShapeTypeSelectionFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  ShapeTypeSelectionFilterParameter& operator=(const ShapeTypeSelectionFilterParameter&) = delete; // Copy Assignment Not Implemented
+  ShapeTypeSelectionFilterParameter& operator=(ShapeTypeSelectionFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/StringFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/StringFilterParameter.h
@@ -133,9 +133,11 @@ class SIMPLib_EXPORT StringFilterParameter : public FilterParameter
        */
       StringFilterParameter();
 
-  private:
-    StringFilterParameter(const StringFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const StringFilterParameter&) = delete;        // Move assignment Not Implemented
+    public:
+      StringFilterParameter(const StringFilterParameter&) = delete;            // Copy Constructor Not Implemented
+      StringFilterParameter(StringFilterParameter&&) = delete;                 // Move Constructor Not Implemented
+      StringFilterParameter& operator=(const StringFilterParameter&) = delete; // Copy Assignment Not Implemented
+      StringFilterParameter& operator=(StringFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/FilterParameters/ThirdOrderPolynomialFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ThirdOrderPolynomialFilterParameter.h
@@ -175,8 +175,10 @@ public:
      */
   ThirdOrderPolynomialFilterParameter();
 
-private:
+public:
   ThirdOrderPolynomialFilterParameter(const ThirdOrderPolynomialFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ThirdOrderPolynomialFilterParameter&) = delete;                      // Move assignment Not Implemented
+  ThirdOrderPolynomialFilterParameter(ThirdOrderPolynomialFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  ThirdOrderPolynomialFilterParameter& operator=(const ThirdOrderPolynomialFilterParameter&) = delete; // Copy Assignment Not Implemented
+  ThirdOrderPolynomialFilterParameter& operator=(ThirdOrderPolynomialFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/FilterParameters/UnknownFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/UnknownFilterParameter.h
@@ -80,8 +80,10 @@ public:
      */
     UnknownFilterParameter();
 
-  private:
+  public:
     UnknownFilterParameter(const UnknownFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const UnknownFilterParameter&) = delete;         // Move assignment Not Implemented
+    UnknownFilterParameter(UnknownFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    UnknownFilterParameter& operator=(const UnknownFilterParameter&) = delete; // Copy Assignment Not Implemented
+    UnknownFilterParameter& operator=(UnknownFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Filtering/AbstractDecisionFilter.h
+++ b/Source/SIMPLib/Filtering/AbstractDecisionFilter.h
@@ -148,7 +148,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   AbstractDecisionFilter(const AbstractDecisionFilter&) = delete; // Copy Constructor Not Implemented
   AbstractDecisionFilter(AbstractDecisionFilter&&) = delete;      // Move Constructor Not Implemented

--- a/Source/SIMPLib/Filtering/AbstractFilter.h
+++ b/Source/SIMPLib/Filtering/AbstractFilter.h
@@ -433,7 +433,10 @@ private:
   bool m_Cancel;
   QUuid m_Uuid;
 
+public:
   AbstractFilter(const AbstractFilter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const AbstractFilter&) = delete; // Move assignment Not Implemented
+  AbstractFilter(AbstractFilter&&) = delete;      // Move Constructor Not Implemented
+  AbstractFilter& operator=(const AbstractFilter&) = delete; // Copy Assignment Not Implemented
+  AbstractFilter& operator=(AbstractFilter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Filtering/CorePlugin.h
+++ b/Source/SIMPLib/Filtering/CorePlugin.h
@@ -179,8 +179,11 @@ class CorePlugin : public QObject, public ISIMPLibPlugin
     QList<QString>      m_Filters;
     bool                m_DidLoad;
 
+  public:
     CorePlugin(const CorePlugin&) = delete; // Copy Constructor Not Implemented
-    void operator=(const CorePlugin&) = delete; // Move assignment Not Implemented
+    CorePlugin(CorePlugin&&) = delete;      // Move Constructor Not Implemented
+    CorePlugin& operator=(const CorePlugin&) = delete; // Copy Assignment Not Implemented
+    CorePlugin& operator=(CorePlugin&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Filtering/FilterManager.h
+++ b/Source/SIMPLib/Filtering/FilterManager.h
@@ -158,7 +158,10 @@ private:
   
   static FilterManager* self;
 
-  FilterManager(const FilterManager&);  // Copy Constructor Not Implemented
-  void operator=(const FilterManager&) = delete; // Move assignment Not Implemented
+public:
+  FilterManager(const FilterManager&) = delete;            // Copy Constructor Not Implemented
+  FilterManager(FilterManager&&) = delete;                 // Move Constructor Not Implemented
+  FilterManager& operator=(const FilterManager&) = delete; // Copy Assignment Not Implemented
+  FilterManager& operator=(FilterManager&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Filtering/FilterPipeline.h
+++ b/Source/SIMPLib/Filtering/FilterPipeline.h
@@ -236,7 +236,10 @@ private:
   void connectSignalsSlots();
   void disconnectSignalsSlots();
 
+public:
   FilterPipeline(const FilterPipeline&) = delete; // Copy Constructor Not Implemented
-  void operator=(const FilterPipeline&) = delete; // Move assignment Not Implemented
+  FilterPipeline(FilterPipeline&&) = delete;      // Move Constructor Not Implemented
+  FilterPipeline& operator=(const FilterPipeline&) = delete; // Copy Assignment Not Implemented
+  FilterPipeline& operator=(FilterPipeline&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Filtering/QMetaObjectUtilities.h
+++ b/Source/SIMPLib/Filtering/QMetaObjectUtilities.h
@@ -50,8 +50,10 @@ public:
 protected:
   QMetaObjectUtilities();
 
-private:
+public:
   QMetaObjectUtilities(const QMetaObjectUtilities&) = delete; // Copy Constructor Not Implemented
-  void operator=(const QMetaObjectUtilities&);                // Move assignment Not Implemented
+  QMetaObjectUtilities(QMetaObjectUtilities&&) = delete;      // Move Constructor Not Implemented
+  QMetaObjectUtilities& operator=(const QMetaObjectUtilities&) = delete; // Copy Assignment Not Implemented
+  QMetaObjectUtilities& operator=(QMetaObjectUtilities&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Filtering/ThresholdFilterHelper.h
+++ b/Source/SIMPLib/Filtering/ThresholdFilterHelper.h
@@ -124,7 +124,10 @@ private:
   double comparisonValue;
   BoolArrayType* m_Output;
 
+public:
   ThresholdFilterHelper(const ThresholdFilterHelper&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ThresholdFilterHelper&);                 // Move assignment Not Implemented
+  ThresholdFilterHelper(ThresholdFilterHelper&&) = delete;      // Move Constructor Not Implemented
+  ThresholdFilterHelper& operator=(const ThresholdFilterHelper&) = delete; // Copy Assignment Not Implemented
+  ThresholdFilterHelper& operator=(ThresholdFilterHelper&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Geometry/EdgeGeom.h
+++ b/Source/SIMPLib/Geometry/EdgeGeom.h
@@ -373,8 +373,11 @@ class SIMPLib_EXPORT EdgeGeom : public IGeometry
 
     friend class FindEdgeDerivativesImpl;
 
+  public:
     EdgeGeom(const EdgeGeom&) = delete;       // Copy Constructor Not Implemented
-    void operator=(const EdgeGeom&) = delete; // Move assignment Not Implemented
+    EdgeGeom(EdgeGeom&&) = delete;            // Move Constructor Not Implemented
+    EdgeGeom& operator=(const EdgeGeom&) = delete; // Copy Assignment Not Implemented
+    EdgeGeom& operator=(EdgeGeom&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/HexahedralGeom.h
+++ b/Source/SIMPLib/Geometry/HexahedralGeom.h
@@ -547,8 +547,11 @@ class SIMPLib_EXPORT HexahedralGeom : public IGeometry3D
 
     friend class FindHexDerivativesImpl;
 
+  public:
     HexahedralGeom(const HexahedralGeom&) = delete; // Copy Constructor Not Implemented
-    void operator=(const HexahedralGeom&) = delete;  // Operator '=' Not Implemented
+    HexahedralGeom(HexahedralGeom&&) = delete;      // Move Constructor Not Implemented
+    HexahedralGeom& operator=(const HexahedralGeom&) = delete; // Copy Assignment Not Implemented
+    HexahedralGeom& operator=(HexahedralGeom&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/IGeometry.h
+++ b/Source/SIMPLib/Geometry/IGeometry.h
@@ -443,7 +443,9 @@ class SIMPLib_EXPORT IGeometry : public Observable
      */
     virtual void setElementSizes(FloatArrayType::Pointer elementSizes) = 0;
 
-  private:
+  public:
     IGeometry(const IGeometry&) = delete;      // Copy Constructor Not Implemented
-    void operator=(const IGeometry&) = delete; // Move assignment Not Implemented
+    IGeometry(IGeometry&&) = delete;           // Move Constructor Not Implemented
+    IGeometry& operator=(const IGeometry&) = delete; // Copy Assignment Not Implemented
+    IGeometry& operator=(IGeometry&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/Geometry/IGeometry2D.h
+++ b/Source/SIMPLib/Geometry/IGeometry2D.h
@@ -201,10 +201,11 @@ class SIMPLib_EXPORT IGeometry2D : public IGeometry
      */
     virtual void setUnsharedEdges(SharedEdgeList::Pointer bEdgeList) = 0;
 
-
-  private:
+  public:
     IGeometry2D(const IGeometry2D&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const IGeometry2D&) = delete; // Move assignment Not Implemented
+    IGeometry2D(IGeometry2D&&) = delete;         // Move Constructor Not Implemented
+    IGeometry2D& operator=(const IGeometry2D&) = delete; // Copy Assignment Not Implemented
+    IGeometry2D& operator=(IGeometry2D&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/IGeometry3D.h
+++ b/Source/SIMPLib/Geometry/IGeometry3D.h
@@ -235,9 +235,11 @@ class SIMPLib_EXPORT IGeometry3D : public IGeometry
      */
     virtual void setUnsharedFaces(SharedFaceList::Pointer bFaceList) = 0;
 
-  private:
+  public:
     IGeometry3D(const IGeometry3D&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const IGeometry3D&) = delete; // Move assignment Not Implemented
+    IGeometry3D(IGeometry3D&&) = delete;         // Move Constructor Not Implemented
+    IGeometry3D& operator=(const IGeometry3D&) = delete; // Copy Assignment Not Implemented
+    IGeometry3D& operator=(IGeometry3D&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/IGeometryGrid.h
+++ b/Source/SIMPLib/Geometry/IGeometryGrid.h
@@ -88,9 +88,11 @@ class SIMPLib_EXPORT IGeometryGrid : public IGeometry
     virtual void getCoords(size_t x, size_t y, size_t z, double coords[3]) = 0;
     virtual void getCoords(size_t idx, double coords[3]) = 0;
 
-  private:
+  public:
     IGeometryGrid(const IGeometryGrid&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const IGeometryGrid&) = delete; // Move assignment Not Implemented
+    IGeometryGrid(IGeometryGrid&&) = delete;       // Move Constructor Not Implemented
+    IGeometryGrid& operator=(const IGeometryGrid&) = delete; // Copy Assignment Not Implemented
+    IGeometryGrid& operator=(IGeometryGrid&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/ImageGeom.h
+++ b/Source/SIMPLib/Geometry/ImageGeom.h
@@ -390,8 +390,11 @@ class SIMPLib_EXPORT ImageGeom : public IGeometryGrid
 
     friend class FindImageDerivativesImpl;
 
+  public:
     ImageGeom(const ImageGeom&) = delete;      // Copy Constructor Not Implemented
-    void operator=(const ImageGeom&) = delete; // Move assignment Not Implemented
+    ImageGeom(ImageGeom&&) = delete;           // Move Constructor Not Implemented
+    ImageGeom& operator=(const ImageGeom&) = delete; // Copy Assignment Not Implemented
+    ImageGeom& operator=(ImageGeom&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/QuadGeom.h
+++ b/Source/SIMPLib/Geometry/QuadGeom.h
@@ -478,8 +478,11 @@ class SIMPLib_EXPORT QuadGeom : public IGeometry2D
 
     friend class FindQuadDerivativesImpl;
 
+  public:
     QuadGeom(const QuadGeom&) = delete;       // Copy Constructor Not Implemented
-    void operator=(const QuadGeom&) = delete; // Move assignment Not Implemented
+    QuadGeom(QuadGeom&&) = delete;            // Move Constructor Not Implemented
+    QuadGeom& operator=(const QuadGeom&) = delete; // Copy Assignment Not Implemented
+    QuadGeom& operator=(QuadGeom&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/RectGridGeom.h
+++ b/Source/SIMPLib/Geometry/RectGridGeom.h
@@ -282,8 +282,11 @@ class SIMPLib_EXPORT RectGridGeom : public IGeometryGrid
 
     friend class FindRectGridDerivativesImpl;
 
+  public:
     RectGridGeom(const RectGridGeom&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const RectGridGeom&) = delete; // Move assignment Not Implemented
+    RectGridGeom(RectGridGeom&&) = delete;        // Move Constructor Not Implemented
+    RectGridGeom& operator=(const RectGridGeom&) = delete; // Copy Assignment Not Implemented
+    RectGridGeom& operator=(RectGridGeom&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/ShapeOps/CubeOctohedronOps.h
+++ b/Source/SIMPLib/Geometry/ShapeOps/CubeOctohedronOps.h
@@ -63,8 +63,11 @@ class SIMPLib_EXPORT CubeOctohedronOps : public ShapeOps
   private:
     float Gvalue;
 
+  public:
     CubeOctohedronOps(const CubeOctohedronOps&) = delete; // Copy Constructor Not Implemented
-    void operator=(const CubeOctohedronOps&) = delete;    // Move assignment Not Implemented
+    CubeOctohedronOps(CubeOctohedronOps&&) = delete;      // Move Constructor Not Implemented
+    CubeOctohedronOps& operator=(const CubeOctohedronOps&) = delete; // Copy Assignment Not Implemented
+    CubeOctohedronOps& operator=(CubeOctohedronOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/ShapeOps/CylinderAOps.h
+++ b/Source/SIMPLib/Geometry/ShapeOps/CylinderAOps.h
@@ -59,9 +59,12 @@ class SIMPLib_EXPORT CylinderAOps : public ShapeOps
 
   protected:
     CylinderAOps();
-  private:
+
+  public:
     CylinderAOps(const CylinderAOps&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const CylinderAOps&) = delete; // Move assignment Not Implemented
+    CylinderAOps(CylinderAOps&&) = delete;        // Move Constructor Not Implemented
+    CylinderAOps& operator=(const CylinderAOps&) = delete; // Copy Assignment Not Implemented
+    CylinderAOps& operator=(CylinderAOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/ShapeOps/CylinderBOps.h
+++ b/Source/SIMPLib/Geometry/ShapeOps/CylinderBOps.h
@@ -59,9 +59,12 @@ class SIMPLib_EXPORT CylinderBOps : public ShapeOps
 
   protected:
     CylinderBOps();
-  private:
+
+  public:
     CylinderBOps(const CylinderBOps&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const CylinderBOps&) = delete; // Move assignment Not Implemented
+    CylinderBOps(CylinderBOps&&) = delete;        // Move Constructor Not Implemented
+    CylinderBOps& operator=(const CylinderBOps&) = delete; // Copy Assignment Not Implemented
+    CylinderBOps& operator=(CylinderBOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/ShapeOps/CylinderCOps.h
+++ b/Source/SIMPLib/Geometry/ShapeOps/CylinderCOps.h
@@ -59,9 +59,12 @@ class SIMPLib_EXPORT CylinderCOps : public ShapeOps
 
   protected:
     CylinderCOps();
-  private:
+
+  public:
     CylinderCOps(const CylinderCOps&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const CylinderCOps&) = delete; // Move assignment Not Implemented
+    CylinderCOps(CylinderCOps&&) = delete;        // Move Constructor Not Implemented
+    CylinderCOps& operator=(const CylinderCOps&) = delete; // Copy Assignment Not Implemented
+    CylinderCOps& operator=(CylinderCOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/ShapeOps/EllipsoidOps.h
+++ b/Source/SIMPLib/Geometry/ShapeOps/EllipsoidOps.h
@@ -56,9 +56,12 @@ class SIMPLib_EXPORT EllipsoidOps : public ShapeOps
 
   protected:
     EllipsoidOps();
-  private:
+
+  public:
     EllipsoidOps(const EllipsoidOps&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const EllipsoidOps&) = delete; // Move assignment Not Implemented
+    EllipsoidOps(EllipsoidOps&&) = delete;        // Move Constructor Not Implemented
+    EllipsoidOps& operator=(const EllipsoidOps&) = delete; // Copy Assignment Not Implemented
+    EllipsoidOps& operator=(EllipsoidOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/ShapeOps/ShapeOps.h
+++ b/Source/SIMPLib/Geometry/ShapeOps/ShapeOps.h
@@ -89,9 +89,11 @@ class SIMPLib_EXPORT ShapeOps
   protected:
     ShapeOps();
 
-  private:
+  public:
     ShapeOps(const ShapeOps&) = delete;       // Copy Constructor Not Implemented
-    void operator=(const ShapeOps&) = delete; // Move assignment Not Implemented
+    ShapeOps(ShapeOps&&) = delete;            // Move Constructor Not Implemented
+    ShapeOps& operator=(const ShapeOps&) = delete; // Copy Assignment Not Implemented
+    ShapeOps& operator=(ShapeOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/ShapeOps/SuperEllipsoidOps.h
+++ b/Source/SIMPLib/Geometry/ShapeOps/SuperEllipsoidOps.h
@@ -61,8 +61,11 @@ class SIMPLib_EXPORT SuperEllipsoidOps : public ShapeOps
   private:
     float Nvalue;
 
+  public:
     SuperEllipsoidOps(const SuperEllipsoidOps&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SuperEllipsoidOps&) = delete;    // Move assignment Not Implemented
+    SuperEllipsoidOps(SuperEllipsoidOps&&) = delete;      // Move Constructor Not Implemented
+    SuperEllipsoidOps& operator=(const SuperEllipsoidOps&) = delete; // Copy Assignment Not Implemented
+    SuperEllipsoidOps& operator=(SuperEllipsoidOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/TetrahedralGeom.h
+++ b/Source/SIMPLib/Geometry/TetrahedralGeom.h
@@ -577,8 +577,11 @@ class SIMPLib_EXPORT TetrahedralGeom : public IGeometry3D
 
     friend class FindTetDerivativesImpl;
 
+  public:
     TetrahedralGeom(const TetrahedralGeom&) = delete; // Copy Constructor Not Implemented
-    void operator=(const TetrahedralGeom&) = delete;  // Move assignment Not Implemented
+    TetrahedralGeom(TetrahedralGeom&&) = delete;      // Move Constructor Not Implemented
+    TetrahedralGeom& operator=(const TetrahedralGeom&) = delete; // Copy Assignment Not Implemented
+    TetrahedralGeom& operator=(TetrahedralGeom&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/TriangleGeom.h
+++ b/Source/SIMPLib/Geometry/TriangleGeom.h
@@ -477,8 +477,11 @@ class SIMPLib_EXPORT TriangleGeom : public IGeometry2D
 
     friend class FindTriangleDerivativesImpl;
 
+  public:
     TriangleGeom(const TriangleGeom&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const TriangleGeom&) = delete; // Move assignment Not Implemented
+    TriangleGeom(TriangleGeom&&) = delete;        // Move Constructor Not Implemented
+    TriangleGeom& operator=(const TriangleGeom&) = delete; // Copy Assignment Not Implemented
+    TriangleGeom& operator=(TriangleGeom&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Geometry/VertexGeom.h
+++ b/Source/SIMPLib/Geometry/VertexGeom.h
@@ -304,8 +304,11 @@ class SIMPLib_EXPORT VertexGeom : public IGeometry
     SharedVertexList::Pointer m_VertexList;
     FloatArrayType::Pointer m_VertexSizes;
 
+  public:
     VertexGeom(const VertexGeom&) = delete;     // Copy Constructor Not Implemented
-    void operator=(const VertexGeom&) = delete; // Move assignment Not Implemented
+    VertexGeom(VertexGeom&&) = delete;          // Move Constructor Not Implemented
+    VertexGeom& operator=(const VertexGeom&) = delete; // Copy Assignment Not Implemented
+    VertexGeom& operator=(VertexGeom&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/HDF5/H5BoundaryStatsDataDelegate.h
+++ b/Source/SIMPLib/HDF5/H5BoundaryStatsDataDelegate.h
@@ -79,9 +79,11 @@ class SIMPLib_EXPORT H5BoundaryStatsDataDelegate : public H5StatsDataDelegate
     int writeParentPhase(BoundaryStatsData* data, hid_t groupId);
     int readParentPhase(BoundaryStatsData* data, hid_t groupId);
 
-  private:
+  public:
     H5BoundaryStatsDataDelegate(const H5BoundaryStatsDataDelegate&) = delete; // Copy Constructor Not Implemented
-    void operator=(const H5BoundaryStatsDataDelegate&) = delete;              // Move assignment Not Implemented
+    H5BoundaryStatsDataDelegate(H5BoundaryStatsDataDelegate&&) = delete;      // Move Constructor Not Implemented
+    H5BoundaryStatsDataDelegate& operator=(const H5BoundaryStatsDataDelegate&) = delete; // Copy Assignment Not Implemented
+    H5BoundaryStatsDataDelegate& operator=(H5BoundaryStatsDataDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/HDF5/H5DataArrayReader.h
+++ b/Source/SIMPLib/HDF5/H5DataArrayReader.h
@@ -98,9 +98,11 @@ class SIMPLib_EXPORT H5DataArrayReader
   protected:
     H5DataArrayReader();
 
-  private:
+  public:
     H5DataArrayReader(const H5DataArrayReader&) = delete; // Copy Constructor Not Implemented
-    void operator=(const H5DataArrayReader&) = delete;    // Move assignment Not Implemented
+    H5DataArrayReader(H5DataArrayReader&&) = delete;      // Move Constructor Not Implemented
+    H5DataArrayReader& operator=(const H5DataArrayReader&) = delete; // Copy Assignment Not Implemented
+    H5DataArrayReader& operator=(H5DataArrayReader&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/HDF5/H5MatrixStatsDataDelegate.h
+++ b/Source/SIMPLib/HDF5/H5MatrixStatsDataDelegate.h
@@ -72,9 +72,11 @@ class SIMPLib_EXPORT H5MatrixStatsDataDelegate : public H5StatsDataDelegate
     int writePhaseFraction(MatrixStatsData* data, hid_t groupId);
     int readPhaseFraction(MatrixStatsData* data, hid_t groupId);
 
-  private:
+  public:
     H5MatrixStatsDataDelegate(const H5MatrixStatsDataDelegate&) = delete; // Copy Constructor Not Implemented
-    void operator=(const H5MatrixStatsDataDelegate&) = delete;            // Move assignment Not Implemented
+    H5MatrixStatsDataDelegate(H5MatrixStatsDataDelegate&&) = delete;      // Move Constructor Not Implemented
+    H5MatrixStatsDataDelegate& operator=(const H5MatrixStatsDataDelegate&) = delete; // Copy Assignment Not Implemented
+    H5MatrixStatsDataDelegate& operator=(H5MatrixStatsDataDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/HDF5/H5PrecipitateStatsDataDelegate.h
+++ b/Source/SIMPLib/HDF5/H5PrecipitateStatsDataDelegate.h
@@ -123,9 +123,11 @@ class SIMPLib_EXPORT H5PrecipitateStatsDataDelegate : public H5StatsDataDelegate
 
     VectorOfFloatArray createRDFMaxMinDistributionArrays();
 
-  private:
+  public:
     H5PrecipitateStatsDataDelegate(const H5PrecipitateStatsDataDelegate&) = delete; // Copy Constructor Not Implemented
-    void operator=(const H5PrecipitateStatsDataDelegate&) = delete;                 // Move assignment Not Implemented
+    H5PrecipitateStatsDataDelegate(H5PrecipitateStatsDataDelegate&&) = delete;      // Move Constructor Not Implemented
+    H5PrecipitateStatsDataDelegate& operator=(const H5PrecipitateStatsDataDelegate&) = delete; // Copy Assignment Not Implemented
+    H5PrecipitateStatsDataDelegate& operator=(H5PrecipitateStatsDataDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/HDF5/H5PrimaryStatsDataDelegate.h
+++ b/Source/SIMPLib/HDF5/H5PrimaryStatsDataDelegate.h
@@ -111,9 +111,11 @@ class SIMPLib_EXPORT H5PrimaryStatsDataDelegate : public H5StatsDataDelegate
 
     VectorOfFloatArray createLogNormalDistributionArrays();
 
-  private:
+  public:
     H5PrimaryStatsDataDelegate(const H5PrimaryStatsDataDelegate&) = delete; // Copy Constructor Not Implemented
-    void operator=(const H5PrimaryStatsDataDelegate&) = delete;             // Move assignment Not Implemented
+    H5PrimaryStatsDataDelegate(H5PrimaryStatsDataDelegate&&) = delete;      // Move Constructor Not Implemented
+    H5PrimaryStatsDataDelegate& operator=(const H5PrimaryStatsDataDelegate&) = delete; // Copy Assignment Not Implemented
+    H5PrimaryStatsDataDelegate& operator=(H5PrimaryStatsDataDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/HDF5/H5StatsDataDelegate.h
+++ b/Source/SIMPLib/HDF5/H5StatsDataDelegate.h
@@ -70,9 +70,11 @@ class SIMPLib_EXPORT H5StatsDataDelegate
 
     int readStatsDataName(StatsData* data, hid_t groupId);
 
-  private:
+  public:
     H5StatsDataDelegate(const H5StatsDataDelegate&) = delete; // Copy Constructor Not Implemented
-    void operator=(const H5StatsDataDelegate&) = delete;      // Move assignment Not Implemented
+    H5StatsDataDelegate(H5StatsDataDelegate&&) = delete;      // Move Constructor Not Implemented
+    H5StatsDataDelegate& operator=(const H5StatsDataDelegate&) = delete; // Copy Assignment Not Implemented
+    H5StatsDataDelegate& operator=(H5StatsDataDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/HDF5/H5TransformationStatsDataDelegate.h
+++ b/Source/SIMPLib/HDF5/H5TransformationStatsDataDelegate.h
@@ -114,9 +114,11 @@ class SIMPLib_EXPORT H5TransformationStatsDataDelegate : public H5StatsDataDeleg
 
     VectorOfFloatArray createLogNormalDistributionArrays();
 
-  private:
+  public:
     H5TransformationStatsDataDelegate(const H5TransformationStatsDataDelegate&) = delete; // Copy Constructor Not Implemented
-    void operator=(const H5TransformationStatsDataDelegate&) = delete;                    // Move assignment Not Implemented
+    H5TransformationStatsDataDelegate(H5TransformationStatsDataDelegate&&) = delete;      // Move Constructor Not Implemented
+    H5TransformationStatsDataDelegate& operator=(const H5TransformationStatsDataDelegate&) = delete; // Copy Assignment Not Implemented
+    H5TransformationStatsDataDelegate& operator=(H5TransformationStatsDataDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/ITK/itkInPlaceDream3DDataToImageFilter.h
+++ b/Source/SIMPLib/ITK/itkInPlaceDream3DDataToImageFilter.h
@@ -57,7 +57,7 @@ protected:
 
 private:
   InPlaceDream3DDataToImageFilter(const InPlaceDream3DDataToImageFilter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const InPlaceDream3DDataToImageFilter&);                           // Move assignment Not Implemented
+  void operator=(const InPlaceDream3DDataToImageFilter&) = delete;                  // Move assignment Not Implemented
   using Superclass::SetInput;
   std::string m_DataArrayName;
   std::string m_AttributeMatrixArrayName;

--- a/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.h
+++ b/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.h
@@ -65,7 +65,7 @@ protected:
 private:
   using Superclass::SetInput;
   InPlaceImageToDream3DDataFilter(const InPlaceImageToDream3DDataFilter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const InPlaceImageToDream3DDataFilter&);                           // Move assignment Not Implemented
+  void operator=(const InPlaceImageToDream3DDataFilter&) = delete;                  // Move assignment Not Implemented
   std::string m_DataArrayName;
   std::string m_AttributeMatrixArrayName;
   bool m_InPlace; // enable the possibility of in-place

--- a/Source/SIMPLib/Math/GeometryMath.h
+++ b/Source/SIMPLib/Math/GeometryMath.h
@@ -355,9 +355,11 @@ class SIMPLib_EXPORT GeometryMath
   protected:
     GeometryMath();
 
-  private:
+  public:
     GeometryMath(const GeometryMath&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const GeometryMath&) = delete; // Move assignment Not Implemented
+    GeometryMath(GeometryMath&&) = delete;        // Move Constructor Not Implemented
+    GeometryMath& operator=(const GeometryMath&) = delete; // Copy Assignment Not Implemented
+    GeometryMath& operator=(GeometryMath&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Math/MatrixMath.h
+++ b/Source/SIMPLib/Math/MatrixMath.h
@@ -311,9 +311,11 @@ class SIMPLib_EXPORT MatrixMath
   protected:
     MatrixMath();
 
-  private:
+  public:
     MatrixMath(const MatrixMath&) = delete;     // Copy Constructor Not Implemented
-    void operator=(const MatrixMath&) = delete; // Move assignment Not Implemented
+    MatrixMath(MatrixMath&&) = delete;          // Move Constructor Not Implemented
+    MatrixMath& operator=(const MatrixMath&) = delete; // Copy Assignment Not Implemented
+    MatrixMath& operator=(MatrixMath&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Math/RadialDistributionFunction.h
+++ b/Source/SIMPLib/Math/RadialDistributionFunction.h
@@ -118,9 +118,11 @@ class SIMPLib_EXPORT RadialDistributionFunction
   protected:
     RadialDistributionFunction();
 
-  private:
+  public:
     RadialDistributionFunction(const RadialDistributionFunction&) = delete; // Copy Constructor Not Implemented
-    void operator=(const RadialDistributionFunction&) = delete;             // Move assignment Not Implemented
+    RadialDistributionFunction(RadialDistributionFunction&&) = delete;      // Move Constructor Not Implemented
+    RadialDistributionFunction& operator=(const RadialDistributionFunction&) = delete; // Copy Assignment Not Implemented
+    RadialDistributionFunction& operator=(RadialDistributionFunction&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Math/SIMPLibMath.h
+++ b/Source/SIMPLib/Math/SIMPLibMath.h
@@ -253,9 +253,11 @@ class SIMPLibMath
   protected:
     SIMPLibMath();
 
-  private:
+  public:
     SIMPLibMath(const SIMPLibMath&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const SIMPLibMath&) = delete; // Move assignment Not Implemented
+    SIMPLibMath(SIMPLibMath&&) = delete;         // Move Constructor Not Implemented
+    SIMPLibMath& operator=(const SIMPLibMath&) = delete; // Copy Assignment Not Implemented
+    SIMPLibMath& operator=(SIMPLibMath&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Plugin/PluginManager.h
+++ b/Source/SIMPLib/Plugin/PluginManager.h
@@ -107,8 +107,11 @@ class SIMPLib_EXPORT PluginManager
     QVector<ISIMPLibPlugin*> plugins;
     static PluginManager* self;
 
+  public:
     PluginManager(const PluginManager&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const PluginManager&) = delete; // Move assignment Not Implemented
+    PluginManager(PluginManager&&) = delete;       // Move Constructor Not Implemented
+    PluginManager& operator=(const PluginManager&) = delete; // Copy Assignment Not Implemented
+    PluginManager& operator=(PluginManager&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Plugin/PluginProxy.h
+++ b/Source/SIMPLib/Plugin/PluginProxy.h
@@ -68,7 +68,10 @@ class SIMPLib_EXPORT PluginProxy
     QString m_FilePath;
     bool m_Enabled;
 
+  public:
     PluginProxy(const PluginProxy&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const PluginProxy&) = delete; // Move assignment Not Implemented
+    PluginProxy(PluginProxy&&) = delete;         // Move Constructor Not Implemented
+    PluginProxy& operator=(const PluginProxy&) = delete; // Copy Assignment Not Implemented
+    PluginProxy& operator=(PluginProxy&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Plugin/SIMPLibPlugin.h
+++ b/Source/SIMPLib/Plugin/SIMPLibPlugin.h
@@ -114,7 +114,10 @@ class SIMPLib_EXPORT SIMPLibPlugin : public QObject
     QString             m_Location;
     QString             m_Status;
 
+  public:
     SIMPLibPlugin(const SIMPLibPlugin&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const SIMPLibPlugin&) = delete; // Move assignment Not Implemented
+    SIMPLibPlugin(SIMPLibPlugin&&) = delete;       // Move Constructor Not Implemented
+    SIMPLibPlugin& operator=(const SIMPLibPlugin&) = delete; // Copy Assignment Not Implemented
+    SIMPLibPlugin& operator=(SIMPLibPlugin&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Plugin/SIMPLibPluginLoader.h
+++ b/Source/SIMPLib/Plugin/SIMPLibPluginLoader.h
@@ -65,9 +65,11 @@ class SIMPLib_EXPORT SIMPLibPluginLoader
   protected:
     SIMPLibPluginLoader();
 
-  private:
+  public:
     SIMPLibPluginLoader(const SIMPLibPluginLoader&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SIMPLibPluginLoader&) = delete;      // Move assignment Not Implemented
+    SIMPLibPluginLoader(SIMPLibPluginLoader&&) = delete;      // Move Constructor Not Implemented
+    SIMPLibPluginLoader& operator=(const SIMPLibPluginLoader&) = delete; // Copy Assignment Not Implemented
+    SIMPLibPluginLoader& operator=(SIMPLibPluginLoader&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/StatsData/BoundaryStatsData.h
+++ b/Source/SIMPLib/StatsData/BoundaryStatsData.h
@@ -168,9 +168,11 @@ class SIMPLib_EXPORT BoundaryStatsData : public StatsData
   protected:
     BoundaryStatsData();
 
-  private:
+  public:
     BoundaryStatsData(const BoundaryStatsData&) = delete; // Copy Constructor Not Implemented
-    void operator=(const BoundaryStatsData&) = delete;    // Move assignment Not Implemented
+    BoundaryStatsData(BoundaryStatsData&&) = delete;      // Move Constructor Not Implemented
+    BoundaryStatsData& operator=(const BoundaryStatsData&) = delete; // Copy Assignment Not Implemented
+    BoundaryStatsData& operator=(BoundaryStatsData&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/StatsData/MatrixStatsData.h
+++ b/Source/SIMPLib/StatsData/MatrixStatsData.h
@@ -153,9 +153,11 @@ class SIMPLib_EXPORT MatrixStatsData : public StatsData
   protected:
     MatrixStatsData();
 
-  private:
+  public:
     MatrixStatsData(const MatrixStatsData&) = delete; // Copy Constructor Not Implemented
-    void operator=(const MatrixStatsData&) = delete;  // Move assignment Not Implemented
+    MatrixStatsData(MatrixStatsData&&) = delete;      // Move Constructor Not Implemented
+    MatrixStatsData& operator=(const MatrixStatsData&) = delete; // Copy Assignment Not Implemented
+    MatrixStatsData& operator=(MatrixStatsData&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/StatsData/PrecipitateStatsData.h
+++ b/Source/SIMPLib/StatsData/PrecipitateStatsData.h
@@ -203,9 +203,11 @@ class SIMPLib_EXPORT PrecipitateStatsData : public StatsData
   protected:
     PrecipitateStatsData();
 
-  private:
+  public:
     PrecipitateStatsData(const PrecipitateStatsData&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PrecipitateStatsData&) = delete;       // Move assignment Not Implemented
+    PrecipitateStatsData(PrecipitateStatsData&&) = delete;      // Move Constructor Not Implemented
+    PrecipitateStatsData& operator=(const PrecipitateStatsData&) = delete; // Copy Assignment Not Implemented
+    PrecipitateStatsData& operator=(PrecipitateStatsData&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/StatsData/PrimaryStatsData.h
+++ b/Source/SIMPLib/StatsData/PrimaryStatsData.h
@@ -200,9 +200,11 @@ class SIMPLib_EXPORT PrimaryStatsData : public StatsData
   protected:
     PrimaryStatsData();
 
-  private:
+  public:
     PrimaryStatsData(const PrimaryStatsData&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PrimaryStatsData&) = delete;   // Move assignment Not Implemented
+    PrimaryStatsData(PrimaryStatsData&&) = delete;      // Move Constructor Not Implemented
+    PrimaryStatsData& operator=(const PrimaryStatsData&) = delete; // Copy Assignment Not Implemented
+    PrimaryStatsData& operator=(PrimaryStatsData&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/StatsData/StatsData.h
+++ b/Source/SIMPLib/StatsData/StatsData.h
@@ -272,9 +272,11 @@ class SIMPLib_EXPORT StatsData
   protected:
     StatsData();
 
-  private:
+  public:
     StatsData(const StatsData&) = delete;      // Copy Constructor Not Implemented
-    void operator=(const StatsData&) = delete; // Move assignment Not Implemented
+    StatsData(StatsData&&) = delete;           // Move Constructor Not Implemented
+    StatsData& operator=(const StatsData&) = delete; // Copy Assignment Not Implemented
+    StatsData& operator=(StatsData&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/StatsData/TransformationStatsData.h
+++ b/Source/SIMPLib/StatsData/TransformationStatsData.h
@@ -200,9 +200,11 @@ class SIMPLib_EXPORT TransformationStatsData : public StatsData
   protected:
     TransformationStatsData();
 
-  private:
+  public:
     TransformationStatsData(const TransformationStatsData&) = delete; // Copy Constructor Not Implemented
-    void operator=(const TransformationStatsData&) = delete;          // Move assignment Not Implemented
+    TransformationStatsData(TransformationStatsData&&) = delete;      // Move Constructor Not Implemented
+    TransformationStatsData& operator=(const TransformationStatsData&) = delete; // Copy Assignment Not Implemented
+    TransformationStatsData& operator=(TransformationStatsData&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/TestFilters/ArraySelectionExample.h
+++ b/Source/SIMPLib/TestFilters/ArraySelectionExample.h
@@ -141,7 +141,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   ArraySelectionExample(const ArraySelectionExample&) = delete; // Copy Constructor Not Implemented
   ArraySelectionExample(ArraySelectionExample&&) = delete;      // Move Constructor Not Implemented

--- a/Source/SIMPLib/TestFilters/DynamicTableExample.h
+++ b/Source/SIMPLib/TestFilters/DynamicTableExample.h
@@ -144,7 +144,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   DynamicTableExample(const DynamicTableExample&) = delete; // Copy Constructor Not Implemented
   DynamicTableExample(DynamicTableExample&&) = delete;      // Move Constructor Not Implemented

--- a/Source/SIMPLib/TestFilters/ErrorWarningFilter.h
+++ b/Source/SIMPLib/TestFilters/ErrorWarningFilter.h
@@ -166,7 +166,6 @@ protected:
   */
   void initialize();
 
-private:
 public:
   ErrorWarningFilter(const ErrorWarningFilter&) = delete; // Copy Constructor Not Implemented
   ErrorWarningFilter(ErrorWarningFilter&&) = delete;      // Move Constructor Not Implemented

--- a/Source/SIMPLib/TestFilters/FilterGroup00.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup00.h
@@ -146,7 +146,7 @@ protected:
   void initialize();
 
 private:
-  TESTCLASSNAME(const TESTCLASSNAME&);  // Copy Constructor Not Implemented
+  TESTCLASSNAME(const TESTCLASSNAME&) = delete;  // Copy Constructor Not Implemented
   void operator=(const TESTCLASSNAME&) = delete; // Move assignment Not Implemented
 };
 

--- a/Source/SIMPLib/TestFilters/FilterGroup01.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup01.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup01(const FilterGroup01&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup01(const FilterGroup01&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup01(FilterGroup01&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup01& operator=(const FilterGroup01&) = delete; // Copy Assignment Not Implemented
   FilterGroup01& operator=(FilterGroup01&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/FilterGroup02.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup02.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup02(const FilterGroup02&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup02(const FilterGroup02&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup02(FilterGroup02&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup02& operator=(const FilterGroup02&) = delete; // Copy Assignment Not Implemented
   FilterGroup02& operator=(FilterGroup02&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/FilterGroup03.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup03.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup03(const FilterGroup03&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup03(const FilterGroup03&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup03(FilterGroup03&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup03& operator=(const FilterGroup03&) = delete; // Copy Assignment Not Implemented
   FilterGroup03& operator=(FilterGroup03&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/FilterGroup04.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup04.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup04(const FilterGroup04&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup04(const FilterGroup04&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup04(FilterGroup04&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup04& operator=(const FilterGroup04&) = delete; // Copy Assignment Not Implemented
   FilterGroup04& operator=(FilterGroup04&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/FilterGroup05.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup05.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup05(const FilterGroup05&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup05(const FilterGroup05&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup05(FilterGroup05&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup05& operator=(const FilterGroup05&) = delete; // Copy Assignment Not Implemented
   FilterGroup05& operator=(FilterGroup05&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/FilterGroup06.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup06.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup06(const FilterGroup06&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup06(const FilterGroup06&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup06(FilterGroup06&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup06& operator=(const FilterGroup06&) = delete; // Copy Assignment Not Implemented
   FilterGroup06& operator=(FilterGroup06&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/FilterGroup07.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup07.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup07(const FilterGroup07&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup07(const FilterGroup07&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup07(FilterGroup07&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup07& operator=(const FilterGroup07&) = delete; // Copy Assignment Not Implemented
   FilterGroup07& operator=(FilterGroup07&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/FilterGroup08.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup08.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup08(const FilterGroup08&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup08(const FilterGroup08&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup08(FilterGroup08&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup08& operator=(const FilterGroup08&) = delete; // Copy Assignment Not Implemented
   FilterGroup08& operator=(FilterGroup08&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/FilterGroup09.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup09.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup09(const FilterGroup09&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup09(const FilterGroup09&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup09(FilterGroup09&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup09& operator=(const FilterGroup09&) = delete; // Copy Assignment Not Implemented
   FilterGroup09& operator=(FilterGroup09&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/FilterGroup10.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup10.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup10(const FilterGroup10&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup10(const FilterGroup10&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup10(FilterGroup10&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup10& operator=(const FilterGroup10&) = delete; // Copy Assignment Not Implemented
   FilterGroup10& operator=(FilterGroup10&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/FilterGroup12.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup12.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup12(const FilterGroup12&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup12(const FilterGroup12&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup12(FilterGroup12&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup12& operator=(const FilterGroup12&) = delete; // Copy Assignment Not Implemented
   FilterGroup12& operator=(FilterGroup12&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/FilterGroup13.h
+++ b/Source/SIMPLib/TestFilters/FilterGroup13.h
@@ -145,8 +145,9 @@ protected:
   */
   void initialize();
 
-private:
-  FilterGroup13(const FilterGroup13&);  // Copy Constructor Not Implemented
+public:
+  FilterGroup13(const FilterGroup13&) = delete;            // Copy Constructor Not Implemented
+  FilterGroup13(FilterGroup13&&) = delete;                 // Move Constructor Not Implemented
   FilterGroup13& operator=(const FilterGroup13&) = delete; // Copy Assignment Not Implemented
   FilterGroup13& operator=(FilterGroup13&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/TestFilters/GenericExample.h
+++ b/Source/SIMPLib/TestFilters/GenericExample.h
@@ -310,7 +310,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   GenericExample(const GenericExample&) = delete; // Copy Constructor Not Implemented
   GenericExample(GenericExample&&) = delete;      // Move Constructor Not Implemented

--- a/Source/SIMPLib/TestFilters/TestFilters.h
+++ b/Source/SIMPLib/TestFilters/TestFilters.h
@@ -100,7 +100,7 @@ protected:
   void initialize();
 
 private:
-  Filt0(const Filt0&);          // Copy Constructor Not Implemented
+  Filt0(const Filt0&) = delete;          // Copy Constructor Not Implemented
   void operator=(const Filt0&) = delete; // Move assignment Not Implemented
 };
 
@@ -192,7 +192,7 @@ protected:
   void initialize();
 
 private:
-  Filt1(const Filt1&);          // Copy Constructor Not Implemented
+  Filt1(const Filt1&) = delete;          // Copy Constructor Not Implemented
   void operator=(const Filt1&) = delete; // Move assignment Not Implemented
 };
 

--- a/Source/SIMPLib/TestFilters/ThresholdExample.h
+++ b/Source/SIMPLib/TestFilters/ThresholdExample.h
@@ -141,7 +141,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   ThresholdExample(const ThresholdExample&) = delete; // Copy Constructor Not Implemented
   ThresholdExample(ThresholdExample&&) = delete;      // Move Constructor Not Implemented

--- a/Source/SIMPLib/Testing/Unused/CSVGrainDataReader.h
+++ b/Source/SIMPLib/Testing/Unused/CSVGrainDataReader.h
@@ -194,7 +194,10 @@ private:
   */
   void readData(const QString& line, int row, size_t i);
 
+public:
   CSVGrainDataReader(const CSVGrainDataReader&) = delete; // Copy Constructor Not Implemented
-  void operator=(const CSVGrainDataReader&);              // Move assignment Not Implemented
+  CSVGrainDataReader(CSVGrainDataReader&&) = delete;      // Move Constructor Not Implemented
+  CSVGrainDataReader& operator=(const CSVGrainDataReader&) = delete; // Copy Assignment Not Implemented
+  CSVGrainDataReader& operator=(CSVGrainDataReader&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Utilities/FilePathGenerator.h
+++ b/Source/SIMPLib/Utilities/FilePathGenerator.h
@@ -74,8 +74,10 @@ public:
 protected:
   FilePathGenerator();
 
-private:
+public:
   FilePathGenerator(const FilePathGenerator&) = delete; // Copy Constructor Not Implemented
-  void operator=(const FilePathGenerator&) = delete;    // Move assignment Not Implemented
+  FilePathGenerator(FilePathGenerator&&) = delete;      // Move Constructor Not Implemented
+  FilePathGenerator& operator=(const FilePathGenerator&) = delete; // Copy Assignment Not Implemented
+  FilePathGenerator& operator=(FilePathGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Utilities/FloatSummation.h
+++ b/Source/SIMPLib/Utilities/FloatSummation.h
@@ -72,8 +72,10 @@ public:
   */
   static double Kahan(std::initializer_list<double> values);
 
-private:
+public:
   FloatSummation(const FloatSummation&) = delete; // Copy Constructor Not Implemented
-  void operator=(const FloatSummation&) = delete; // Move assignment Not Implemented
+  FloatSummation(FloatSummation&&) = delete;      // Move Constructor Not Implemented
+  FloatSummation& operator=(const FloatSummation&) = delete; // Copy Assignment Not Implemented
+  FloatSummation& operator=(FloatSummation&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/Utilities/SIMPLDataPathValidator.h
+++ b/Source/SIMPLib/Utilities/SIMPLDataPathValidator.h
@@ -74,6 +74,9 @@ class SIMPLib_EXPORT SIMPLDataPathValidator : public QObject
 
     QString m_SIMPLDataDirectory;
 
-    SIMPLDataPathValidator(const SIMPLDataPathValidator&);    // Copy Constructor Not Implemented
-    void operator=(const SIMPLDataPathValidator&);    // Move assignment Not Implemented
+  public:
+    SIMPLDataPathValidator(const SIMPLDataPathValidator&) = delete;            // Copy Constructor Not Implemented
+    SIMPLDataPathValidator(SIMPLDataPathValidator&&) = delete;                 // Move Constructor Not Implemented
+    SIMPLDataPathValidator& operator=(const SIMPLDataPathValidator&) = delete; // Copy Assignment Not Implemented
+    SIMPLDataPathValidator& operator=(SIMPLDataPathValidator&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/Utilities/SIMPLH5DataReader.h
+++ b/Source/SIMPLib/Utilities/SIMPLH5DataReader.h
@@ -124,8 +124,11 @@ class SIMPLib_EXPORT SIMPLH5DataReader : public Observable
      */
     bool readDataContainerBundles(hid_t fileId, DataContainerArray::Pointer dca);
 
+  public:
     SIMPLH5DataReader(const SIMPLH5DataReader&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SIMPLH5DataReader&) = delete;    // Move assignment Not Implemented
+    SIMPLH5DataReader(SIMPLH5DataReader&&) = delete;      // Move Constructor Not Implemented
+    SIMPLH5DataReader& operator=(const SIMPLH5DataReader&) = delete; // Copy Assignment Not Implemented
+    SIMPLH5DataReader& operator=(SIMPLH5DataReader&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Utilities/StringOperations.h
+++ b/Source/SIMPLib/Utilities/StringOperations.h
@@ -74,9 +74,11 @@ class SIMPLib_EXPORT StringOperations
      */
     static QString GeneratePaddedString(int value, int totalDigits, char padChar);
 
-  private:
+  public:
     StringOperations(const StringOperations&) = delete; // Copy Constructor Not Implemented
-    void operator=(const StringOperations&) = delete;   // Move assignment Not Implemented
+    StringOperations(StringOperations&&) = delete;      // Move Constructor Not Implemented
+    StringOperations& operator=(const StringOperations&) = delete; // Copy Assignment Not Implemented
+    StringOperations& operator=(StringOperations&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/Utilities/TestObserver.h
+++ b/Source/SIMPLib/Utilities/TestObserver.h
@@ -52,9 +52,11 @@ class SIMPLib_EXPORT TestObserver : public QObject, public IObserver
  public slots:
       void processPipelineMessage(const PipelineMessage& pm) override;
 
-  private:
-    TestObserver(const TestObserver&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const TestObserver&) = delete; // Move assignment Not Implemented
+    public:
+      TestObserver(const TestObserver&) = delete;            // Copy Constructor Not Implemented
+      TestObserver(TestObserver&&) = delete;                 // Move Constructor Not Implemented
+      TestObserver& operator=(const TestObserver&) = delete; // Copy Assignment Not Implemented
+      TestObserver& operator=(TestObserver&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLib/VTKUtils/VTKFileReader.h
+++ b/Source/SIMPLib/VTKUtils/VTKFileReader.h
@@ -213,10 +213,11 @@ class SIMPLib_EXPORT VTKFileReader : public FileReader
   protected:
     VTKFileReader();
 
-
-  private:
+  public:
     VTKFileReader(const VTKFileReader&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const VTKFileReader&) = delete; // Move assignment Not Implemented
+    VTKFileReader(VTKFileReader&&) = delete;       // Move Constructor Not Implemented
+    VTKFileReader& operator=(const VTKFileReader&) = delete; // Copy Assignment Not Implemented
+    VTKFileReader& operator=(VTKFileReader&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/Animations/PipelineItemBorderSizeAnimation.h
+++ b/Source/SVWidgetsLib/Animations/PipelineItemBorderSizeAnimation.h
@@ -53,6 +53,9 @@ class SVWidgetsLib_EXPORT PipelineItemBorderSizeAnimation : public QVariantAnima
     QPersistentModelIndex m_Index;
     PipelineModel* m_PipelineModel;
 
+  public:
     PipelineItemBorderSizeAnimation(const PipelineItemBorderSizeAnimation&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PipelineItemBorderSizeAnimation&) = delete;        // Operator '=' Not Implemented
+    PipelineItemBorderSizeAnimation(PipelineItemBorderSizeAnimation&&) = delete;      // Move Constructor Not Implemented
+    PipelineItemBorderSizeAnimation& operator=(const PipelineItemBorderSizeAnimation&) = delete; // Copy Assignment Not Implemented
+    PipelineItemBorderSizeAnimation& operator=(PipelineItemBorderSizeAnimation&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SVWidgetsLib/Animations/PipelineItemHeightAnimation.h
+++ b/Source/SVWidgetsLib/Animations/PipelineItemHeightAnimation.h
@@ -59,6 +59,9 @@ class SVWidgetsLib_EXPORT PipelineItemHeightAnimation : public QVariantAnimation
     PipelineModel* m_PipelineModel;
     AnimationDirection m_Direction;
 
+  public:
     PipelineItemHeightAnimation(const PipelineItemHeightAnimation&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PipelineItemHeightAnimation&) = delete;        // Operator '=' Not Implemented
+    PipelineItemHeightAnimation(PipelineItemHeightAnimation&&) = delete;      // Move Constructor Not Implemented
+    PipelineItemHeightAnimation& operator=(const PipelineItemHeightAnimation&) = delete; // Copy Assignment Not Implemented
+    PipelineItemHeightAnimation& operator=(PipelineItemHeightAnimation&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SVWidgetsLib/Animations/PipelineItemSlideAnimation.h
+++ b/Source/SVWidgetsLib/Animations/PipelineItemSlideAnimation.h
@@ -64,6 +64,9 @@ class SVWidgetsLib_EXPORT PipelineItemSlideAnimation : public QVariantAnimation
     int m_NumberOfPixels = 0;
     int m_StartX = 0;
 
+  public:
     PipelineItemSlideAnimation(const PipelineItemSlideAnimation&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PipelineItemSlideAnimation&) = delete;        // Operator '=' Not Implemented
+    PipelineItemSlideAnimation(PipelineItemSlideAnimation&&) = delete;      // Move Constructor Not Implemented
+    PipelineItemSlideAnimation& operator=(const PipelineItemSlideAnimation&) = delete; // Copy Assignment Not Implemented
+    PipelineItemSlideAnimation& operator=(PipelineItemSlideAnimation&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SVWidgetsLib/Core/FilterWidgetManager.h
+++ b/Source/SVWidgetsLib/Core/FilterWidgetManager.h
@@ -112,8 +112,11 @@ class SVWidgetsLib_EXPORT FilterWidgetManager
 
     static FilterWidgetManager* self;
 
+  public:
     FilterWidgetManager(const FilterWidgetManager&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FilterWidgetManager&) = delete;      // Move assignment Not Implemented
+    FilterWidgetManager(FilterWidgetManager&&) = delete;      // Move Constructor Not Implemented
+    FilterWidgetManager& operator=(const FilterWidgetManager&) = delete; // Copy Assignment Not Implemented
+    FilterWidgetManager& operator=(FilterWidgetManager&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/Core/IFilterWidgetFactory.h
+++ b/Source/SVWidgetsLib/Core/IFilterWidgetFactory.h
@@ -74,9 +74,11 @@ class SVWidgetsLib_EXPORT IFilterWidgetFactory
   protected:
     IFilterWidgetFactory();
 
-  private:
+  public:
     IFilterWidgetFactory(const IFilterWidgetFactory&) = delete; // Copy Constructor Not Implemented
-    void operator=(const IFilterWidgetFactory&) = delete;       // Move assignment Not Implemented
+    IFilterWidgetFactory(IFilterWidgetFactory&&) = delete;      // Move Constructor Not Implemented
+    IFilterWidgetFactory& operator=(const IFilterWidgetFactory&) = delete; // Copy Assignment Not Implemented
+    IFilterWidgetFactory& operator=(IFilterWidgetFactory&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/Dialogs/AboutPlugins.h
+++ b/Source/SVWidgetsLib/Dialogs/AboutPlugins.h
@@ -96,7 +96,10 @@ class SVWidgetsLib_EXPORT AboutPlugins : public SVDialog, private Ui::AboutPlugi
     bool m_loadPreferencesDidChange;
     QAction* m_CloseAction = nullptr;
 
+  public:
     AboutPlugins(const AboutPlugins&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const AboutPlugins&) = delete; // Move assignment Not Implemented
+    AboutPlugins(AboutPlugins&&) = delete;        // Move Constructor Not Implemented
+    AboutPlugins& operator=(const AboutPlugins&) = delete; // Copy Assignment Not Implemented
+    AboutPlugins& operator=(AboutPlugins&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Dialogs/ColorPresets.h
+++ b/Source/SVWidgetsLib/Dialogs/ColorPresets.h
@@ -114,7 +114,10 @@ private:
   class vtkInternals;
   vtkInternals* Internals;
 
+public:
   ColorPresets(const ColorPresets&) = delete;   // Copy Constructor Not Implemented
-  void operator=(const ColorPresets&) = delete; // Move assignment Not Implemented
+  ColorPresets(ColorPresets&&) = delete;        // Move Constructor Not Implemented
+  ColorPresets& operator=(const ColorPresets&) = delete; // Copy Assignment Not Implemented
+  ColorPresets& operator=(ColorPresets&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Dialogs/ColorPresetsDialog.h
+++ b/Source/SVWidgetsLib/Dialogs/ColorPresetsDialog.h
@@ -98,7 +98,10 @@ private:
   class pqInternals;
   const QScopedPointer<pqInternals> Internals;
 
+public:
   ColorPresetsDialog(const ColorPresetsDialog&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ColorPresetsDialog&) = delete;     // Move assignment Not Implemented
+  ColorPresetsDialog(ColorPresetsDialog&&) = delete;      // Move Constructor Not Implemented
+  ColorPresetsDialog& operator=(const ColorPresetsDialog&) = delete; // Copy Assignment Not Implemented
+  ColorPresetsDialog& operator=(ColorPresetsDialog&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Dialogs/ColorPresetsDialogTableModel.h
+++ b/Source/SVWidgetsLib/Dialogs/ColorPresetsDialogTableModel.h
@@ -75,7 +75,10 @@ private:
   // 'mutable' allows us to avoid having to pregenerate all the pixmaps.
   mutable QList<QPixmap> Pixmaps;
 
+public:
   ColorPresetsDialogTableModel(const ColorPresetsDialogTableModel&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ColorPresetsDialogTableModel&) = delete;               // Move assignment Not Implemented
+  ColorPresetsDialogTableModel(ColorPresetsDialogTableModel&&) = delete;      // Move Constructor Not Implemented
+  ColorPresetsDialogTableModel& operator=(const ColorPresetsDialogTableModel&) = delete; // Copy Assignment Not Implemented
+  ColorPresetsDialogTableModel& operator=(ColorPresetsDialogTableModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Dialogs/FavoritesChangedDialog.h
+++ b/Source/SVWidgetsLib/Dialogs/FavoritesChangedDialog.h
@@ -74,10 +74,11 @@ class SVWidgetsLib_EXPORT FavoritesChangedDialog : public SVDialog, private Ui::
   private:
     QString m_OpenDialogLastFilePath;
 
-
-  private:
+  public:
     FavoritesChangedDialog(const FavoritesChangedDialog&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FavoritesChangedDialog&) = delete;         // Move assignment Not Implemented
+    FavoritesChangedDialog(FavoritesChangedDialog&&) = delete;      // Move Constructor Not Implemented
+    FavoritesChangedDialog& operator=(const FavoritesChangedDialog&) = delete; // Copy Assignment Not Implemented
+    FavoritesChangedDialog& operator=(FavoritesChangedDialog&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/Dialogs/PluginDetails.h
+++ b/Source/SVWidgetsLib/Dialogs/PluginDetails.h
@@ -68,8 +68,10 @@ class PluginDetails : public QWidget, private Ui::PluginDetails
      */
     void setupGui();
 
-  private:
+  public:
     PluginDetails(const PluginDetails&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const PluginDetails&) = delete; // Move assignment Not Implemented
+    PluginDetails(PluginDetails&&) = delete;       // Move Constructor Not Implemented
+    PluginDetails& operator=(const PluginDetails&) = delete; // Copy Assignment Not Implemented
+    PluginDetails& operator=(PluginDetails&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Dialogs/UpdateCheck.h
+++ b/Source/SVWidgetsLib/Dialogs/UpdateCheck.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT UpdateCheck : public QObject
     QNetworkAccessManager*        m_Nam;
     UpdateCheck::SIMPLVersionData_t m_VersionData;
 
-    UpdateCheck(const UpdateCheck&);    // Copy Constructor Not Implemented
-    void operator=(const UpdateCheck&); // Move assignment Not Implemented
+  public:
+    UpdateCheck(const UpdateCheck&) = delete;            // Copy Constructor Not Implemented
+    UpdateCheck(UpdateCheck&&) = delete;                 // Move Constructor Not Implemented
+    UpdateCheck& operator=(const UpdateCheck&) = delete; // Copy Assignment Not Implemented
+    UpdateCheck& operator=(UpdateCheck&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/Dialogs/UpdateCheckDialog.h
+++ b/Source/SVWidgetsLib/Dialogs/UpdateCheckDialog.h
@@ -144,8 +144,11 @@ class SVWidgetsLib_EXPORT UpdateCheckDialog : public SVDialog, private Ui::Updat
 
     QAction*            m_CloseAction = nullptr;
 
+  public:
     UpdateCheckDialog(const UpdateCheckDialog&) = delete; // Copy Constructor Not Implemented
-    void operator=(const UpdateCheckDialog&) = delete;    // Move assignment Not Implemented
+    UpdateCheckDialog(UpdateCheckDialog&&) = delete;      // Move Constructor Not Implemented
+    UpdateCheckDialog& operator=(const UpdateCheckDialog&) = delete; // Copy Assignment Not Implemented
+    UpdateCheckDialog& operator=(UpdateCheckDialog&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.h
@@ -117,8 +117,11 @@ class SVWidgetsLib_EXPORT AbstractIOFileWidget : public FilterParameterWidget, p
     QString  m_CurrentlyValidPath = "";
     QString  m_CurrentText = "";
 
+  public:
     AbstractIOFileWidget(const AbstractIOFileWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AbstractIOFileWidget&) = delete;       // Move assignment Not Implemented
+    AbstractIOFileWidget(AbstractIOFileWidget&&) = delete;      // Move Constructor Not Implemented
+    AbstractIOFileWidget& operator=(const AbstractIOFileWidget&) = delete; // Copy Assignment Not Implemented
+    AbstractIOFileWidget& operator=(AbstractIOFileWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixCreationWidget.h
@@ -136,8 +136,11 @@ private:
 
   void setSelectedPath(DataArrayPath dcPath);
 
+public:
   AttributeMatrixCreationWidget(const AttributeMatrixCreationWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const AttributeMatrixCreationWidget&) = delete;                // Move assignment Not Implemented
+  AttributeMatrixCreationWidget(AttributeMatrixCreationWidget&&) = delete;      // Move Constructor Not Implemented
+  AttributeMatrixCreationWidget& operator=(const AttributeMatrixCreationWidget&) = delete; // Copy Assignment Not Implemented
+  AttributeMatrixCreationWidget& operator=(AttributeMatrixCreationWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AttributeMatrixSelectionWidget.h
@@ -114,8 +114,11 @@ class SVWidgetsLib_EXPORT AttributeMatrixSelectionWidget : public FilterParamete
 
     void setSelectedPath(DataArrayPath amPath);
 
+  public:
     AttributeMatrixSelectionWidget(const AttributeMatrixSelectionWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AttributeMatrixSelectionWidget&) = delete;                 // Move assignment Not Implemented
+    AttributeMatrixSelectionWidget(AttributeMatrixSelectionWidget&&) = delete;      // Move Constructor Not Implemented
+    AttributeMatrixSelectionWidget& operator=(const AttributeMatrixSelectionWidget&) = delete; // Copy Assignment Not Implemented
+    AttributeMatrixSelectionWidget& operator=(AttributeMatrixSelectionWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AxisAngleWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AxisAngleWidget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT AxisAngleWidget : public FilterParameterWidget, privat
   private:
     AxisAngleFilterParameter*  m_FilterParameter;
 
+  public:
     AxisAngleWidget(const AxisAngleWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AxisAngleWidget&) = delete;  // Move assignment Not Implemented
+    AxisAngleWidget(AxisAngleWidget&&) = delete;      // Move Constructor Not Implemented
+    AxisAngleWidget& operator=(const AxisAngleWidget&) = delete; // Copy Assignment Not Implemented
+    AxisAngleWidget& operator=(AxisAngleWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/BooleanWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/BooleanWidget.h
@@ -88,8 +88,11 @@ class SVWidgetsLib_EXPORT BooleanWidget : public FilterParameterWidget, private 
   private:
     BooleanFilterParameter* m_FilterParameter;
 
+  public:
     BooleanWidget(const BooleanWidget&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const BooleanWidget&) = delete; // Move assignment Not Implemented
+    BooleanWidget(BooleanWidget&&) = delete;       // Move Constructor Not Implemented
+    BooleanWidget& operator=(const BooleanWidget&) = delete; // Copy Assignment Not Implemented
+    BooleanWidget& operator=(BooleanWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/CalculatorWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/CalculatorWidget.h
@@ -124,8 +124,11 @@ class SVWidgetsLib_EXPORT CalculatorWidget : public FilterParameterWidget, priva
 
     void printStringToEquation(QString str);
 
+  public:
     CalculatorWidget(const CalculatorWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const CalculatorWidget&) = delete;   // Move assignment Not Implemented
+    CalculatorWidget(CalculatorWidget&&) = delete;      // Move Constructor Not Implemented
+    CalculatorWidget& operator=(const CalculatorWidget&) = delete; // Copy Assignment Not Implemented
+    CalculatorWidget& operator=(CalculatorWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ChoiceWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ChoiceWidget.h
@@ -94,8 +94,11 @@ class SVWidgetsLib_EXPORT ChoiceWidget : public FilterParameterWidget, private U
   private:
     ChoiceFilterParameter* m_FilterParameter;
 
+  public:
     ChoiceWidget(const ChoiceWidget&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const ChoiceWidget&) = delete; // Move assignment Not Implemented
+    ChoiceWidget(ChoiceWidget&&) = delete;        // Move Constructor Not Implemented
+    ChoiceWidget& operator=(const ChoiceWidget&) = delete; // Copy Assignment Not Implemented
+    ChoiceWidget& operator=(ChoiceWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionItemDelegate.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionItemDelegate.h
@@ -85,8 +85,11 @@ class SVWidgetsLib_EXPORT ComparisonSelectionItemDelegate : public QStyledItemDe
     QStringList m_FeatureList;
     int m_NumberOfPhases;
 
+  public:
     ComparisonSelectionItemDelegate(const ComparisonSelectionItemDelegate&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ComparisonSelectionItemDelegate&) = delete;                  // Move assignment Not Implemented
+    ComparisonSelectionItemDelegate(ComparisonSelectionItemDelegate&&) = delete;      // Move Constructor Not Implemented
+    ComparisonSelectionItemDelegate& operator=(const ComparisonSelectionItemDelegate&) = delete; // Copy Assignment Not Implemented
+    ComparisonSelectionItemDelegate& operator=(ComparisonSelectionItemDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionTableModel.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionTableModel.h
@@ -177,8 +177,11 @@ class SVWidgetsLib_EXPORT ComparisonSelectionTableModel : public QAbstractTableM
     QVector<float>     m_FeatureValues;
     QVector<QString> m_FeatureOperators;
 
+  public:
     ComparisonSelectionTableModel(const ComparisonSelectionTableModel&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ComparisonSelectionTableModel&) = delete;                // Move assignment Not Implemented
+    ComparisonSelectionTableModel(ComparisonSelectionTableModel&&) = delete;      // Move Constructor Not Implemented
+    ComparisonSelectionTableModel& operator=(const ComparisonSelectionTableModel&) = delete; // Copy Assignment Not Implemented
+    ComparisonSelectionTableModel& operator=(ComparisonSelectionTableModel&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ComparisonSelectionWidget.h
@@ -222,8 +222,11 @@ class ComparisonSelectionWidget : public FilterParameterWidget, private Ui::Comp
      */
     ComparisonSelectionTableModel* createComparisonModel();
 
+  public:
     ComparisonSelectionWidget(const ComparisonSelectionWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ComparisonSelectionWidget&) = delete;            // Move assignment Not Implemented
+    ComparisonSelectionWidget(ComparisonSelectionWidget&&) = delete;      // Move Constructor Not Implemented
+    ComparisonSelectionWidget& operator=(const ComparisonSelectionWidget&) = delete; // Copy Assignment Not Implemented
+    ComparisonSelectionWidget& operator=(ComparisonSelectionWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ConstrainedDoubleWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ConstrainedDoubleWidget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT ConstrainedDoubleWidget : public FilterParameterWidget
   private:
     ConstrainedDoubleFilterParameter* m_FilterParameter;
 
+  public:
     ConstrainedDoubleWidget(const ConstrainedDoubleWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ConstrainedDoubleWidget&) = delete;          // Move assignment Not Implemented
+    ConstrainedDoubleWidget(ConstrainedDoubleWidget&&) = delete;      // Move Constructor Not Implemented
+    ConstrainedDoubleWidget& operator=(const ConstrainedDoubleWidget&) = delete; // Copy Assignment Not Implemented
+    ConstrainedDoubleWidget& operator=(ConstrainedDoubleWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ConstrainedIntWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ConstrainedIntWidget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT ConstrainedIntWidget : public FilterParameterWidget, p
   private:
     ConstrainedIntFilterParameter* m_FilterParameter;
 
+  public:
     ConstrainedIntWidget(const ConstrainedIntWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ConstrainedIntWidget&) = delete;       // Move assignment Not Implemented
+    ConstrainedIntWidget(ConstrainedIntWidget&&) = delete;      // Move Constructor Not Implemented
+    ConstrainedIntWidget& operator=(const ConstrainedIntWidget&) = delete; // Copy Assignment Not Implemented
+    ConstrainedIntWidget& operator=(ConstrainedIntWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/CustomWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/CustomWidget.h
@@ -76,10 +76,11 @@ class FilterWidgetsLib_EXPORT CustomWidget : public QWidget, private Ui::CustomW
 
   public slots:
 
-
-  private:
+  public:
     CustomWidget(const CustomWidget&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const CustomWidget&) = delete; // Move assignment Not Implemented
+    CustomWidget(CustomWidget&&) = delete;        // Move Constructor Not Implemented
+    CustomWidget& operator=(const CustomWidget&) = delete; // Copy Assignment Not Implemented
+    CustomWidget& operator=(CustomWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayCreationWidget.h
@@ -121,8 +121,11 @@ class SVWidgetsLib_EXPORT DataArrayCreationWidget : public FilterParameterWidget
 
     void setSelectedPath(DataArrayPath amPath);
 
+  public:
     DataArrayCreationWidget(const DataArrayCreationWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataArrayCreationWidget&) = delete;          // Move assignment Not Implemented
+    DataArrayCreationWidget(DataArrayCreationWidget&&) = delete;      // Move Constructor Not Implemented
+    DataArrayCreationWidget& operator=(const DataArrayCreationWidget&) = delete; // Copy Assignment Not Implemented
+    DataArrayCreationWidget& operator=(DataArrayCreationWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayInformationDisplayWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArrayInformationDisplayWidget.h
@@ -87,9 +87,11 @@ class SVWidgetsLib_EXPORT DataArrayInformationDisplayWidget : public FilterParam
     */
     void setupGui();
 
-  private:
+  public:
     DataArrayInformationDisplayWidget(const DataArrayInformationDisplayWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataArrayInformationDisplayWidget&) = delete;                    // Move assignment Not Implemented
+    DataArrayInformationDisplayWidget(DataArrayInformationDisplayWidget&&) = delete;      // Move Constructor Not Implemented
+    DataArrayInformationDisplayWidget& operator=(const DataArrayInformationDisplayWidget&) = delete; // Copy Assignment Not Implemented
+    DataArrayInformationDisplayWidget& operator=(DataArrayInformationDisplayWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataArraySelectionWidget.h
@@ -121,8 +121,11 @@ class SVWidgetsLib_EXPORT DataArraySelectionWidget : public FilterParameterWidge
 
     void setSelectedPath(DataArrayPath path);
 
+  public:
     DataArraySelectionWidget(const DataArraySelectionWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataArraySelectionWidget&) = delete;           // Move assignment Not Implemented
+    DataArraySelectionWidget(DataArraySelectionWidget&&) = delete;      // Move Constructor Not Implemented
+    DataArraySelectionWidget& operator=(const DataArraySelectionWidget&) = delete; // Copy Assignment Not Implemented
+    DataArraySelectionWidget& operator=(DataArraySelectionWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerArrayProxyWidget.h
@@ -140,8 +140,11 @@ class SVWidgetsLib_EXPORT DataContainerArrayProxyWidget : public FilterParameter
 
     void toggleStrikeOutFont(QListWidgetItem* item, Qt::CheckState state);
 
+  public:
     DataContainerArrayProxyWidget(const DataContainerArrayProxyWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerArrayProxyWidget&) = delete;                // Move assignment Not Implemented
+    DataContainerArrayProxyWidget(DataContainerArrayProxyWidget&&) = delete;      // Move Constructor Not Implemented
+    DataContainerArrayProxyWidget& operator=(const DataContainerArrayProxyWidget&) = delete; // Copy Assignment Not Implemented
+    DataContainerArrayProxyWidget& operator=(DataContainerArrayProxyWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerCreationWidget.h
@@ -91,8 +91,11 @@ class SVWidgetsLib_EXPORT DataContainerCreationWidget : public FilterParameterWi
   private:
     DataContainerCreationFilterParameter*                 m_FilterParameter;
 
+  public:
     DataContainerCreationWidget(const DataContainerCreationWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerCreationWidget&) = delete;              // Move assignment Not Implemented
+    DataContainerCreationWidget(DataContainerCreationWidget&&) = delete;      // Move Constructor Not Implemented
+    DataContainerCreationWidget& operator=(const DataContainerCreationWidget&) = delete; // Copy Assignment Not Implemented
+    DataContainerCreationWidget& operator=(DataContainerCreationWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerReaderWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerReaderWidget.h
@@ -162,7 +162,10 @@ class SVWidgetsLib_EXPORT DataContainerReaderWidget : public FilterParameterWidg
      */
     bool hasValidFilePath(const QString &filePath);
 
+  public:
     DataContainerReaderWidget(const DataContainerReaderWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerReaderWidget&) = delete;            // Move assignment Not Implemented
+    DataContainerReaderWidget(DataContainerReaderWidget&&) = delete;      // Move Constructor Not Implemented
+    DataContainerReaderWidget& operator=(const DataContainerReaderWidget&) = delete; // Copy Assignment Not Implemented
+    DataContainerReaderWidget& operator=(DataContainerReaderWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DataContainerSelectionWidget.h
@@ -123,8 +123,11 @@ class SVWidgetsLib_EXPORT DataContainerSelectionWidget : public FilterParameterW
 
     void setSelectedPath(DataArrayPath dcPath);
 
+  public:
     DataContainerSelectionWidget(const DataContainerSelectionWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerSelectionWidget&) = delete;               // Move assignment Not Implemented
+    DataContainerSelectionWidget(DataContainerSelectionWidget&&) = delete;      // Move Constructor Not Implemented
+    DataContainerSelectionWidget& operator=(const DataContainerSelectionWidget&) = delete; // Copy Assignment Not Implemented
+    DataContainerSelectionWidget& operator=(DataContainerSelectionWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DoubleWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DoubleWidget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT DoubleWidget : public FilterParameterWidget, private U
   private:
     DoubleFilterParameter* m_FilterParameter;
 
+  public:
     DoubleWidget(const DoubleWidget&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const DoubleWidget&) = delete; // Move assignment Not Implemented
+    DoubleWidget(DoubleWidget&&) = delete;        // Move Constructor Not Implemented
+    DoubleWidget& operator=(const DoubleWidget&) = delete; // Copy Assignment Not Implemented
+    DoubleWidget& operator=(DoubleWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DynamicChoiceWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DynamicChoiceWidget.h
@@ -94,8 +94,11 @@ class SVWidgetsLib_EXPORT DynamicChoiceWidget : public FilterParameterWidget, pr
     DynamicChoiceFilterParameter*  m_FilterParameter;
     bool m_DidCausePreflight;
 
+  public:
     DynamicChoiceWidget(const DynamicChoiceWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DynamicChoiceWidget&) = delete;      // Move assignment Not Implemented
+    DynamicChoiceWidget(DynamicChoiceWidget&&) = delete;      // Move Constructor Not Implemented
+    DynamicChoiceWidget& operator=(const DynamicChoiceWidget&) = delete; // Copy Assignment Not Implemented
+    DynamicChoiceWidget& operator=(DynamicChoiceWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DynamicTableItemDelegate.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DynamicTableItemDelegate.h
@@ -56,8 +56,10 @@ class DynamicTableItemDelegate : public QStyledItemDelegate
     void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const override;
     void updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 
-  private:
+  public:
     DynamicTableItemDelegate(const DynamicTableItemDelegate&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DynamicTableItemDelegate&) = delete;           // Move assignment Not Implemented
+    DynamicTableItemDelegate(DynamicTableItemDelegate&&) = delete;      // Move Constructor Not Implemented
+    DynamicTableItemDelegate& operator=(const DynamicTableItemDelegate&) = delete; // Copy Assignment Not Implemented
+    DynamicTableItemDelegate& operator=(DynamicTableItemDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/DynamicTableWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/DynamicTableWidget.h
@@ -113,7 +113,10 @@ class SVWidgetsLib_EXPORT DynamicTableWidget : public FilterParameterWidget, pri
     void renumberDynamicHeaders();
     void updateDynamicButtons();
 
+  public:
     DynamicTableWidget(const DynamicTableWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DynamicTableWidget&) = delete;     // Move assignment Not Implemented
+    DynamicTableWidget(DynamicTableWidget&&) = delete;      // Move Constructor Not Implemented
+    DynamicTableWidget& operator=(const DynamicTableWidget&) = delete; // Copy Assignment Not Implemented
+    DynamicTableWidget& operator=(DynamicTableWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FileListInfoWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FileListInfoWidget.h
@@ -173,7 +173,10 @@ private:
    */
   void connectSignalsSlots();
 
+public:
   FileListInfoWidget(const FileListInfoWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const FileListInfoWidget&) = delete;     // Move assignment Not Implemented
+  FileListInfoWidget(FileListInfoWidget&&) = delete;      // Move Constructor Not Implemented
+  FileListInfoWidget& operator=(const FileListInfoWidget&) = delete; // Copy Assignment Not Implemented
+  FileListInfoWidget& operator=(FileListInfoWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FilterParameterWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FilterParameterWidget.h
@@ -181,8 +181,11 @@ class SVWidgetsLib_EXPORT FilterParameterWidget : public QFrame
     QGraphicsOpacityEffect*       effect;
     QString                       m_CurrentlyValidPath;
 
+  public:
     FilterParameterWidget(const FilterParameterWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FilterParameterWidget&) = delete;        // Move assignment Not Implemented
+    FilterParameterWidget(FilterParameterWidget&&) = delete;      // Move Constructor Not Implemented
+    FilterParameterWidget& operator=(const FilterParameterWidget&) = delete; // Copy Assignment Not Implemented
+    FilterParameterWidget& operator=(FilterParameterWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 // -----------------------------------------------------------------------------

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FloatVec2Widget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FloatVec2Widget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT FloatVec2Widget : public FilterParameterWidget, privat
   private:
     FloatVec2FilterParameter* m_FilterParameter;
 
+  public:
     FloatVec2Widget(const FloatVec2Widget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FloatVec2Widget&) = delete;  // Move assignment Not Implemented
+    FloatVec2Widget(FloatVec2Widget&&) = delete;      // Move Constructor Not Implemented
+    FloatVec2Widget& operator=(const FloatVec2Widget&) = delete; // Copy Assignment Not Implemented
+    FloatVec2Widget& operator=(FloatVec2Widget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FloatVec3Widget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FloatVec3Widget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT FloatVec3Widget : public FilterParameterWidget, privat
   private:
     FloatVec3FilterParameter* m_FilterParameter;
 
+  public:
     FloatVec3Widget(const FloatVec3Widget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FloatVec3Widget&) = delete;  // Move assignment Not Implemented
+    FloatVec3Widget(FloatVec3Widget&&) = delete;      // Move Constructor Not Implemented
+    FloatVec3Widget& operator=(const FloatVec3Widget&) = delete; // Copy Assignment Not Implemented
+    FloatVec3Widget& operator=(FloatVec3Widget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FloatWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FloatWidget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT FloatWidget : public FilterParameterWidget, private Ui
   private:
     FloatFilterParameter* m_FilterParameter;
 
+  public:
     FloatWidget(const FloatWidget&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const FloatWidget&) = delete; // Move assignment Not Implemented
+    FloatWidget(FloatWidget&&) = delete;         // Move Constructor Not Implemented
+    FloatWidget& operator=(const FloatWidget&) = delete; // Copy Assignment Not Implemented
+    FloatWidget& operator=(FloatWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FourthOrderPolynomialWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FourthOrderPolynomialWidget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT FourthOrderPolynomialWidget : public FilterParameterWi
   private:
     FourthOrderPolynomialFilterParameter* m_FilterParameter;
 
+  public:
     FourthOrderPolynomialWidget(const FourthOrderPolynomialWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FourthOrderPolynomialWidget&) = delete;              // Move assignment Not Implemented
+    FourthOrderPolynomialWidget(FourthOrderPolynomialWidget&&) = delete;      // Move Constructor Not Implemented
+    FourthOrderPolynomialWidget& operator=(const FourthOrderPolynomialWidget&) = delete; // Copy Assignment Not Implemented
+    FourthOrderPolynomialWidget& operator=(FourthOrderPolynomialWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/GenerateColorTableWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/GenerateColorTableWidget.h
@@ -108,8 +108,11 @@ class SVWidgetsLib_EXPORT GenerateColorTableWidget : public FilterParameterWidge
     QSharedPointer<ColorPresetsDialog>        m_PresetsDialog;
     bool                                      m_DidCausePreflight;
 
+  public:
     GenerateColorTableWidget(const GenerateColorTableWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const GenerateColorTableWidget&) = delete;           // Move assignment Not Implemented
+    GenerateColorTableWidget(GenerateColorTableWidget&&) = delete;      // Move Constructor Not Implemented
+    GenerateColorTableWidget& operator=(const GenerateColorTableWidget&) = delete; // Copy Assignment Not Implemented
+    GenerateColorTableWidget& operator=(GenerateColorTableWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.h
@@ -175,6 +175,10 @@ private:
   void calculatePrimeFactors(int n, QVector<int>& primeFactors);
 
   ~ImportHDF5DatasetWidget() override;
+
+public:
   ImportHDF5DatasetWidget(const ImportHDF5DatasetWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ImportHDF5DatasetWidget&);                   // Copy Assignment Not Implemented
+  ImportHDF5DatasetWidget(ImportHDF5DatasetWidget&&) = delete;      // Move Constructor Not Implemented
+  ImportHDF5DatasetWidget& operator=(const ImportHDF5DatasetWidget&) = delete; // Copy Assignment Not Implemented
+  ImportHDF5DatasetWidget& operator=(ImportHDF5DatasetWidget&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SVWidgetsLib/FilterParameterWidgets/InputFileWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/InputFileWidget.h
@@ -76,8 +76,11 @@ class SVWidgetsLib_EXPORT InputFileWidget : public AbstractIOFileWidget
   private:
     InputFileFilterParameter* m_FilterParameter;
 
+  public:
     InputFileWidget(const InputFileWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const InputFileWidget&) = delete;  // Move assignment Not Implemented
+    InputFileWidget(InputFileWidget&&) = delete;      // Move Constructor Not Implemented
+    InputFileWidget& operator=(const InputFileWidget&) = delete; // Copy Assignment Not Implemented
+    InputFileWidget& operator=(InputFileWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/InputPathWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/InputPathWidget.h
@@ -77,8 +77,11 @@ class SVWidgetsLib_EXPORT InputPathWidget : public AbstractIOFileWidget
   private:
     InputPathFilterParameter*  m_FilterParameter;
 
+  public:
     InputPathWidget(const InputPathWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const InputPathWidget&) = delete;  // Move assignment Not Implemented
+    InputPathWidget(InputPathWidget&&) = delete;      // Move Constructor Not Implemented
+    InputPathWidget& operator=(const InputPathWidget&) = delete; // Copy Assignment Not Implemented
+    InputPathWidget& operator=(InputPathWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/IntVec3Widget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/IntVec3Widget.h
@@ -89,8 +89,11 @@ class SVWidgetsLib_EXPORT IntVec3Widget : public FilterParameterWidget, private 
   private:
     IntVec3FilterParameter* m_FilterParameter;
 
+  public:
     IntVec3Widget(const IntVec3Widget&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const IntVec3Widget&) = delete; // Move assignment Not Implemented
+    IntVec3Widget(IntVec3Widget&&) = delete;       // Move Constructor Not Implemented
+    IntVec3Widget& operator=(const IntVec3Widget&) = delete; // Copy Assignment Not Implemented
+    IntVec3Widget& operator=(IntVec3Widget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/IntWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/IntWidget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT IntWidget : public FilterParameterWidget, private Ui::
   private:
     IntFilterParameter* m_FilterParameter;
 
+  public:
     IntWidget(const IntWidget&) = delete;      // Copy Constructor Not Implemented
-    void operator=(const IntWidget&) = delete; // Move assignment Not Implemented
+    IntWidget(IntWidget&&) = delete;           // Move Constructor Not Implemented
+    IntWidget& operator=(const IntWidget&) = delete; // Copy Assignment Not Implemented
+    IntWidget& operator=(IntWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/LinkedBooleanWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/LinkedBooleanWidget.h
@@ -97,8 +97,11 @@ class SVWidgetsLib_EXPORT LinkedBooleanWidget : public FilterParameterWidget, pr
   private:
     LinkedBooleanFilterParameter* m_FilterParameter;
 
+  public:
     LinkedBooleanWidget(const LinkedBooleanWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const LinkedBooleanWidget&) = delete;      // Move assignment Not Implemented
+    LinkedBooleanWidget(LinkedBooleanWidget&&) = delete;      // Move Constructor Not Implemented
+    LinkedBooleanWidget& operator=(const LinkedBooleanWidget&) = delete; // Copy Assignment Not Implemented
+    LinkedBooleanWidget& operator=(LinkedBooleanWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/LinkedDataContainerSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/LinkedDataContainerSelectionWidget.h
@@ -124,8 +124,11 @@ class SVWidgetsLib_EXPORT LinkedDataContainerSelectionWidget : public FilterPara
     void setSelectedPath(QString path);
     void setSelectedPath(DataArrayPath dcPath);
 
+  public:
     LinkedDataContainerSelectionWidget(const LinkedDataContainerSelectionWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const LinkedDataContainerSelectionWidget&) = delete;                     // Move assignment Not Implemented
+    LinkedDataContainerSelectionWidget(LinkedDataContainerSelectionWidget&&) = delete;      // Move Constructor Not Implemented
+    LinkedDataContainerSelectionWidget& operator=(const LinkedDataContainerSelectionWidget&) = delete; // Copy Assignment Not Implemented
+    LinkedDataContainerSelectionWidget& operator=(LinkedDataContainerSelectionWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiAttributeMatrixSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiAttributeMatrixSelectionWidget.h
@@ -139,8 +139,11 @@ class SVWidgetsLib_EXPORT MultiAttributeMatrixSelectionWidget : public FilterPar
 
     void selectionChanged();
 
+  public:
     MultiAttributeMatrixSelectionWidget(const MultiAttributeMatrixSelectionWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const MultiAttributeMatrixSelectionWidget&) = delete;                      // Move assignment Not Implemented
+    MultiAttributeMatrixSelectionWidget(MultiAttributeMatrixSelectionWidget&&) = delete;      // Move Constructor Not Implemented
+    MultiAttributeMatrixSelectionWidget& operator=(const MultiAttributeMatrixSelectionWidget&) = delete; // Copy Assignment Not Implemented
+    MultiAttributeMatrixSelectionWidget& operator=(MultiAttributeMatrixSelectionWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataArraySelectionWidget.h
@@ -142,8 +142,11 @@ class SVWidgetsLib_EXPORT MultiDataArraySelectionWidget : public FilterParameter
 
     void selectionChanged();
 
+  public:
     MultiDataArraySelectionWidget(const MultiDataArraySelectionWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const MultiDataArraySelectionWidget&) = delete;                // Move assignment Not Implemented
+    MultiDataArraySelectionWidget(MultiDataArraySelectionWidget&&) = delete;      // Move Constructor Not Implemented
+    MultiDataArraySelectionWidget& operator=(const MultiDataArraySelectionWidget&) = delete; // Copy Assignment Not Implemented
+    MultiDataArraySelectionWidget& operator=(MultiDataArraySelectionWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/NumericTypeWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/NumericTypeWidget.h
@@ -85,8 +85,11 @@ class SVWidgetsLib_EXPORT NumericTypeWidget : public FilterParameterWidget, priv
   private:
     NumericTypeFilterParameter* m_FilterParameter;
 
+  public:
     NumericTypeWidget(const NumericTypeWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const NumericTypeWidget&) = delete;    // Move assignment Not Implemented
+    NumericTypeWidget(NumericTypeWidget&&) = delete;      // Move Constructor Not Implemented
+    NumericTypeWidget& operator=(const NumericTypeWidget&) = delete; // Copy Assignment Not Implemented
+    NumericTypeWidget& operator=(NumericTypeWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/OutputFileWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/OutputFileWidget.h
@@ -73,8 +73,11 @@ class SVWidgetsLib_EXPORT OutputFileWidget : public AbstractIOFileWidget
   private:
     OutputFileFilterParameter*  m_FilterParameter;
 
+  public:
     OutputFileWidget(const OutputFileWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const OutputFileWidget&) = delete;   // Move assignment Not Implemented
+    OutputFileWidget(OutputFileWidget&&) = delete;      // Move Constructor Not Implemented
+    OutputFileWidget& operator=(const OutputFileWidget&) = delete; // Copy Assignment Not Implemented
+    OutputFileWidget& operator=(OutputFileWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/OutputPathWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/OutputPathWidget.h
@@ -73,8 +73,11 @@ class SVWidgetsLib_EXPORT OutputPathWidget : public AbstractIOFileWidget
   private:
     OutputPathFilterParameter*  m_FilterParameter;
 
+  public:
     OutputPathWidget(const OutputPathWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const OutputPathWidget&) = delete;   // Move assignment Not Implemented
+    OutputPathWidget(OutputPathWidget&&) = delete;      // Move Constructor Not Implemented
+    OutputPathWidget& operator=(const OutputPathWidget&) = delete; // Copy Assignment Not Implemented
+    OutputPathWidget& operator=(OutputPathWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ParagraphWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ParagraphWidget.h
@@ -85,7 +85,10 @@ private:
 
   ParagraphFilterParameter* m_FilterParameter;
 
+public:
   ParagraphWidget(const ParagraphWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ParagraphWidget&);           // Move assignment Not Implemented
+  ParagraphWidget(ParagraphWidget&&) = delete;      // Move Constructor Not Implemented
+  ParagraphWidget& operator=(const ParagraphWidget&) = delete; // Copy Assignment Not Implemented
+  ParagraphWidget& operator=(ParagraphWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/PhaseTypeSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/PhaseTypeSelectionWidget.h
@@ -120,8 +120,11 @@ class SVWidgetsLib_EXPORT PhaseTypeSelectionWidget : public FilterParameterWidge
 
     void setSelectedPath(DataArrayPath amPath);
 
+  public:
     PhaseTypeSelectionWidget(const PhaseTypeSelectionWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PhaseTypeSelectionWidget&) = delete;           // Move assignment Not Implemented
+    PhaseTypeSelectionWidget(PhaseTypeSelectionWidget&&) = delete;      // Move Constructor Not Implemented
+    PhaseTypeSelectionWidget& operator=(const PhaseTypeSelectionWidget&) = delete; // Copy Assignment Not Implemented
+    PhaseTypeSelectionWidget& operator=(PhaseTypeSelectionWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/PreflightUpdatedValueWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/PreflightUpdatedValueWidget.h
@@ -87,8 +87,11 @@ class SVWidgetsLib_EXPORT PreflightUpdatedValueWidget : public FilterParameterWi
 
     PreflightUpdatedValueFilterParameter* m_FilterParameter;
 
+  public:
     PreflightUpdatedValueWidget(const PreflightUpdatedValueWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PreflightUpdatedValueWidget&) = delete;              // Move assignment Not Implemented
+    PreflightUpdatedValueWidget(PreflightUpdatedValueWidget&&) = delete;      // Move Constructor Not Implemented
+    PreflightUpdatedValueWidget& operator=(const PreflightUpdatedValueWidget&) = delete; // Copy Assignment Not Implemented
+    PreflightUpdatedValueWidget& operator=(PreflightUpdatedValueWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/RangeWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/RangeWidget.h
@@ -90,8 +90,11 @@ class SVWidgetsLib_EXPORT RangeWidget : public FilterParameterWidget, private Ui
   private:
     RangeFilterParameter* m_FilterParameter;
 
+  public:
     RangeWidget(const RangeWidget&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const RangeWidget&) = delete; // Move assignment Not Implemented
+    RangeWidget(RangeWidget&&) = delete;         // Move Constructor Not Implemented
+    RangeWidget& operator=(const RangeWidget&) = delete; // Copy Assignment Not Implemented
+    RangeWidget& operator=(RangeWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ReadASCIIDataWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ReadASCIIDataWidget.h
@@ -99,7 +99,10 @@ class SVWidgetsLib_EXPORT ReadASCIIDataWidget : public FilterParameterWidget, pr
     QThread*                                          m_WorkerThread;
     LineCounterObject*                                m_LineCounter;
 
+  public:
     ReadASCIIDataWidget(const ReadASCIIDataWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ReadASCIIDataWidget&) = delete;      // Move assignment Not Implemented
+    ReadASCIIDataWidget(ReadASCIIDataWidget&&) = delete;      // Move Constructor Not Implemented
+    ReadASCIIDataWidget& operator=(const ReadASCIIDataWidget&) = delete; // Copy Assignment Not Implemented
+    ReadASCIIDataWidget& operator=(ReadASCIIDataWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ScalarTypeWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ScalarTypeWidget.h
@@ -85,8 +85,11 @@ class SVWidgetsLib_EXPORT ScalarTypeWidget : public FilterParameterWidget, priva
   private:
     ScalarTypeFilterParameter* m_FilterParameter;
 
+  public:
     ScalarTypeWidget(const ScalarTypeWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ScalarTypeWidget&) = delete;   // Move assignment Not Implemented
+    ScalarTypeWidget(ScalarTypeWidget&&) = delete;      // Move Constructor Not Implemented
+    ScalarTypeWidget& operator=(const ScalarTypeWidget&) = delete; // Copy Assignment Not Implemented
+    ScalarTypeWidget& operator=(ScalarTypeWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/SecondOrderPolynomialWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/SecondOrderPolynomialWidget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT SecondOrderPolynomialWidget : public FilterParameterWi
   private:
     SecondOrderPolynomialFilterParameter* m_FilterParameter;
 
+  public:
     SecondOrderPolynomialWidget(const SecondOrderPolynomialWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SecondOrderPolynomialWidget&) = delete;              // Move assignment Not Implemented
+    SecondOrderPolynomialWidget(SecondOrderPolynomialWidget&&) = delete;      // Move Constructor Not Implemented
+    SecondOrderPolynomialWidget& operator=(const SecondOrderPolynomialWidget&) = delete; // Copy Assignment Not Implemented
+    SecondOrderPolynomialWidget& operator=(SecondOrderPolynomialWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/SeparatorWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/SeparatorWidget.h
@@ -92,8 +92,11 @@ class SVWidgetsLib_EXPORT SeparatorWidget : public FilterParameterWidget, privat
 
     SeparatorFilterParameter* m_FilterParameter;
 
+  public:
     SeparatorWidget(const SeparatorWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SeparatorWidget&) = delete;  // Move assignment Not Implemented
+    SeparatorWidget(SeparatorWidget&&) = delete;      // Move Constructor Not Implemented
+    SeparatorWidget& operator=(const SeparatorWidget&) = delete; // Copy Assignment Not Implemented
+    SeparatorWidget& operator=(SeparatorWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ShapeTypeSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ShapeTypeSelectionWidget.h
@@ -102,8 +102,11 @@ class SVWidgetsLib_EXPORT ShapeTypeSelectionWidget : public FilterParameterWidge
 
     ShapeTypeSelectionFilterParameter* m_FilterParameter;
 
+  public:
     ShapeTypeSelectionWidget(const ShapeTypeSelectionWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ShapeTypeSelectionWidget&) = delete;           // Move assignment Not Implemented
+    ShapeTypeSelectionWidget(ShapeTypeSelectionWidget&&) = delete;      // Move Constructor Not Implemented
+    ShapeTypeSelectionWidget& operator=(const ShapeTypeSelectionWidget&) = delete; // Copy Assignment Not Implemented
+    ShapeTypeSelectionWidget& operator=(ShapeTypeSelectionWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/StringWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/StringWidget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT StringWidget : public FilterParameterWidget, private U
   private:
     StringFilterParameter* m_FilterParameter;
 
+  public:
     StringWidget(const StringWidget&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const StringWidget&) = delete; // Move assignment Not Implemented
+    StringWidget(StringWidget&&) = delete;        // Move Constructor Not Implemented
+    StringWidget& operator=(const StringWidget&) = delete; // Copy Assignment Not Implemented
+    StringWidget& operator=(StringWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ThirdOrderPolynomialWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ThirdOrderPolynomialWidget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT ThirdOrderPolynomialWidget : public FilterParameterWid
   private:
     ThirdOrderPolynomialFilterParameter* m_FilterParameter;
 
+  public:
     ThirdOrderPolynomialWidget(const ThirdOrderPolynomialWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ThirdOrderPolynomialWidget&) = delete;             // Move assignment Not Implemented
+    ThirdOrderPolynomialWidget(ThirdOrderPolynomialWidget&&) = delete;      // Move Constructor Not Implemented
+    ThirdOrderPolynomialWidget& operator=(const ThirdOrderPolynomialWidget&) = delete; // Copy Assignment Not Implemented
+    ThirdOrderPolynomialWidget& operator=(ThirdOrderPolynomialWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UnknownWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UnknownWidget.h
@@ -86,8 +86,11 @@ class SVWidgetsLib_EXPORT UnknownWidget : public FilterParameterWidget, private 
 
     UnknownFilterParameter* m_FilterParameter;
 
+  public:
     UnknownWidget(const UnknownWidget&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const UnknownWidget&) = delete; // Move assignment Not Implemented
+    UnknownWidget(UnknownWidget&&) = delete;       // Move Constructor Not Implemented
+    UnknownWidget& operator=(const UnknownWidget&) = delete; // Copy Assignment Not Implemented
+    UnknownWidget& operator=(UnknownWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/QtSupport/QtSApplicationAboutBoxDialog.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSApplicationAboutBoxDialog.h
@@ -94,8 +94,11 @@ class SVWidgetsLib_EXPORT QtSApplicationAboutBoxDialog: public QDialog, private 
   private:
     QStringList m_licenseFiles;
 
+  public:
     QtSApplicationAboutBoxDialog(const QtSApplicationAboutBoxDialog&) = delete; // Copy Constructor Not Implemented
-    void operator=(const QtSApplicationAboutBoxDialog&) = delete;               // Move assignment Not Implemented
+    QtSApplicationAboutBoxDialog(QtSApplicationAboutBoxDialog&&) = delete;      // Move Constructor Not Implemented
+    QtSApplicationAboutBoxDialog& operator=(const QtSApplicationAboutBoxDialog&) = delete; // Copy Assignment Not Implemented
+    QtSApplicationAboutBoxDialog& operator=(QtSApplicationAboutBoxDialog&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/QtSupport/QtSApplicationFileInfo.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSApplicationFileInfo.h
@@ -49,9 +49,10 @@ class SVWidgetsLib_EXPORT QtSApplicationFileInfo
 
     static QString GenerateFileSystemPath(QString pathEnding);
 
-  private:
-
-    QtSApplicationFileInfo(const QtSApplicationFileInfo&);    // Copy Constructor Not Implemented
-    void operator=(const QtSApplicationFileInfo&);            // Move assignment Not Implemented
+  public:
+    QtSApplicationFileInfo(const QtSApplicationFileInfo&) = delete;            // Copy Constructor Not Implemented
+    QtSApplicationFileInfo(QtSApplicationFileInfo&&) = delete;                 // Move Constructor Not Implemented
+    QtSApplicationFileInfo& operator=(const QtSApplicationFileInfo&) = delete; // Copy Assignment Not Implemented
+    QtSApplicationFileInfo& operator=(QtSApplicationFileInfo&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/QtSupport/QtSBookmarkMissingDialog.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSBookmarkMissingDialog.h
@@ -60,8 +60,11 @@ class SVWidgetsLib_EXPORT QtSBookmarkMissingDialog : public QDialog, private Ui:
   private:
     QString m_OpenDialogLastFilePath;
 
+  public:
     QtSBookmarkMissingDialog(const QtSBookmarkMissingDialog&) = delete; // Copy Constructor Not Implemented
-    void operator=(const QtSBookmarkMissingDialog&) = delete;           // Move assignment Not Implemented
+    QtSBookmarkMissingDialog(QtSBookmarkMissingDialog&&) = delete;      // Move Constructor Not Implemented
+    QtSBookmarkMissingDialog& operator=(const QtSBookmarkMissingDialog&) = delete; // Copy Assignment Not Implemented
+    QtSBookmarkMissingDialog& operator=(QtSBookmarkMissingDialog&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/QtSupport/QtSCheckboxDialog.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSCheckboxDialog.h
@@ -66,8 +66,11 @@ class SVWidgetsLib_EXPORT QtSCheckboxDialog : public QDialog
     QVector<QString>    m_List;
     QMap<QString, QCheckBox*>   m_WidgetMap;
 
+  public:
     QtSCheckboxDialog(const QtSCheckboxDialog&) = delete; // Copy Constructor Not Implemented
-    void operator=(const QtSCheckboxDialog&) = delete;    // Move assignment Not Implemented
+    QtSCheckboxDialog(QtSCheckboxDialog&&) = delete;      // Move Constructor Not Implemented
+    QtSCheckboxDialog& operator=(const QtSCheckboxDialog&) = delete; // Copy Assignment Not Implemented
+    QtSCheckboxDialog& operator=(QtSCheckboxDialog&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/QtSupport/QtSDisclosableGroupBox.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSDisclosableGroupBox.h
@@ -80,10 +80,10 @@ public slots:
   void updateWidgetStyle();
 
 
-protected:
-
-private:
+public:
   QtSDisclosableGroupBox(const QtSDisclosableGroupBox&) = delete; // Copy Constructor Not Implemented
-  void operator=(const QtSDisclosableGroupBox&) = delete;         // Move assignment Not Implemented
+  QtSDisclosableGroupBox(QtSDisclosableGroupBox&&) = delete;      // Move Constructor Not Implemented
+  QtSDisclosableGroupBox& operator=(const QtSDisclosableGroupBox&) = delete; // Copy Assignment Not Implemented
+  QtSDisclosableGroupBox& operator=(QtSDisclosableGroupBox&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/QtSupport/QtSDistributionTypeWidget.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSDistributionTypeWidget.h
@@ -62,10 +62,11 @@ class SVWidgetsLib_EXPORT QtSDistributionTypeWidget : public QWidget, private Ui
   protected:
     void setupGui();
 
-
-  private:
+  public:
     QtSDistributionTypeWidget(const QtSDistributionTypeWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const QtSDistributionTypeWidget&) = delete;            // Move assignment Not Implemented
+    QtSDistributionTypeWidget(QtSDistributionTypeWidget&&) = delete;      // Move Constructor Not Implemented
+    QtSDistributionTypeWidget& operator=(const QtSDistributionTypeWidget&) = delete; // Copy Assignment Not Implemented
+    QtSDistributionTypeWidget& operator=(QtSDistributionTypeWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/QtSupport/QtSDocServer.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSDocServer.h
@@ -87,5 +87,7 @@ private:
 
 public:
   QtSDocServer(const QtSDocServer&) = delete;   // Copy Constructor Not Implemented
-  void operator=(const QtSDocServer&) = delete; // Move assignment Not Implemented
+  QtSDocServer(QtSDocServer&&) = delete;        // Move Constructor Not Implemented
+  QtSDocServer& operator=(const QtSDocServer&) = delete; // Copy Assignment Not Implemented
+  QtSDocServer& operator=(QtSDocServer&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SVWidgetsLib/QtSupport/QtSGraphicsView.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSGraphicsView.h
@@ -175,7 +175,10 @@ class SVWidgetsLib_EXPORT QtSGraphicsView : public QGraphicsView
     QVector<QRgb> m_CustomColorTable;
     QVector<QRgb> m_OriginalColorTable;
 
+  public:
     QtSGraphicsView(const QtSGraphicsView&) = delete; // Copy Constructor Not Implemented
-    void operator=(const QtSGraphicsView&) = delete;  // Move assignment Not Implemented
+    QtSGraphicsView(QtSGraphicsView&&) = delete;      // Move Constructor Not Implemented
+    QtSGraphicsView& operator=(const QtSGraphicsView&) = delete; // Copy Assignment Not Implemented
+    QtSGraphicsView& operator=(QtSGraphicsView&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/QtSupport/QtSHelpUrlGenerator.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSHelpUrlGenerator.h
@@ -69,9 +69,11 @@ class SVWidgetsLib_EXPORT QtSHelpUrlGenerator
     */
     static void generateAndOpenHTMLUrl(QString helpName, QWidget* parent);
 
-  private:
+  public:
     QtSHelpUrlGenerator(const QtSHelpUrlGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const QtSHelpUrlGenerator&) = delete;      // Move assignment Not Implemented
+    QtSHelpUrlGenerator(QtSHelpUrlGenerator&&) = delete;      // Move Constructor Not Implemented
+    QtSHelpUrlGenerator& operator=(const QtSHelpUrlGenerator&) = delete; // Copy Assignment Not Implemented
+    QtSHelpUrlGenerator& operator=(QtSHelpUrlGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/QtSupport/QtSHoverButton.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSHoverButton.h
@@ -50,8 +50,10 @@ class SVWidgetsLib_EXPORT QtSHoverButton : public QPushButton
   protected:
     bool event(QEvent* event) override;
 
-  private:
+  public:
     QtSHoverButton(const QtSHoverButton&) = delete; // Copy Constructor Not Implemented
-    void operator=(const QtSHoverButton&) = delete; // Move assignment Not Implemented
+    QtSHoverButton(QtSHoverButton&&) = delete;      // Move Constructor Not Implemented
+    QtSHoverButton& operator=(const QtSHoverButton&) = delete; // Copy Assignment Not Implemented
+    QtSHoverButton& operator=(QtSHoverButton&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/QtSupport/QtSPluginFrame.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSPluginFrame.h
@@ -191,8 +191,11 @@ class SVWidgetsLib_EXPORT QtSPluginFrame : public QFrame
   private:
     QStatusBar*    m_StatusBar;
 
+  public:
     QtSPluginFrame(const QtSPluginFrame&) = delete; // Copy Constructor Not Implemented
-    void operator=(const QtSPluginFrame&) = delete; // Move assignment Not Implemented
+    QtSPluginFrame(QtSPluginFrame&&) = delete;      // Move Constructor Not Implemented
+    QtSPluginFrame& operator=(const QtSPluginFrame&) = delete; // Copy Assignment Not Implemented
+    QtSPluginFrame& operator=(QtSPluginFrame&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/QtSupport/QtSSettings.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSSettings.h
@@ -110,7 +110,10 @@ class SVWidgetsLib_EXPORT QtSSettings : public QObject
       Type
     };
 
-    QtSSettings(const QtSSettings&);    // Copy Constructor Not Implemented
-    void operator=(const QtSSettings&); // Move assignment Not Implemented
+  public:
+    QtSSettings(const QtSSettings&) = delete;            // Copy Constructor Not Implemented
+    QtSSettings(QtSSettings&&) = delete;                 // Move Constructor Not Implemented
+    QtSSettings& operator=(const QtSSettings&) = delete; // Copy Assignment Not Implemented
+    QtSSettings& operator=(QtSSettings&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/QtSupport/QtSSplitter.h
+++ b/Source/SVWidgetsLib/QtSupport/QtSSplitter.h
@@ -54,8 +54,10 @@ class SVWidgetsLib_EXPORT QtSSplitter : public QSplitter
 
     QSplitterHandle* createHandle() override;
 
-  private:
+  public:
     QtSSplitter(const QtSSplitter&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const QtSSplitter&) = delete; // Move assignment Not Implemented
+    QtSSplitter(QtSSplitter&&) = delete;         // Move Constructor Not Implemented
+    QtSSplitter& operator=(const QtSSplitter&) = delete; // Copy Assignment Not Implemented
+    QtSSplitter& operator=(QtSSplitter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/BookmarksItem.h
+++ b/Source/SVWidgetsLib/Widgets/BookmarksItem.h
@@ -94,7 +94,10 @@ class SVWidgetsLib_EXPORT BookmarksItem
     QList<BookmarksItem*>               m_ChildItems;
     BookmarksItem*                      m_ParentItem;
 
-    BookmarksItem(const BookmarksItem&);    // Copy Constructor Not Implemented
-    void operator=(const BookmarksItem&);   // Move assignment Not Implemented
+  public:
+    BookmarksItem(const BookmarksItem&) = delete;            // Copy Constructor Not Implemented
+    BookmarksItem(BookmarksItem&&) = delete;                 // Move Constructor Not Implemented
+    BookmarksItem& operator=(const BookmarksItem&) = delete; // Copy Assignment Not Implemented
+    BookmarksItem& operator=(BookmarksItem&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/BookmarksItemDelegate.h
+++ b/Source/SVWidgetsLib/Widgets/BookmarksItemDelegate.h
@@ -57,8 +57,10 @@ class BookmarksItemDelegate : public QStyledItemDelegate
 
     QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
-  private:
+  public:
     BookmarksItemDelegate(const BookmarksItemDelegate&) = delete; // Copy Constructor Not Implemented
-    void operator=(const BookmarksItemDelegate&) = delete;        // Move assignment Not Implemented
+    BookmarksItemDelegate(BookmarksItemDelegate&&) = delete;      // Move Constructor Not Implemented
+    BookmarksItemDelegate& operator=(const BookmarksItemDelegate&) = delete; // Copy Assignment Not Implemented
+    BookmarksItemDelegate& operator=(BookmarksItemDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/BookmarksModel.h
+++ b/Source/SVWidgetsLib/Widgets/BookmarksModel.h
@@ -205,7 +205,10 @@ class SVWidgetsLib_EXPORT BookmarksModel : public QAbstractItemModel
      */
     void loadModel();
 
-    BookmarksModel(const BookmarksModel&);    // Copy Constructor Not Implemented
-    void operator=(const BookmarksModel&);    // Move assignment Not Implemented
+  public:
+    BookmarksModel(const BookmarksModel&) = delete;            // Copy Constructor Not Implemented
+    BookmarksModel(BookmarksModel&&) = delete;                 // Move Constructor Not Implemented
+    BookmarksModel& operator=(const BookmarksModel&) = delete; // Copy Assignment Not Implemented
+    BookmarksModel& operator=(BookmarksModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/BookmarksToolboxWidget.h
+++ b/Source/SVWidgetsLib/Widgets/BookmarksToolboxWidget.h
@@ -172,7 +172,10 @@ class SVWidgetsLib_EXPORT BookmarksToolboxWidget : public QWidget, private Ui::B
      */
     bool locateBookmark();
 
+  public:
     BookmarksToolboxWidget(const BookmarksToolboxWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const BookmarksToolboxWidget&) = delete;         // Move assignment Not Implemented
+    BookmarksToolboxWidget(BookmarksToolboxWidget&&) = delete;      // Move Constructor Not Implemented
+    BookmarksToolboxWidget& operator=(const BookmarksToolboxWidget&) = delete; // Copy Assignment Not Implemented
+    BookmarksToolboxWidget& operator=(BookmarksToolboxWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/DataContainerArrayWidget.h
+++ b/Source/SVWidgetsLib/Widgets/DataContainerArrayWidget.h
@@ -61,7 +61,10 @@ class SVWidgetsLib_EXPORT DataContainerArrayWidget : public QWidget, private Ui:
   private:
     AbstractFilter*     m_Filter;
 
+  public:
     DataContainerArrayWidget(const DataContainerArrayWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerArrayWidget&) = delete;           // Move assignment Not Implemented
+    DataContainerArrayWidget(DataContainerArrayWidget&&) = delete;      // Move Constructor Not Implemented
+    DataContainerArrayWidget& operator=(const DataContainerArrayWidget&) = delete; // Copy Assignment Not Implemented
+    DataContainerArrayWidget& operator=(DataContainerArrayWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/DataStructureItem.h
+++ b/Source/SVWidgetsLib/Widgets/DataStructureItem.h
@@ -128,7 +128,10 @@ class SVWidgetsLib_EXPORT DataStructureItem
     QIcon                               m_Icon;
     ItemType                            m_ItemType;
 
-    DataStructureItem(const DataStructureItem&);    // Copy Constructor Not Implemented
-    void operator=(const DataStructureItem&);       // Move assignment Not Implemented
+  public:
+    DataStructureItem(const DataStructureItem&) = delete;            // Copy Constructor Not Implemented
+    DataStructureItem(DataStructureItem&&) = delete;                 // Move Constructor Not Implemented
+    DataStructureItem& operator=(const DataStructureItem&) = delete; // Copy Assignment Not Implemented
+    DataStructureItem& operator=(DataStructureItem&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/DataStructureItemDelegate.h
+++ b/Source/SVWidgetsLib/Widgets/DataStructureItemDelegate.h
@@ -123,9 +123,11 @@ protected:
   */
   void createNewPathIcons();
 
-private:
+public:
   DataStructureItemDelegate(const DataStructureItemDelegate&) = delete; // Copy Constructor Not Implemented
-  void operator=(const DataStructureItemDelegate&) = delete;            // Move assignment Not Implemented
+  DataStructureItemDelegate(DataStructureItemDelegate&&) = delete;      // Move Constructor Not Implemented
+  DataStructureItemDelegate& operator=(const DataStructureItemDelegate&) = delete; // Copy Assignment Not Implemented
+  DataStructureItemDelegate& operator=(DataStructureItemDelegate&&) = delete;      // Move Assignment Not Implemented
 
   AbstractFilter::Pointer m_Filter = nullptr;
   std::list<DataArrayPath> m_CreatedPaths;

--- a/Source/SVWidgetsLib/Widgets/DataStructureModel.h
+++ b/Source/SVWidgetsLib/Widgets/DataStructureModel.h
@@ -142,7 +142,10 @@ the setData() and setHeaderData() functions, respectively.
 
     //    QModelIndexList findIndexByPath(const QModelIndex& index, QString filePath);
 
-    DataStructureModel(const DataStructureModel&);    // Copy Constructor Not Implemented
-    void operator=(const DataStructureModel&);        // Move assignment Not Implemented
+  public:
+    DataStructureModel(const DataStructureModel&) = delete;            // Copy Constructor Not Implemented
+    DataStructureModel(DataStructureModel&&) = delete;                 // Move Constructor Not Implemented
+    DataStructureModel& operator=(const DataStructureModel&) = delete; // Copy Assignment Not Implemented
+    DataStructureModel& operator=(DataStructureModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/DataStructureWidget.h
+++ b/Source/SVWidgetsLib/Widgets/DataStructureWidget.h
@@ -161,7 +161,10 @@ private:
   QIcon m_TriangleGeomIcon;
   QIcon m_QuadGeomIcon;
 
+public:
   DataStructureWidget(const DataStructureWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const DataStructureWidget&);               // Move assignment Not Implemented
+  DataStructureWidget(DataStructureWidget&&) = delete;      // Move Constructor Not Implemented
+  DataStructureWidget& operator=(const DataStructureWidget&) = delete; // Copy Assignment Not Implemented
+  DataStructureWidget& operator=(DataStructureWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/FilterInputWidget.h
+++ b/Source/SVWidgetsLib/Widgets/FilterInputWidget.h
@@ -135,6 +135,8 @@ class SVWidgetsLib_EXPORT FilterInputWidget : public QWidget
 
   public:
     FilterInputWidget(const FilterInputWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FilterInputWidget&) = delete;    // Move assignment Not Implemented
+    FilterInputWidget(FilterInputWidget&&) = delete;      // Move Constructor Not Implemented
+    FilterInputWidget& operator=(const FilterInputWidget&) = delete; // Copy Assignment Not Implemented
+    FilterInputWidget& operator=(FilterInputWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/FilterLibraryToolboxWidget.h
+++ b/Source/SVWidgetsLib/Widgets/FilterLibraryToolboxWidget.h
@@ -127,7 +127,10 @@ class SVWidgetsLib_EXPORT FilterLibraryToolboxWidget : public QWidget, private U
     QMenu* m_ContextMenu;
     QSignalMapper* m_Mapper;
 
+  public:
     FilterLibraryToolboxWidget(const FilterLibraryToolboxWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FilterLibraryToolboxWidget&) = delete;             // Move assignment Not Implemented
+    FilterLibraryToolboxWidget(FilterLibraryToolboxWidget&&) = delete;      // Move Constructor Not Implemented
+    FilterLibraryToolboxWidget& operator=(const FilterLibraryToolboxWidget&) = delete; // Copy Assignment Not Implemented
+    FilterLibraryToolboxWidget& operator=(FilterLibraryToolboxWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/FilterListItem.h
+++ b/Source/SVWidgetsLib/Widgets/FilterListItem.h
@@ -83,6 +83,9 @@ class SVWidgetsLib_EXPORT FilterListItem
     QList<FilterListItem*>               m_ChildItems;
     FilterListItem*                      m_ParentItem;
 
-    FilterListItem(const FilterListItem&);    // Copy Constructor Not Implemented
-    void operator=(const FilterListItem&);   // Move assignment Not Implemented
+  public:
+    FilterListItem(const FilterListItem&) = delete;            // Copy Constructor Not Implemented
+    FilterListItem(FilterListItem&&) = delete;                 // Move Constructor Not Implemented
+    FilterListItem& operator=(const FilterListItem&) = delete; // Copy Assignment Not Implemented
+    FilterListItem& operator=(FilterListItem&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SVWidgetsLib/Widgets/FilterListModel.h
+++ b/Source/SVWidgetsLib/Widgets/FilterListModel.h
@@ -95,6 +95,9 @@ class SVWidgetsLib_EXPORT FilterListModel : public QAbstractItemModel
 
     FilterListItem* getItem(const QModelIndex& index) const;
 
-    FilterListModel(const FilterListModel&);    // Copy Constructor Not Implemented
-    void operator=(const FilterListModel&);    // Move assignment Not Implemented
+  public:
+    FilterListModel(const FilterListModel&) = delete;            // Copy Constructor Not Implemented
+    FilterListModel(FilterListModel&&) = delete;                 // Move Constructor Not Implemented
+    FilterListModel& operator=(const FilterListModel&) = delete; // Copy Assignment Not Implemented
+    FilterListModel& operator=(FilterListModel&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SVWidgetsLib/Widgets/FilterListToolboxWidget.h
+++ b/Source/SVWidgetsLib/Widgets/FilterListToolboxWidget.h
@@ -140,8 +140,11 @@ class SVWidgetsLib_EXPORT FilterListToolboxWidget : public QWidget, private Ui::
 
     int getMatchingRelevanceForFilter(QStringList searchTokens, AbstractFilter::Pointer filter, FilterListView::SearchGroup searchGroup);
 
+  public:
     FilterListToolboxWidget(const FilterListToolboxWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FilterListToolboxWidget&) = delete;          // Move assignment Not Implemented
+    FilterListToolboxWidget(FilterListToolboxWidget&&) = delete;      // Move Constructor Not Implemented
+    FilterListToolboxWidget& operator=(const FilterListToolboxWidget&) = delete; // Copy Assignment Not Implemented
+    FilterListToolboxWidget& operator=(FilterListToolboxWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ASCIIDataItem.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ASCIIDataItem.h
@@ -64,7 +64,10 @@ private:
 
   QString                                                       m_OriginalString;
 
-  ASCIIDataItem(const ASCIIDataItem&);    // Copy Constructor Not Implemented
-  void operator=(const ASCIIDataItem&);   // Move assignment Not Implemented
+public:
+  ASCIIDataItem(const ASCIIDataItem&) = delete;            // Copy Constructor Not Implemented
+  ASCIIDataItem(ASCIIDataItem&&) = delete;                 // Move Constructor Not Implemented
+  ASCIIDataItem& operator=(const ASCIIDataItem&) = delete; // Copy Assignment Not Implemented
+  ASCIIDataItem& operator=(ASCIIDataItem&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ASCIIDataModel.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ASCIIDataModel.h
@@ -99,7 +99,10 @@ private:
 
   ASCIIDataItem* getItem(const QModelIndex& index) const;
 
-  ASCIIDataModel(const ASCIIDataModel&);    // Copy Constructor Not Implemented
-  void operator=(const ASCIIDataModel&);    // Move assignment Not Implemented
+public:
+  ASCIIDataModel(const ASCIIDataModel&) = delete;            // Copy Constructor Not Implemented
+  ASCIIDataModel(ASCIIDataModel&&) = delete;                 // Move Constructor Not Implemented
+  ASCIIDataModel& operator=(const ASCIIDataModel&) = delete; // Copy Assignment Not Implemented
+  ASCIIDataModel& operator=(ASCIIDataModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/AbstractWizardPage.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/AbstractWizardPage.h
@@ -60,8 +60,10 @@ class AbstractWizardPage : public QWizardPage
 
     QString                                         m_InputFilePath;
 
-  private:
+  public:
     AbstractWizardPage(const AbstractWizardPage&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AbstractWizardPage&) = delete;     // Move assignment Not Implemented
+    AbstractWizardPage(AbstractWizardPage&&) = delete;      // Move Constructor Not Implemented
+    AbstractWizardPage& operator=(const AbstractWizardPage&) = delete; // Copy Assignment Not Implemented
+    AbstractWizardPage& operator=(AbstractWizardPage&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.h
@@ -296,6 +296,8 @@ class DataFormatPage : public AbstractWizardPage, private Ui::DataFormatPage
   
   public:
     DataFormatPage(const DataFormatPage&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataFormatPage&) = delete; // Move assignment Not Implemented
+    DataFormatPage(DataFormatPage&&) = delete;      // Move Constructor Not Implemented
+    DataFormatPage& operator=(const DataFormatPage&) = delete; // Copy Assignment Not Implemented
+    DataFormatPage& operator=(DataFormatPage&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DelimitedPage.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DelimitedPage.h
@@ -85,7 +85,10 @@ class DelimitedPage : public AbstractWizardPage, private Ui::DelimitedPage
     int m_NumLines = -1;
     bool m_EditSettings = false;
 
+  public:
     DelimitedPage(const DelimitedPage&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const DelimitedPage&) = delete; // Move assignment Not Implemented
+    DelimitedPage(DelimitedPage&&) = delete;       // Move Constructor Not Implemented
+    DelimitedPage& operator=(const DelimitedPage&) = delete; // Copy Assignment Not Implemented
+    DelimitedPage& operator=(DelimitedPage&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/EditHeadersDialog.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/EditHeadersDialog.h
@@ -68,7 +68,11 @@ private:
   QDialogButtonBox*                                         m_ButtonBox;
   QVector<QString>                                          m_Headers;
   QSharedPointer<ASCIIDataModel> m_ASCIIDataModel;
+
+public:
   EditHeadersDialog(const EditHeadersDialog&) = delete; // Copy Constructor Not Implemented
-  void operator=(const EditHeadersDialog&) = delete;    // Move assignment Not Implemented
+  EditHeadersDialog(EditHeadersDialog&&) = delete;      // Move Constructor Not Implemented
+  EditHeadersDialog& operator=(const EditHeadersDialog&) = delete; // Copy Assignment Not Implemented
+  EditHeadersDialog& operator=(EditHeadersDialog&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ImportASCIIDataWizard.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ImportASCIIDataWizard.h
@@ -158,7 +158,10 @@ class ImportASCIIDataWizard : public QWizard
     QPushButton*                                        m_RefreshBtn = nullptr;
     QSharedPointer<ASCIIDataModel> m_ASCIIDataModel;
 
+  public:
     ImportASCIIDataWizard(const ImportASCIIDataWizard&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ImportASCIIDataWizard&) = delete;        // Move assignment Not Implemented
+    ImportASCIIDataWizard(ImportASCIIDataWizard&&) = delete;      // Move Constructor Not Implemented
+    ImportASCIIDataWizard& operator=(const ImportASCIIDataWizard&) = delete; // Copy Assignment Not Implemented
+    ImportASCIIDataWizard& operator=(ImportASCIIDataWizard&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/LineCounterObject.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/LineCounterObject.h
@@ -92,7 +92,10 @@ private:
   QString m_FilePath;
   int m_NumOfLines;
 
+public:
   LineCounterObject(const LineCounterObject&) = delete; // Copy Constructor Not Implemented
-  void operator=(const LineCounterObject&);             // Move assignment Not Implemented
+  LineCounterObject(LineCounterObject&&) = delete;      // Move Constructor Not Implemented
+  LineCounterObject& operator=(const LineCounterObject&) = delete; // Copy Assignment Not Implemented
+  LineCounterObject& operator=(LineCounterObject&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/TupleSelectionPage.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/TupleSelectionPage.h
@@ -74,8 +74,10 @@ class TupleSelectionPage : public AbstractWizardPage, private Ui::TupleSelection
     */
     virtual int nextId() const;
 
-  private:
+  public:
     TupleSelectionPage(const TupleSelectionPage&) = delete; // Copy Constructor Not Implemented
-    void operator=(const TupleSelectionPage&) = delete;     // Move assignment Not Implemented
+    TupleSelectionPage(TupleSelectionPage&&) = delete;      // Move Constructor Not Implemented
+    TupleSelectionPage& operator=(const TupleSelectionPage&) = delete; // Copy Assignment Not Implemented
+    TupleSelectionPage& operator=(TupleSelectionPage&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/TupleTableItemDelegate.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/TupleTableItemDelegate.h
@@ -56,8 +56,10 @@ class TupleTableItemDelegate : public QStyledItemDelegate
     void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const override;
     void updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 
-  private:
+  public:
     TupleTableItemDelegate(const TupleTableItemDelegate&) = delete; // Copy Constructor Not Implemented
-    void operator=(const TupleTableItemDelegate&) = delete;         // Move assignment Not Implemented
+    TupleTableItemDelegate(TupleTableItemDelegate&&) = delete;      // Move Constructor Not Implemented
+    TupleTableItemDelegate& operator=(const TupleTableItemDelegate&) = delete; // Copy Assignment Not Implemented
+    TupleTableItemDelegate& operator=(TupleTableItemDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/TupleTableWidget.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/TupleTableWidget.h
@@ -92,7 +92,10 @@ class TupleTableWidget : public QWidget, private Ui::TupleTableWidget
 
     bool m_UserEdited = false;
 
+  public:
     TupleTableWidget(const TupleTableWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const TupleTableWidget&) = delete;   // Move assignment Not Implemented
+    TupleTableWidget(TupleTableWidget&&) = delete;      // Move Constructor Not Implemented
+    TupleTableWidget& operator=(const TupleTableWidget&) = delete; // Copy Assignment Not Implemented
+    TupleTableWidget& operator=(TupleTableWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/IssuesWidget.h
+++ b/Source/SVWidgetsLib/Widgets/IssuesWidget.h
@@ -99,7 +99,10 @@ class SVWidgetsLib_EXPORT IssuesWidget : public QWidget, public IObserver
     QSharedPointer<Ui::IssuesWidget> ui = nullptr;
     QVector<PipelineMessage> m_CachedMessages;
 
+  public:
     IssuesWidget(const IssuesWidget&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const IssuesWidget&) = delete; // Move assignment Not Implemented
+    IssuesWidget(IssuesWidget&&) = delete;        // Move Constructor Not Implemented
+    IssuesWidget& operator=(const IssuesWidget&) = delete; // Copy Assignment Not Implemented
+    IssuesWidget& operator=(IssuesWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/PipelineFilterMimeData.h
+++ b/Source/SVWidgetsLib/Widgets/PipelineFilterMimeData.h
@@ -48,7 +48,9 @@ class SVWidgetsLib_EXPORT PipelineFilterMimeData : public QMimeData
 
     SIMPL_INSTANCE_PROPERTY(std::vector<FilterDragMetadata>, FilterDragData)
 
-  private:
+  public:
     PipelineFilterMimeData(const PipelineFilterMimeData&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PipelineFilterMimeData&) = delete;  // Operator '=' Not Implemented
+    PipelineFilterMimeData(PipelineFilterMimeData&&) = delete;      // Move Constructor Not Implemented
+    PipelineFilterMimeData& operator=(const PipelineFilterMimeData&) = delete; // Copy Assignment Not Implemented
+    PipelineFilterMimeData& operator=(PipelineFilterMimeData&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SVWidgetsLib/Widgets/PipelineItem.h
+++ b/Source/SVWidgetsLib/Widgets/PipelineItem.h
@@ -151,7 +151,10 @@ class SVWidgetsLib_EXPORT PipelineItem
 
     void setupFilterInputWidget();
 
-    PipelineItem(const PipelineItem&);    // Copy Constructor Not Implemented
-    void operator=(const PipelineItem&);  // Operator '=' Not Implemented
+  public:
+    PipelineItem(const PipelineItem&) = delete;            // Copy Constructor Not Implemented
+    PipelineItem(PipelineItem&&) = delete;                 // Move Constructor Not Implemented
+    PipelineItem& operator=(const PipelineItem&) = delete; // Copy Assignment Not Implemented
+    PipelineItem& operator=(PipelineItem&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/PipelineItemDelegate.h
+++ b/Source/SVWidgetsLib/Widgets/PipelineItemDelegate.h
@@ -88,6 +88,9 @@ class SVWidgetsLib_EXPORT PipelineItemDelegate : public QStyledItemDelegate
      */
     const PipelineModel* getPipelineModel(const QModelIndex &index) const;
 
+  public:
     PipelineItemDelegate(const PipelineItemDelegate&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PipelineItemDelegate&) = delete;        // Operator '=' Not Implemented
+    PipelineItemDelegate(PipelineItemDelegate&&) = delete;      // Move Constructor Not Implemented
+    PipelineItemDelegate& operator=(const PipelineItemDelegate&) = delete; // Copy Assignment Not Implemented
+    PipelineItemDelegate& operator=(PipelineItemDelegate&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SVWidgetsLib/Widgets/PipelineListWidget.h
+++ b/Source/SVWidgetsLib/Widgets/PipelineListWidget.h
@@ -104,6 +104,8 @@ class SVWidgetsLib_EXPORT PipelineListWidget : public QFrame, private Ui::Pipeli
 
   public:
     PipelineListWidget(const PipelineListWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PipelineListWidget&) = delete;  // Operator '=' Not Implemented
+    PipelineListWidget(PipelineListWidget&&) = delete;      // Move Constructor Not Implemented
+    PipelineListWidget& operator=(const PipelineListWidget&) = delete; // Copy Assignment Not Implemented
+    PipelineListWidget& operator=(PipelineListWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/PipelineModel.h
+++ b/Source/SVWidgetsLib/Widgets/PipelineModel.h
@@ -149,7 +149,10 @@ class SVWidgetsLib_EXPORT PipelineModel : public QAbstractItemModel
 
     QColor getForegroundColor(const QModelIndex &index) const;
 
-    PipelineModel(const PipelineModel&);    // Copy Constructor Not Implemented
-    void operator=(const PipelineModel&);  // Operator '=' Not Implemented
+  public:
+    PipelineModel(const PipelineModel&) = delete;            // Copy Constructor Not Implemented
+    PipelineModel(PipelineModel&&) = delete;                 // Move Constructor Not Implemented
+    PipelineModel& operator=(const PipelineModel&) = delete; // Copy Assignment Not Implemented
+    PipelineModel& operator=(PipelineModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/PipelineView.h
+++ b/Source/SVWidgetsLib/Widgets/PipelineView.h
@@ -94,7 +94,10 @@ class SVWidgetsLib_EXPORT PipelineView
      */
     void setupUndoStack();
 
+  public:
     PipelineView(const PipelineView&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const PipelineView&) = delete; // Move assignment Not Implemented
+    PipelineView(PipelineView&&) = delete;        // Move Constructor Not Implemented
+    PipelineView& operator=(const PipelineView&) = delete; // Copy Assignment Not Implemented
+    PipelineView& operator=(PipelineView&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/PopUpWidget.h
+++ b/Source/SVWidgetsLib/Widgets/PopUpWidget.h
@@ -88,7 +88,10 @@ class SVWidgetsLib_EXPORT PopUpWidget : public QWidget, private Ui::PopUpWidget
   private:
     ArrowOrientation                    m_ArrowOrientation;
 
-    PopUpWidget(const PopUpWidget&); // Copy Constructor Not Implemented
-    void operator=(const PopUpWidget&); // Move assignment Not Implemented
+  public:
+    PopUpWidget(const PopUpWidget&) = delete;            // Copy Constructor Not Implemented
+    PopUpWidget(PopUpWidget&&) = delete;                 // Move Constructor Not Implemented
+    PopUpWidget& operator=(const PopUpWidget&) = delete; // Copy Assignment Not Implemented
+    PopUpWidget& operator=(PopUpWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/SVPipelineView.h
+++ b/Source/SVWidgetsLib/Widgets/SVPipelineView.h
@@ -548,6 +548,9 @@ private:
    */
   QPixmap setPixmapColor(QPixmap pixmap, QColor pixmapColor);
 
+public:
   SVPipelineView(const SVPipelineView&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SVPipelineView&) = delete; // Move assignment Not Implemented
+  SVPipelineView(SVPipelineView&&) = delete;      // Move Constructor Not Implemented
+  SVPipelineView& operator=(const SVPipelineView&) = delete; // Copy Assignment Not Implemented
+  SVPipelineView& operator=(SVPipelineView&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SVWidgetsLib/Widgets/SVUserManualDialog.h
+++ b/Source/SVWidgetsLib/Widgets/SVUserManualDialog.h
@@ -109,6 +109,8 @@ private:
 
 public:
   SVUserManualDialog(const SVUserManualDialog&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SVUserManualDialog&) = delete;     // Move assignment Not Implemented
+  SVUserManualDialog(SVUserManualDialog&&) = delete;      // Move Constructor Not Implemented
+  SVUserManualDialog& operator=(const SVUserManualDialog&) = delete; // Copy Assignment Not Implemented
+  SVUserManualDialog& operator=(SVUserManualDialog&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/StandardOutputWidget.h
+++ b/Source/SVWidgetsLib/Widgets/StandardOutputWidget.h
@@ -82,7 +82,10 @@ class SVWidgetsLib_EXPORT StandardOutputWidget : public QWidget, public IObserve
   private:
     QString             m_LastPathOpened = "";
 
+  public:
     StandardOutputWidget(const StandardOutputWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const StandardOutputWidget&) = delete;       // Move assignment Not Implemented
+    StandardOutputWidget(StandardOutputWidget&&) = delete;      // Move Constructor Not Implemented
+    StandardOutputWidget& operator=(const StandardOutputWidget&) = delete; // Copy Assignment Not Implemented
+    StandardOutputWidget& operator=(StandardOutputWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/StatusBarButton.h
+++ b/Source/SVWidgetsLib/Widgets/StatusBarButton.h
@@ -49,8 +49,11 @@ class SVWidgetsLib_EXPORT StatusBarButton : public QToolButton
     int m_TextMargin = 6;
     
     bool m_Pressed = false;
-    
+
+  public:
     StatusBarButton(const StatusBarButton&) = delete; // Copy Constructor Not Implemented
-    void operator=(const StatusBarButton&) = delete;  // Move assignment Not Implemented
+    StatusBarButton(StatusBarButton&&) = delete;      // Move Constructor Not Implemented
+    StatusBarButton& operator=(const StatusBarButton&) = delete; // Copy Assignment Not Implemented
+    StatusBarButton& operator=(StatusBarButton&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/StatusBarIssuesButton.h
+++ b/Source/SVWidgetsLib/Widgets/StatusBarIssuesButton.h
@@ -32,7 +32,10 @@ class SVWidgetsLib_EXPORT StatusBarIssuesButton : public StatusBarButton
     
     int m_BadgeMargin = 4;
     int m_BadgeWidth = 0;
-    
+
+  public:
     StatusBarIssuesButton(const StatusBarIssuesButton&) = delete; // Copy Constructor Not Implemented
-    void operator=(const StatusBarIssuesButton&) = delete;  // Move assignment Not Implemented
+    StatusBarIssuesButton(StatusBarIssuesButton&&) = delete;      // Move Constructor Not Implemented
+    StatusBarIssuesButton& operator=(const StatusBarIssuesButton&) = delete; // Copy Assignment Not Implemented
+    StatusBarIssuesButton& operator=(StatusBarIssuesButton&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SVWidgetsLib/Widgets/StatusBarWidget.h
+++ b/Source/SVWidgetsLib/Widgets/StatusBarWidget.h
@@ -165,7 +165,10 @@ class SVWidgetsLib_EXPORT StatusBarWidget : public QFrame, private Ui::StatusBar
      */
     QAction* addButtonVisibilityAction(StatusBarButton* button);
 
+  public:
     StatusBarWidget(const StatusBarWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const StatusBarWidget&) = delete;  // Move assignment Not Implemented
+    StatusBarWidget(StatusBarWidget&&) = delete;      // Move Constructor Not Implemented
+    StatusBarWidget& operator=(const StatusBarWidget&) = delete; // Copy Assignment Not Implemented
+    StatusBarWidget& operator=(StatusBarWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/util/AddFilterCommand.h
+++ b/Source/SVWidgetsLib/Widgets/util/AddFilterCommand.h
@@ -95,7 +95,10 @@ private:
    */
   void disconnectFilterSignalsSlots(AbstractFilter::Pointer filter);
 
+public:
   AddFilterCommand(const AddFilterCommand&) = delete; // Copy Constructor Not Implemented
-  void operator=(const AddFilterCommand&) = delete;   // Move assignment Not Implemented
+  AddFilterCommand(AddFilterCommand&&) = delete;      // Move Constructor Not Implemented
+  AddFilterCommand& operator=(const AddFilterCommand&) = delete; // Copy Assignment Not Implemented
+  AddFilterCommand& operator=(AddFilterCommand&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/util/MoveFilterCommand.h
+++ b/Source/SVWidgetsLib/Widgets/util/MoveFilterCommand.h
@@ -102,7 +102,10 @@ private:
    */
   void removeFilter(int filterIndex);
 
+public:
   MoveFilterCommand(const MoveFilterCommand&) = delete; // Copy Constructor Not Implemented
-  void operator=(const MoveFilterCommand&);             // Move assignment Not Implemented
+  MoveFilterCommand(MoveFilterCommand&&) = delete;      // Move Constructor Not Implemented
+  MoveFilterCommand& operator=(const MoveFilterCommand&) = delete; // Copy Assignment Not Implemented
+  MoveFilterCommand& operator=(MoveFilterCommand&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/util/RemoveFilterCommand.h
+++ b/Source/SVWidgetsLib/Widgets/util/RemoveFilterCommand.h
@@ -91,7 +91,10 @@ private:
    */
   void disconnectFilterSignalsSlots(AbstractFilter::Pointer filter);
 
+public:
   RemoveFilterCommand(const RemoveFilterCommand&) = delete; // Copy Constructor Not Implemented
-  void operator=(const RemoveFilterCommand&) = delete;      // Move assignment Not Implemented
+  RemoveFilterCommand(RemoveFilterCommand&&) = delete;      // Move Constructor Not Implemented
+  RemoveFilterCommand& operator=(const RemoveFilterCommand&) = delete; // Copy Assignment Not Implemented
+  RemoveFilterCommand& operator=(RemoveFilterCommand&&) = delete;      // Move Assignment Not Implemented
 };
 


### PR DESCRIPTION
Classes are updated to use C++11 standard '=delete' or '=default' for each of
the copy and move constructors and copy and move assignments.

Other misc formatting updates to any affected classes.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>