### PR TITLE
Enable per object parallel compilation

### DIFF
--- a/Source/SIMPLib/CMakeLists.txt
+++ b/Source/SIMPLib/CMakeLists.txt
@@ -171,6 +171,11 @@ endif()
 add_library(${PROJECT_NAME} ${LIB_TYPE} ${Project_SRCS} )
 CMP_AddDefinitions(TARGET ${PROJECT_NAME})
 
+if(MSVC)
+  # enable per object parallel compilation in this large library
+  target_compile_options(${PROJECT_NAME} PRIVATE "/MP")
+endif()
+
 #-- Add Target specific definitions
 if(WIN32 AND BUILD_SHARED_LIBS)
       target_compile_definitions(${PROJECT_NAME} PUBLIC "-DSIMPLib_BUILT_AS_DYNAMIC_LIB")


### PR DESCRIPTION
This parallelizes compilation within this library. The motivation was that 7 of my cores were sitting idle for a long time while SIMPLib was being compiled. It almost took me less time to write the patch then it did for my computer to compile it in single-threaded mode.