### PR TITLE
Remove the notification at the end of the execute() method of filters.

### DIFF
--- a/Source/SIMPLib/CoreFilters/ArrayCalculator.cpp
+++ b/Source/SIMPLib/CoreFilters/ArrayCalculator.cpp
@@ -484,7 +484,6 @@ void ArrayCalculator::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/CombineAttributeArrays.cpp
+++ b/Source/SIMPLib/CoreFilters/CombineAttributeArrays.cpp
@@ -337,9 +337,6 @@ void CombineAttributeArrays::execute()
       attrMat->removeAttributeArray(path.getDataArrayName());
     }
   }
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/CombineAttributeMatrices.cpp
+++ b/Source/SIMPLib/CoreFilters/CombineAttributeMatrices.cpp
@@ -352,7 +352,6 @@ void CombineAttributeMatrices::execute()
     EXECUTE_FUNCTION_TEMPLATE(this, copyData, fromDataArray, fromDataArray, toDataArray, location);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/ConditionalSetValue.cpp
+++ b/Source/SIMPLib/CoreFilters/ConditionalSetValue.cpp
@@ -276,9 +276,6 @@ void ConditionalSetValue::execute()
   }
 
   EXECUTE_FUNCTION_TEMPLATE(this, replaceValue, m_ArrayPtr.lock(), this, m_ArrayPtr.lock(), m_ConditionalArrayPtr.lock(), m_ReplaceValue)
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/ConvertData.cpp
+++ b/Source/SIMPLib/CoreFilters/ConvertData.cpp
@@ -368,9 +368,6 @@ void ConvertData::execute()
   CHECK_AND_CONVERT(FloatArrayType, m, m_ScalarType, iArray, m_SelectedCellArrayPath.getAttributeMatrixName(), m_OutputArrayName)
   CHECK_AND_CONVERT(DoubleArrayType, m, m_ScalarType, iArray, m_SelectedCellArrayPath.getAttributeMatrixName(), m_OutputArrayName)
   CHECK_AND_CONVERT(BoolArrayType, m, m_ScalarType, iArray, m_SelectedCellArrayPath.getAttributeMatrixName(), m_OutputArrayName)
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/SIMPLib/CoreFilters/CopyFeatureArrayToElementArray.cpp
+++ b/Source/SIMPLib/CoreFilters/CopyFeatureArrayToElementArray.cpp
@@ -300,7 +300,6 @@ void CopyFeatureArrayToElementArray::execute()
     am->addAttributeArray(p->getName(), p);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/CopyObject.cpp
+++ b/Source/SIMPLib/CoreFilters/CopyObject.cpp
@@ -249,7 +249,6 @@ void CopyObject::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/CreateAttributeMatrix.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateAttributeMatrix.cpp
@@ -182,7 +182,6 @@ void CreateAttributeMatrix::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/CreateDataArray.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateDataArray.cpp
@@ -479,9 +479,6 @@ void CreateDataArray::execute()
   {
     initializeArrayWithInts<bool>(m_OutputArrayPtr.lock(), m_InitializationType, m_InitializationRange, m_InitializationValue, m_ScalarType);
   }
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/CreateDataContainer.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateDataContainer.cpp
@@ -123,7 +123,6 @@ void CreateDataContainer::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/CreateFeatureArrayFromElementArray.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateFeatureArrayFromElementArray.cpp
@@ -326,7 +326,6 @@ void CreateFeatureArrayFromElementArray::execute()
     getDataContainerArray()->getAttributeMatrix(m_CellFeatureAttributeMatrixName)->addAttributeArray(p->getName(), p);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/CreateGeometry.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateGeometry.cpp
@@ -904,7 +904,6 @@ void CreateGeometry::execute()
   }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/CreateImageGeometry.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateImageGeometry.cpp
@@ -173,7 +173,6 @@ void CreateImageGeometry::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/CreateStringArray.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateStringArray.cpp
@@ -190,9 +190,6 @@ void CreateStringArray::execute()
   }
 
   initializeArray(m_OutputArrayPtr.lock(), m_InitializationValue);
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/CropVertexGeometry.cpp
+++ b/Source/SIMPLib/CoreFilters/CropVertexGeometry.cpp
@@ -315,7 +315,6 @@ void CropVertexGeometry::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/DataContainerReader.cpp
+++ b/Source/SIMPLib/CoreFilters/DataContainerReader.cpp
@@ -243,7 +243,6 @@ void DataContainerReader::execute()
    */
   dataCheck();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/DataContainerWriter.cpp
