### PR TITLE
Fix failingREST API Unit test in the SIMPLib project

### DIFF
--- a/Source/SIMPLib/REST/Testing/Cxx/RESTErrorPipeline.json
+++ b/Source/SIMPLib/REST/Testing/Cxx/RESTErrorPipeline.json
@@ -13,10 +13,10 @@
         "Filter_Uuid": "{0559aa37-c5ad-549a-82d4-bff4bfcb6cc6}",
         "HourglassStiffness": 250,
         "JobName": "",
-        "OutputPath": "/Users/joeykleingers"
+        "OutputPath": ""
     },
     "1": {
-        "AlignmentShiftFileName": "/Users/joeykleingers",
+        "AlignmentShiftFileName": "",
         "CellPhasesArrayPath": {
             "Attribute Matrix Name": "CellData",
             "Data Array Name": "Phases",

--- a/Source/SIMPLib/REST/Testing/Cxx/RESTUnitTest.cpp
+++ b/Source/SIMPLib/REST/Testing/Cxx/RESTUnitTest.cpp
@@ -1509,7 +1509,7 @@ public:
       DREAM3D_REQUIRE_EQUAL(responseObject[SIMPL::JSON::PipelineErrors].isArray(), true);
 
       QJsonArray responseErrorsArray = responseObject[SIMPL::JSON::PipelineErrors].toArray();
-      DREAM3D_REQUIRE_EQUAL(responseErrorsArray.size(), 3);
+      DREAM3D_REQUIRE_EQUAL(responseErrorsArray.size(), 4);
 
       DREAM3D_REQUIRE_EQUAL(responseObject[SIMPL::JSON::PipelineWarnings].isArray(), true);
       QJsonArray responseWarningsArray = responseObject[SIMPL::JSON::PipelineWarnings].toArray();


### PR DESCRIPTION
The precomputed pipeline file had a path that is actually valid on some of the test machines. This path was replaced by a blank path and the value for the expected number of errors was increased to 4.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>