### PR TITLE
Misc style cleanups focusing on better styling inside of darker themes.

### DIFF
--- a/Resources/SIMPL.qrc
+++ b/Resources/SIMPL.qrc
@@ -143,6 +143,8 @@
     <file>SIMPL/icons/images/zoom_in@2x.png</file>
     <file>SIMPL/icons/images/zoom_out.png</file>
     <file>SIMPL/icons/images/zoom_out@2x.png</file>
+    <file>SIMPL/icons/images/x.png</file>
+    <file>SIMPL/icons/images/x@2x.png</file>
 
  </qresource>
  </RCC>

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/SeparatorWidget.ui
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/SeparatorWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>923</width>
-    <height>22</height>
+    <height>31</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -38,19 +38,6 @@
    <property name="verticalSpacing">
     <number>0</number>
    </property>
-   <item row="1" column="0" colspan="2">
-    <widget class="QFrame" name="separatorFrame">
-     <property name="frameShape">
-      <enum>QFrame::HLine</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
-      <number>2</number>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="separatorLabel">
      <property name="sizePolicy">
@@ -61,6 +48,31 @@
      </property>
      <property name="text">
       <string>label</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QFrame" name="separatorFrame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>1</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::HLine</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>1</number>
      </property>
     </widget>
    </item>

--- a/Source/SVWidgetsLib/QtSupport/UI_Files/QtSStringEdit.ui
+++ b/Source/SVWidgetsLib/QtSupport/UI_Files/QtSStringEdit.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>358</width>
-    <height>30</height>
+    <width>565</width>
+    <height>28</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -36,7 +36,7 @@
     <number>2</number>
    </property>
    <item>
-    <widget class="QLineEdit" name="value">
+    <widget class="SVLineEdit" name="value">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>1</horstretch>
@@ -147,6 +147,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SVLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header location="global">SVControlWidgets.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../icons/images/Icons.qrc"/>
  </resources>

--- a/Source/SVWidgetsLib/Widgets/SVPipelineView.h
+++ b/Source/SVWidgetsLib/Widgets/SVPipelineView.h
@@ -229,38 +229,38 @@ public slots:
    * the filter gets appended to the end of the model
    * @param filter
    */
-  void addFilter(AbstractFilter::Pointer filter, int insertIndex = -1, bool useAnimationOnFirstRun = true);
+  void addFilter(const AbstractFilter::Pointer& filter, int insertIndex = -1, bool useAnimationOnFirstRun = true);
 
   /**
    * @brief Adds multiple filters to the current model.  If insertIndex is < 0,
    * the filters get appended to the end of the model
    * @param filters
    */
-  void addFilters(std::vector<AbstractFilter::Pointer> filters, int insertIndex = -1, bool useAnimationOnFirstRun = true);
+  void addFilters(const std::vector<AbstractFilter::Pointer>& filters, int insertIndex = -1, bool useAnimationOnFirstRun = true);
 
   /**
    * @brief Removes filter from the current model
    * @param filter
    */
-  void removeFilter(AbstractFilter::Pointer filter, bool useAnimationOnFirstRun = true);
+  void removeFilter(const AbstractFilter::Pointer& filter, bool useAnimationOnFirstRun = true);
 
   /**
    * @brief Removes multiple filters from the current model
    * @param filters
    */
-  void removeFilters(std::vector<AbstractFilter::Pointer> filters, bool useAnimationOnFirstRun = true);
+  void removeFilters(const std::vector<AbstractFilter::Pointer>& filters, bool useAnimationOnFirstRun = true);
 
   /**
    * @brief Cuts filter from the current model
    * @param filter
    */
-  void cutFilter(AbstractFilter::Pointer filter, bool useAnimationOnFirstRun = true);
+  void cutFilter(const AbstractFilter::Pointer& filter, bool useAnimationOnFirstRun = true);
 
   /**
    * @brief Cuts multiple filters from the current model
    * @param filters
    */
-  void cutFilters(std::vector<AbstractFilter::Pointer> filters, bool useAnimationOnFirstRun = true);
+  void cutFilters(const std::vector<AbstractFilter::Pointer>& filters, bool useAnimationOnFirstRun = true);
 
   /**
    * @brief Copies the currently selected filters from the current model into the system clipboard
@@ -546,7 +546,7 @@ private:
    * @param pixmap
    * @param pixmapColor
    */
-  QPixmap setPixmapColor(QPixmap pixmap, QColor pixmapColor);
+  QPixmap setPixmapColor(const QPixmap& pixmap, const QColor& pixmapColor);
 
 public:
   SVPipelineView(const SVPipelineView&) = delete; // Copy Constructor Not Implemented

--- a/Source/SVWidgetsLib/Widgets/SVStyle.cpp
+++ b/Source/SVWidgetsLib/Widgets/SVStyle.cpp
@@ -746,3 +746,29 @@ QIcon SVStyle::IconForGroup(const QString &grpName)
   return QIcon(QPixmap::fromImage(grpImage));
 }
 
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString SVStyle::WrapTextWithHtmlStyle(const QString& msg, bool bold) const
+{
+  QString formattedMessage;
+  QTextStream out(&formattedMessage);
+
+  if(bold)
+  {
+    out << "<b ";
+  }
+  else {
+    out << "<span ";
+  }
+  out << "style=\"color: " << getQLabel_color().name(QColor::HexRgb) << ";\">";
+  out << msg;
+  if(bold)
+  {
+    out << " </b>";
+  }
+  else {
+    out << "</span>";
+  }
+  return formattedMessage;
+}

