### PR TITLE
Fix runtime crashes inside of FilterPipeline and DataArrayPath

### DIFF
--- a/Source/SIMPLib/DataContainers/DataArrayPath.cpp
+++ b/Source/SIMPLib/DataContainers/DataArrayPath.cpp
@@ -119,11 +119,12 @@ QVector<DataArrayPath> DataArrayPath::ConvertToQVector(QStringList& paths)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataArrayPath::operator=(const DataArrayPath& rhs)
+DataArrayPath& DataArrayPath::operator=(const DataArrayPath& rhs)
 {
-  m_DataContainerName = rhs.getDataContainerName();
-  m_AttributeMatrixName = rhs.getAttributeMatrixName();
-  m_DataArrayName = rhs.getDataArrayName();
+  m_DataContainerName = rhs.m_DataContainerName;
+  m_AttributeMatrixName = rhs.m_AttributeMatrixName;
+  m_DataArrayName = rhs.m_DataArrayName;
+  return *this;
 }
 
 // -----------------------------------------------------------------------------
@@ -131,7 +132,7 @@ void DataArrayPath::operator=(const DataArrayPath& rhs)
 // -----------------------------------------------------------------------------
 bool DataArrayPath::operator==(const DataArrayPath& rhs) const
 {
-  return m_DataContainerName == rhs.getDataContainerName() && m_AttributeMatrixName == rhs.getAttributeMatrixName() && m_DataArrayName == rhs.getDataArrayName();
+  return m_DataContainerName == rhs.m_DataContainerName && m_AttributeMatrixName == rhs.m_AttributeMatrixName && m_DataArrayName == rhs.m_DataArrayName;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/DataContainers/DataArrayPath.h
+++ b/Source/SIMPLib/DataContainers/DataArrayPath.h
@@ -172,7 +172,7 @@ class SIMPLib_EXPORT DataArrayPath : public QObject
     /**
      * @brief operator =
      */
-    void operator=(const DataArrayPath& rhs);
+    DataArrayPath& operator=(const DataArrayPath& rhs);
 
     /**
      * @brief operator ==

--- a/Source/SIMPLib/Filtering/FilterPipeline.h
+++ b/Source/SIMPLib/Filtering/FilterPipeline.h
@@ -111,11 +111,11 @@ public:
   /**
    * @brief
    */
-  virtual void pushFront(AbstractFilter::Pointer f);
+  virtual void pushFront(const AbstractFilter::Pointer& f);
   virtual void popFront();
-  virtual void pushBack(AbstractFilter::Pointer f);
+  virtual void pushBack(const AbstractFilter::Pointer& f);
   virtual void popBack();
-  virtual void insert(size_t index, AbstractFilter::Pointer f);
+  virtual void insert(size_t index, const AbstractFilter::Pointer& f);
   virtual void erase(size_t index);
   virtual void clear();
   virtual size_t size();
@@ -181,7 +181,7 @@ public slots:
    */
   virtual void cancelPipeline();
 
-  void setName(QString name);
+  void setName(const QString& name);
 
 protected:
   FilterPipeline();

--- a/Source/SVWidgetsLib/Widgets/util/AddFilterCommand.h
+++ b/Source/SVWidgetsLib/Widgets/util/AddFilterCommand.h
@@ -39,8 +39,7 @@
 
 #include <QtWidgets/QUndoCommand>
 
-#include <SIMPLib/Filtering/AbstractFilter.h>
-#include <SIMPLib/Filtering/FilterPipeline.h>
+#include "SIMPLib/Filtering/AbstractFilter.h"
 
 #include "SVWidgetsLib/SVWidgetsLib.h"
 


### PR DESCRIPTION
Updated DataArrayPath with clang-tidy suggestions
Reverted code from previous commit in FilterPipeline that causes
a crash during runtime when using std::copy
Removed an include from AddFilterCommand and fixed up another one.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>