+++ b/Source/SIMPLib/CoreFilters/DataContainerWriter.cpp
@@ -295,7 +295,6 @@ void DataContainerWriter::execute()
 
   dcaGid = -1;
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/EmptyFilter.cpp
+++ b/Source/SIMPLib/CoreFilters/EmptyFilter.cpp
@@ -120,8 +120,6 @@ void EmptyFilter::execute()
 {
   dataCheck();
   initialize();
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/ExecuteProcess.cpp
+++ b/Source/SIMPLib/CoreFilters/ExecuteProcess.cpp
@@ -233,7 +233,6 @@ void ExecuteProcess::processHasFinished(int exitCode, QProcess::ExitStatus exitS
   }
   else if(getErrorCondition() >= 0)
   {
-    notifyStatusMessage(getHumanLabel(), "Complete");
   }
 
   m_Pause = false;

--- a/Source/SIMPLib/CoreFilters/ExtractAttributeArraysFromGeometry.cpp
+++ b/Source/SIMPLib/CoreFilters/ExtractAttributeArraysFromGeometry.cpp
@@ -634,7 +634,6 @@ void ExtractAttributeArraysFromGeometry::execute()
   }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/ExtractComponentAsArray.cpp
+++ b/Source/SIMPLib/CoreFilters/ExtractComponentAsArray.cpp
@@ -206,7 +206,6 @@ void ExtractComponentAsArray::execute()
 
   EXECUTE_FUNCTION_TEMPLATE(this, extractComponent, m_InArrayPtr.lock(), m_InArrayPtr.lock(), m_NewArrayPtr.lock(), m_CompNumber)
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/ExtractVertexGeometry.cpp
+++ b/Source/SIMPLib/CoreFilters/ExtractVertexGeometry.cpp
@@ -299,7 +299,6 @@ void ExtractVertexGeometry::execute()
 
   // The moving or copying of the Cell DataArrays was already handled in the dataCheck() method.
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/FeatureCountDecision.cpp
+++ b/Source/SIMPLib/CoreFilters/FeatureCountDecision.cpp
@@ -153,7 +153,6 @@ void FeatureCountDecision::execute()
   emit decisionMade(dm);
   emit targetValue(m_FeatureIds[1]);
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/FeatureDataCSVWriter.cpp
+++ b/Source/SIMPLib/CoreFilters/FeatureDataCSVWriter.cpp
@@ -307,9 +307,6 @@ void FeatureDataCSVWriter::execute()
     }
   }
   file.close();