--- a/Source/SVWidgetsLib/Widgets/SVStyle.h
+++ b/Source/SVWidgetsLib/Widgets/SVStyle.h
@@ -554,6 +554,16 @@ class SVWidgetsLib_EXPORT SVStyle : public QObject
      */
     QIcon IconForGroup(const QString &grpName);
 
+    /**
+     * @brief WrapTextWithHtmlStyle This method will take an existing QString and wrap the contents
+     * with some HTML <b> or <span> with an internal "style=..." html snippet of code. This makes
+     * the string suitable for a QTextEdit. An option to create bold text is also provided.
+     * @param msg
+     * @param bold
+     * @return
+     */
+    QString WrapTextWithHtmlStyle(const QString& msg, bool bold) const;
+
   protected:
     SVStyle();
 

--- a/Source/SVWidgetsLib/Widgets/UI_Files/FilterListToolboxWidget.ui
+++ b/Source/SVWidgetsLib/Widgets/UI_Files/FilterListToolboxWidget.ui
@@ -57,7 +57,7 @@
    <item>
     <widget class="FilterListView" name="filterListView">
      <property name="alternatingRowColors">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="itemsExpandable">
       <bool>false</bool>

--- a/Source/SVWidgetsLib/Widgets/util/AddFilterCommand.cpp
+++ b/Source/SVWidgetsLib/Widgets/util/AddFilterCommand.cpp
@@ -49,6 +49,8 @@
 #include "SVWidgetsLib/Widgets/FilterInputWidget.h"
 #include "SVWidgetsLib/Widgets/PipelineModel.h"
 #include "SVWidgetsLib/Widgets/SVPipelineView.h"
+#include "SVWidgetsLib/Widgets/SVStyle.h"
+
 
 // -----------------------------------------------------------------------------
 //
@@ -144,7 +146,7 @@ void AddFilterCommand::undo()
   emit m_PipelineView->pipelineChanged();
 
   emit m_PipelineView->statusMessage(statusMessage);
-  emit m_PipelineView->stdOutMessage(statusMessage);
+  emit m_PipelineView->stdOutMessage(SVStyle::Instance()->WrapTextWithHtmlStyle(statusMessage,false));
 }
 
 // -----------------------------------------------------------------------------
@@ -188,7 +190,7 @@ void AddFilterCommand::redo()
   }
 
   emit model->statusMessageGenerated(statusMessage);
-  emit model->standardOutputMessageGenerated(statusMessage);
+  emit model->standardOutputMessageGenerated(SVStyle::Instance()->WrapTextWithHtmlStyle(statusMessage,false));
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SVWidgetsLib/Widgets/util/RemoveFilterCommand.cpp
+++ b/Source/SVWidgetsLib/Widgets/util/RemoveFilterCommand.cpp
@@ -39,6 +39,7 @@
 #include "SVWidgetsLib/Widgets/FilterInputWidget.h"
 #include "SVWidgetsLib/Widgets/PipelineModel.h"
 #include "SVWidgetsLib/Widgets/SVPipelineView.h"
+#include "SVWidgetsLib/Widgets/SVStyle.h"
 
 // -----------------------------------------------------------------------------
 //
@@ -127,7 +128,7 @@ void RemoveFilterCommand::undo()
   }
 
   emit m_PipelineView->statusMessage(statusMessage);
-  emit m_PipelineView->stdOutMessage(statusMessage);
+  emit m_PipelineView->stdOutMessage(SVStyle::Instance()->WrapTextWithHtmlStyle(statusMessage,false));
 }
 
 // -----------------------------------------------------------------------------
@@ -143,9 +144,9 @@ bool variantCompare(const QVariant& v1, const QVariant& v2)
 // -----------------------------------------------------------------------------
 void RemoveFilterCommand::redo()
 {
-  for(size_t i = 0; i < m_Filters.size(); i++)
+  for(const auto& filter : m_Filters)
   {
-    removeFilter(m_Filters[i]);
+    removeFilter(filter);
   }
 
   QString statusMessage;
@@ -179,7 +180,7 @@ void RemoveFilterCommand::redo()
   emit m_PipelineView->pipelineChanged();
 
   emit m_PipelineView->statusMessage(statusMessage);
-  emit m_PipelineView->stdOutMessage(statusMessage);
+  emit m_PipelineView->stdOutMessage(SVStyle::Instance()->WrapTextWithHtmlStyle(statusMessage,false));
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
+ Added x.png file to the SIMPL.qrc file to use in checkboxes
+ Redesigned SeparatorWidget to have a nice thin line next to the QLabel
+ Created method in SVStyle to wrap some text in HTML tags that will define the color based on the current style sheet
+ Remove Alternating row colors in the FilterListToolboxWidget
+ Properly use the StyleSheet information with sending messages to the StandardOutput widget

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>