### PR TITLE
Remove any colon characters that end up in a file path.

### DIFF
--- a/Source/SIMPLib/Utilities/SIMPLDataPathValidator.cpp
+++ b/Source/SIMPLib/Utilities/SIMPLDataPathValidator.cpp
@@ -100,6 +100,10 @@ QString SIMPLDataPathValidator::convertToAbsolutePath(const QString &path)
     }
     absolutePath.prepend(parentPath);
     absolutePath = QDir::toNativeSeparators(absolutePath);
+    //macOS and Linux do not like to have a ":" character in the path names
+    #if !defined (Q_OS_WIN)
+    absolutePath.replace(":", "");
+    #endif
   }
 
   return absolutePath;

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.cpp
@@ -193,7 +193,7 @@ void AbstractIOFileWidget::setupMenuField()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-bool AbstractIOFileWidget::verifyPathExists(QString filePath, QLineEdit* lineEdit)
+bool AbstractIOFileWidget::verifyPathExists(const QString& filePath, QLineEdit* lineEdit)
 {
   QFileInfo fileinfo(filePath);
   SVStyle* style = SVStyle::Instance();
@@ -327,7 +327,7 @@ void AbstractIOFileWidget::afterPreflight()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void AbstractIOFileWidget::setOpenDialogLastFilePath(QString val) 
+void AbstractIOFileWidget::setOpenDialogLastFilePath(const QString& val)
 {
   m_LineEdit->setText(val);
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.h
@@ -83,7 +83,7 @@ class SVWidgetsLib_EXPORT AbstractIOFileWidget : public FilterParameterWidget, p
     /**
     * @brief
     */
-    bool verifyPathExists(QString filePath, QLineEdit* lineEdit);
+    bool verifyPathExists(const QString &filePath, QLineEdit* lineEdit);
 
   public slots:
     void beforePreflight();
@@ -97,7 +97,7 @@ class SVWidgetsLib_EXPORT AbstractIOFileWidget : public FilterParameterWidget, p
 
 
   protected:
-    void setOpenDialogLastFilePath(QString val);
+    void setOpenDialogLastFilePath(const QString &val);
 
     QString getOpenDialogLastFilePath();
 


### PR DESCRIPTION
When users load a pipeline file that was produced on a Windows machine the
resulting path will typically have a [drive letter]:/ which can mess with macOS
and probably Linux. This fix will remove any ':' character that is still remaining
in the file path after generating an absolute path.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>