-
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/FindDerivatives.cpp
+++ b/Source/SIMPLib/CoreFilters/FindDerivatives.cpp
@@ -373,9 +373,6 @@ void FindDerivatives::execute()
 
   geom->setMessagePrefix("");
   geom->setMessageTitle("");
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/GenerateColorTable.cpp
+++ b/Source/SIMPLib/CoreFilters/GenerateColorTable.cpp
@@ -361,7 +361,6 @@ void GenerateColorTable::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/ImportAsciDataArray.cpp
+++ b/Source/SIMPLib/CoreFilters/ImportAsciDataArray.cpp
@@ -646,9 +646,6 @@ void ImportAsciDataArray::execute()
     setErrorCondition(RBR_READ_EOF);
     notifyErrorMessage(getHumanLabel(), "ImportAsciDataArray read past the end of the specified file", getErrorCondition());
   }
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.cpp
+++ b/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.cpp
@@ -366,7 +366,6 @@ void ImportHDF5Dataset::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/LinkFeatureMapToElementArray.cpp
+++ b/Source/SIMPLib/CoreFilters/LinkFeatureMapToElementArray.cpp
@@ -200,7 +200,6 @@ void LinkFeatureMapToElementArray::execute()
     m_Active[i] = active[i];
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/MaskCountDecision.cpp
+++ b/Source/SIMPLib/CoreFilters/MaskCountDecision.cpp
@@ -166,7 +166,6 @@ void MaskCountDecision::execute()
 
   emit decisionMade(dm);
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/MoveData.cpp
+++ b/Source/SIMPLib/CoreFilters/MoveData.cpp
@@ -235,7 +235,6 @@ void MoveData::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/MoveMultiData.cpp
+++ b/Source/SIMPLib/CoreFilters/MoveMultiData.cpp
@@ -252,7 +252,6 @@ void MoveMultiData::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/MultiThresholdObjects.cpp
+++ b/Source/SIMPLib/CoreFilters/MultiThresholdObjects.cpp
@@ -257,9 +257,6 @@ void MultiThresholdObjects::execute()
       }
     }
   }
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/MultiThresholdObjects2.cpp
+++ b/Source/SIMPLib/CoreFilters/MultiThresholdObjects2.cpp
@@ -248,9 +248,6 @@ void MultiThresholdObjects2::execute()
     {
       m_Destination[p] = threshold[p];
     }
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/PostSlackMessage.cpp
+++ b/Source/SIMPLib/CoreFilters/PostSlackMessage.cpp
@@ -177,7 +177,6 @@ void PostSlackMessage::execute()
   delete reply;
   delete connection;
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/RawBinaryReader.cpp
+++ b/Source/SIMPLib/CoreFilters/RawBinaryReader.cpp
@@ -498,9 +498,6 @@ void RawBinaryReader::execute()
     setErrorCondition(RBR_READ_EOF);
     notifyErrorMessage(getHumanLabel(), "RawBinaryReader read past the end of the specified file", getErrorCondition());
   }
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/ReadASCIIData.cpp
+++ b/Source/SIMPLib/CoreFilters/ReadASCIIData.cpp
@@ -592,7 +592,6 @@ void ReadASCIIData::execute()
     inputFile.close();
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/RemoveArrays.cpp
+++ b/Source/SIMPLib/CoreFilters/RemoveArrays.cpp
@@ -213,7 +213,6 @@ void RemoveArrays::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/RemoveComponentFromArray.cpp
+++ b/Source/SIMPLib/CoreFilters/RemoveComponentFromArray.cpp
@@ -284,7 +284,6 @@ void RemoveComponentFromArray::execute()
     EXECUTE_FUNCTION_TEMPLATE(this, reduceArrayOnly, m_InArrayPtr.lock(), m_InArrayPtr.lock(), m_ReducedArrayPtr.lock(), m_CompNumber)
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/RenameAttributeArray.cpp
+++ b/Source/SIMPLib/CoreFilters/RenameAttributeArray.cpp
@@ -164,7 +164,6 @@ void RenameAttributeArray::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/SIMPLib/CoreFilters/RenameAttributeMatrix.cpp
+++ b/Source/SIMPLib/CoreFilters/RenameAttributeMatrix.cpp
@@ -151,7 +151,6 @@ void RenameAttributeMatrix::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/SIMPLib/CoreFilters/RenameDataContainer.cpp
+++ b/Source/SIMPLib/CoreFilters/RenameDataContainer.cpp
@@ -147,7 +147,6 @@ void RenameDataContainer::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/SIMPLib/CoreFilters/ReplaceValueInArray.cpp
+++ b/Source/SIMPLib/CoreFilters/ReplaceValueInArray.cpp
@@ -270,9 +270,6 @@ void ReplaceValueInArray::execute()
   }
 
   EXECUTE_FUNCTION_TEMPLATE(this, replaceValue, m_ArrayPtr.lock(), this, m_ArrayPtr.lock(), m_RemoveValue, m_ReplaceValue)
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/RequiredZThickness.cpp
+++ b/Source/SIMPLib/CoreFilters/RequiredZThickness.cpp
@@ -199,7 +199,6 @@ void RequiredZThickness::execute()
     emit decisionMade(needMoreData);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/ScaleVolume.cpp
