### PR TITLE
Fix issue where the parent of a stored path was used instead of the path

### DIFF
--- a/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.cpp
@@ -301,7 +301,7 @@ void AbstractIOFileWidget::on_m_LineEdit_fileDropped(const QString& text)
   SIMPLDataPathValidator* validator = SIMPLDataPathValidator::Instance();
   QString inputPath = validator->convertToAbsolutePath(text);
 
-  setOpenDialogLastFilePath(text);
+  setValue(text);
   // Set/Remove the red outline if the file does exist
   verifyPathExists(inputPath, m_LineEdit);
 
@@ -342,7 +342,7 @@ void AbstractIOFileWidget::afterPreflight()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void AbstractIOFileWidget::setOpenDialogLastFilePath(const QString& val)
+void AbstractIOFileWidget::setValue(const QString& val)
 {
   m_LineEdit->setText(val);
 }
@@ -350,7 +350,7 @@ void AbstractIOFileWidget::setOpenDialogLastFilePath(const QString& val)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QString AbstractIOFileWidget::getOpenDialogLastFilePath() 
+QString AbstractIOFileWidget::getValue()
 {
   if(m_LineEdit->text().isEmpty())
   {

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.h
@@ -101,9 +101,9 @@ class SVWidgetsLib_EXPORT AbstractIOFileWidget : public FilterParameterWidget, p
 
 
   protected:
-    void setOpenDialogLastFilePath(const QString &val);
+    void setValue(const QString& val);
 
-    QString getOpenDialogLastFilePath();
+    QString getValue();
 
     /**
     * @brief

--- a/Source/SVWidgetsLib/FilterParameterWidgets/InputFileWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/InputFileWidget.cpp
@@ -78,7 +78,7 @@ void InputFileWidget::selectInputFile()
   QString ext = m_FilterParameter->getFileExtension();
   QString s = Ftype + QString(" Files (") + ext + QString(");;All Files(*.*)");
   // QString defaultName = m_OpenDialogLastDirectory + QDir::separator() + "Untitled";
-  QString file = QFileDialog::getOpenFileName(this, tr("Select Input File"), getOpenDialogLastFilePath(), s);
+  QString file = QFileDialog::getOpenFileName(this, tr("Select Input File"), getValue(), s);
 
   if(file.isEmpty())
   {
@@ -87,7 +87,7 @@ void InputFileWidget::selectInputFile()
   file = QDir::toNativeSeparators(file);
   // Store the last used directory into the private instance variable
   QFileInfo fi(file);
-  setOpenDialogLastFilePath(fi.filePath());
+  setValue(fi.filePath());
   m_LineEdit->setText(file);
   on_m_LineEdit_editingFinished();
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/InputPathWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/InputPathWidget.cpp
@@ -62,13 +62,11 @@ InputPathWidget::InputPathWidget(FilterParameter* parameter, AbstractFilter* fil
     if(!currentPath.isEmpty())
     {
       currentPath = QDir::toNativeSeparators(currentPath);
-      // Store the last used directory into the private instance variable
-      QFileInfo fi(currentPath);
-      setOpenDialogLastFilePath(fi.path());
+      setValue(currentPath);
     }
     else
     {
-      setOpenDialogLastFilePath(QDir::homePath());
+      setValue(QDir::homePath());
     }
   }
 }
@@ -96,7 +94,7 @@ void InputPathWidget::selectInputPath()
   QString currentPath = getFilter()->property(PROPERTY_NAME_AS_CHAR).toString();
   if(currentPath.isEmpty())
   {
-    currentPath = getOpenDialogLastFilePath();
+    currentPath = getValue();
   }
   QString Ftype = m_FilterParameter->getFileType();
   QString ext = m_FilterParameter->getFileExtension();
@@ -112,7 +110,7 @@ void InputPathWidget::selectInputPath()
   file = QDir::toNativeSeparators(file);
   // Store the last used directory into the private instance variable
   QFileInfo fi(file);
-  setOpenDialogLastFilePath(fi.filePath());
+  setValue(fi.filePath());
 
   m_LineEdit->setText(file);
   on_m_LineEdit_editingFinished();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/OutputFileWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/OutputFileWidget.cpp
@@ -75,12 +75,12 @@ void OutputFileWidget::selectOutputFile()
   QString currentPath = getFilter()->property(PROPERTY_NAME_AS_CHAR).toString();
   if(currentPath.isEmpty())
   {
-    currentPath = getOpenDialogLastFilePath();
+    currentPath = getValue();
   }
   QString Ftype = m_FilterParameter->getFileType();
   QString ext = m_FilterParameter->getFileExtension();
   QString s = Ftype + QString(" Files (") + ext + QString(");;All Files(*.*)");
-  QString defaultName = getOpenDialogLastFilePath();
+  QString defaultName = getValue();
   QString file = QFileDialog::getSaveFileName(this, tr("Save File As"), defaultName, s);
 
   if(file.isEmpty())
@@ -91,7 +91,7 @@ void OutputFileWidget::selectOutputFile()
   file = QDir::toNativeSeparators(file);
   // Store the last used directory into the private instance variable
   QFileInfo fi(file);
-  setOpenDialogLastFilePath(fi.filePath());
+  setValue(fi.filePath());
 
   m_LineEdit->setText(file);
   on_m_LineEdit_editingFinished();

--- a/Source/SVWidgetsLib/FilterParameterWidgets/OutputPathWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/OutputPathWidget.cpp
@@ -58,11 +58,11 @@ OutputPathWidget::OutputPathWidget(FilterParameter* parameter, AbstractFilter* f
       currentPath = QDir::toNativeSeparators(currentPath);
       // Store the last used directory into the private instance variable
       QFileInfo fi(currentPath);
-      setOpenDialogLastFilePath(fi.filePath());
+      setValue(fi.filePath());
     }
     else
     {
-      setOpenDialogLastFilePath(QDir::homePath());
+      setValue(QDir::homePath());
     }
   }
 }
@@ -90,7 +90,7 @@ void OutputPathWidget::selectOutputPath()
   QString currentPath = getFilter()->property(PROPERTY_NAME_AS_CHAR).toString();
   if(currentPath.isEmpty())
   {
-    currentPath = getOpenDialogLastFilePath();
+    currentPath = getValue();
   }
   QString Ftype = m_FilterParameter->getFileType();
   QString ext = m_FilterParameter->getFileExtension();
@@ -106,7 +106,7 @@ void OutputPathWidget::selectOutputPath()
   file = QDir::toNativeSeparators(file);
   // Store the last used directory into the private instance variable
   QFileInfo fi(file);
-  setOpenDialogLastFilePath(fi.filePath());
+  setValue(fi.filePath());
 
   m_LineEdit->setText(file);
   on_m_LineEdit_editingFinished();


### PR DESCRIPTION
Bug was discovered working with various widgets that save a path instead of a file path.

API change to make it more consistent as to what is being set/get

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>