### PR TITLE
Change API from FromPointer to CopyFromPointer

### DIFF
--- a/Source/SIMPLib/DataArrays/DataArray.hpp
+++ b/Source/SIMPLib/DataArrays/DataArray.hpp
@@ -371,7 +371,7 @@ class DataArray : public IDataArray
      * @param name
      * @return
      */
-    static Pointer FromPointer(T* data, size_t size, const QString& name, bool allocate = true)
+    static Pointer CopyFromPointer(T* data, size_t size, const QString& name, bool allocate = true)
     {
       Pointer p = CreateArray(size, name, allocate);
       if (nullptr != p.get())


### PR DESCRIPTION
This makes it more obvious what the method is going to do and who owns the
underlying memory.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>