+++ b/Source/SIMPLib/CoreFilters/ScaleVolume.cpp
@@ -288,7 +288,6 @@ void ScaleVolume::execute()
     updateSurfaceMesh();
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/SetOriginResolutionImageGeom.cpp
+++ b/Source/SIMPLib/CoreFilters/SetOriginResolutionImageGeom.cpp
@@ -205,7 +205,6 @@ void SetOriginResolutionImageGeom::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/SplitAttributeArray.cpp
+++ b/Source/SIMPLib/CoreFilters/SplitAttributeArray.cpp
@@ -201,7 +201,6 @@ void SplitAttributeArray::execute()
 
   EXECUTE_FUNCTION_TEMPLATE(this, splitMulticomponentArray, m_InputArrayPtr.lock(), m_InputArrayPtr.lock(), m_SplitArraysPtrVector)
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/WriteASCIIData.cpp
+++ b/Source/SIMPLib/CoreFilters/WriteASCIIData.cpp
@@ -358,7 +358,6 @@ void WriteASCIIData::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/WriteTriangleGeometry.cpp
+++ b/Source/SIMPLib/CoreFilters/WriteTriangleGeometry.cpp
@@ -286,9 +286,6 @@ void WriteTriangleGeometry::execute()
   }
 
   fileTri.close();
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/ArraySelectionExample.cpp
+++ b/Source/SIMPLib/TestFilters/ArraySelectionExample.cpp
@@ -123,9 +123,6 @@ void ArraySelectionExample::execute()
   }
 
   /* Place all your code to execute your filter here. */
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/DynamicTableExample.cpp
+++ b/Source/SIMPLib/TestFilters/DynamicTableExample.cpp
@@ -182,9 +182,6 @@ void DynamicTableExample::preflight()
 void DynamicTableExample::execute()
 {
   // This filter does nothing during execute!
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/ErrorWarningFilter.cpp
+++ b/Source/SIMPLib/TestFilters/ErrorWarningFilter.cpp
@@ -147,7 +147,6 @@ void ErrorWarningFilter::execute()
     notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup00.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup00.cpp
@@ -115,7 +115,6 @@ void TESTCLASSNAME::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup01.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup01.cpp
@@ -115,7 +115,6 @@ void FilterGroup01::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup02.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup02.cpp
@@ -115,7 +115,6 @@ void FilterGroup02::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup03.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup03.cpp
@@ -115,7 +115,6 @@ void FilterGroup03::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup04.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup04.cpp
@@ -115,7 +115,6 @@ void FilterGroup04::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup05.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup05.cpp
@@ -115,7 +115,6 @@ void FilterGroup05::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup06.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup06.cpp
@@ -115,7 +115,6 @@ void FilterGroup06::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup07.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup07.cpp
@@ -115,7 +115,6 @@ void FilterGroup07::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup08.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup08.cpp
@@ -115,7 +115,6 @@ void FilterGroup08::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup09.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup09.cpp
@@ -115,7 +115,6 @@ void FilterGroup09::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup10.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup10.cpp
@@ -115,7 +115,6 @@ void FilterGroup10::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup12.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup12.cpp
@@ -115,7 +115,6 @@ void FilterGroup12::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/FilterGroup13.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup13.cpp
@@ -115,7 +115,6 @@ void FilterGroup13::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/GenericExample.cpp
+++ b/Source/SIMPLib/TestFilters/GenericExample.cpp
@@ -418,8 +418,6 @@ void GenericExample::execute()
   }
 
   qDebug() << "Feature Ids: " << getFeatureIdsArrayPath().getDataArrayName();
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/TestFilters/MakeDataContainer.cpp
+++ b/Source/SIMPLib/TestFilters/MakeDataContainer.cpp
@@ -202,9 +202,6 @@ void MakeDataContainer::execute()
   {
     m_FeatureIds[i] = i;
   }
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/SIMPLib/TestFilters/TestFilters.cpp
+++ b/Source/SIMPLib/TestFilters/TestFilters.cpp
@@ -101,9 +101,6 @@ void Filt0::execute()
   setWarningCondition(0);
 
   /* Place all your code to execute your filter here. */
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------
@@ -199,7 +196,4 @@ void Filt1::execute()
   setWarningCondition(0);
 
   /* Place all your code to execute your filter here. */
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }

--- a/Source/SIMPLib/TestFilters/ThresholdExample.cpp
+++ b/Source/SIMPLib/TestFilters/ThresholdExample.cpp
@@ -182,9 +182,6 @@ void ThresholdExample::execute()
 {
   dataCheck();
   /* Place all your code to execute your filter here. */
-
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
The FilterPipeline class now sends a PipelineMessage object at the completion of
each filter in a consistent form.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>