### PR TITLE
Improvements to the Write ASCII Data filter. Single file mode

### DIFF
--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/WriteASCIIDataTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/WriteASCIIDataTest.cpp
@@ -33,7 +33,7 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <iostream>
 #include <string>
@@ -77,6 +77,7 @@ public:
   {
 #if REMOVE_TEST_FILES
     QFile::remove(UnitTest::TestTempDir + "/" + k_ArrayName + k_Extension);
+    QFile::remove(UnitTest::TestTempDir + "/" + "SingleFileMode.csv");
 #endif
   }
 
@@ -115,6 +116,7 @@ public:
     writer->setDelimiter(WriteASCIIData::DelimiterType::Comma);
     writer->setFileExtension(k_Extension);
     writer->setMaxValPerLine(1);
+    writer->setOutputType(0);
 
     writer->preflight();
     int err = writer->getErrorCondition();
@@ -123,6 +125,20 @@ public:
     writer->execute();
     err = writer->getErrorCondition();
     DREAM3D_REQUIRE(err >= 0)
+
+    // Test Single File mode
+    writer->setOutputType(1);
+    writer->setOutputFilePath(UnitTest::TestTempDir + "/" + "SingleFileMode.csv");
+    writer->preflight();
+    err = writer->getErrorCondition();
+    DREAM3D_REQUIRE(err >= 0)
+
+    writer->execute();
+    err = writer->getErrorCondition();
+    DREAM3D_REQUIRE(err >= 0)
+
+    // Back to MultiFile mode
+    writer->setOutputType(0);
 
     NeighborList<int32_t>::Pointer neighborList = NeighborList<int32_t>::CreateArray(k_ArraySize, "NeighborList", true);
     am->addAttributeArray(neighborList->getName(), neighborList);
@@ -181,7 +197,9 @@ public:
 #endif
   }
 
-private:
-  WriteASCIIDataTest(const WriteASCIIDataTest&); // Copy Constructor Not Implemented
-  void operator=(const WriteASCIIDataTest&);     // Move assignment Not Implemented
+public:
+  WriteASCIIDataTest(const WriteASCIIDataTest&) = delete;            // Copy Constructor Not Implemented
+  WriteASCIIDataTest(WriteASCIIDataTest&&) = delete;                 // Move Constructor Not Implemented
+  WriteASCIIDataTest& operator=(const WriteASCIIDataTest&) = delete; // Copy Assignment Not Implemented
+  WriteASCIIDataTest& operator=(WriteASCIIDataTest&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/WriteASCIIDataTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/WriteASCIIDataTest.cpp
@@ -116,7 +116,7 @@ public:
     writer->setDelimiter(WriteASCIIData::DelimiterType::Comma);
     writer->setFileExtension(k_Extension);
     writer->setMaxValPerLine(1);
-    writer->setOutputType(0);
+    writer->setOutputStyle(WriteASCIIData::MultiFile);
 
     writer->preflight();
     int err = writer->getErrorCondition();
@@ -127,7 +127,7 @@ public:
     DREAM3D_REQUIRE(err >= 0)
 
     // Test Single File mode
-    writer->setOutputType(1);
+    writer->setOutputStyle(WriteASCIIData::SingleFile);
     writer->setOutputFilePath(UnitTest::TestTempDir + "/" + "SingleFileMode.csv");
     writer->preflight();
     err = writer->getErrorCondition();
@@ -138,7 +138,7 @@ public:
     DREAM3D_REQUIRE(err >= 0)
 
     // Back to MultiFile mode
-    writer->setOutputType(0);
+    writer->setOutputStyle(WriteASCIIData::MultiFile);
 
     NeighborList<int32_t>::Pointer neighborList = NeighborList<int32_t>::CreateArray(k_ArraySize, "NeighborList", true);
     am->addAttributeArray(neighborList->getName(), neighborList);

--- a/Source/SIMPLib/CoreFilters/WriteASCIIData.cpp
+++ b/Source/SIMPLib/CoreFilters/WriteASCIIData.cpp
@@ -51,11 +51,6 @@
 #include "SIMPLib/FilterParameters/StringFilterParameter.h"
 #include "SIMPLib/SIMPLibVersion.h"
 
-namespace
-{
-static const int32_t k_MultiFile = 0;
-static const int32_t k_SingleFile = 1;
-} // namespace
 
 /**
  * @brief The ExportDataPrivate class is a templated class that implements a method to generically
@@ -153,9 +148,9 @@ void WriteASCIIData::setupFilterParameters()
   {
     LinkedChoicesFilterParameter::Pointer parameter = LinkedChoicesFilterParameter::New();
     parameter->setHumanLabel("Output Type");
-    parameter->setPropertyName("OutputType");
-    parameter->setSetterCallback(SIMPL_BIND_SETTER(WriteASCIIData, this, OutputType));
-    parameter->setGetterCallback(SIMPL_BIND_GETTER(WriteASCIIData, this, OutputType));
+    parameter->setPropertyName("OutputStyle");
+    parameter->setSetterCallback(SIMPL_BIND_SETTER(WriteASCIIData, this, OutputStyle));
+    parameter->setGetterCallback(SIMPL_BIND_GETTER(WriteASCIIData, this, OutputStyle));
     QVector<QString> choices;
     choices.push_back("Multiple Files");
     choices.push_back("Single File");
@@ -235,7 +230,7 @@ void WriteASCIIData::dataCheck()
   setWarningCondition(0);
 
   //**************** MultiFile Checks ******************
-  if(m_OutputType == ::k_MultiFile)
+  if(m_OutputStyle == MultiFile)
   {
     if(m_OutputPath.isEmpty())
     {
@@ -262,7 +257,7 @@ void WriteASCIIData::dataCheck()
     }
   }
   //**************** MultiFile Checks ******************
-  else if(m_OutputType == ::k_SingleFile)
+  else if(m_OutputStyle == SingleFile)
   {
     if(m_OutputFilePath.isEmpty())
     {
@@ -373,11 +368,11 @@ void WriteASCIIData::execute()
     return;
   }
 
-  if(m_OutputType == ::k_MultiFile)
+  if(m_OutputStyle == MultiFile)
   {
     writeMultiFileOutput();
   }
-  else if(m_OutputType == ::k_SingleFile)
+  else if(m_OutputStyle == SingleFile)
   {
     writeSingleFileOutput();
   }

--- a/Source/SIMPLib/CoreFilters/WriteASCIIData.h
+++ b/Source/SIMPLib/CoreFilters/WriteASCIIData.h
@@ -49,9 +49,11 @@ class SIMPLib_EXPORT WriteASCIIData : public AbstractFilter
     PYB11_CREATE_BINDINGS(WriteASCIIData SUPERCLASS AbstractFilter)
     PYB11_PROPERTY(QVector<DataArrayPath> SelectedDataArrayPaths READ getSelectedDataArrayPaths WRITE setSelectedDataArrayPaths)
     PYB11_PROPERTY(QString OutputPath READ getOutputPath WRITE setOutputPath)
+    PYB11_PROPERTY(QString OutputFilePath READ getOutputFilePath WRITE setOutputFilePath)
     PYB11_PROPERTY(int Delimiter READ getDelimiter WRITE setDelimiter)
     PYB11_PROPERTY(QString FileExtension READ getFileExtension WRITE setFileExtension)
     PYB11_PROPERTY(int MaxValPerLine READ getMaxValPerLine WRITE setMaxValPerLine)
+    PYB11_PROPERTY(int OutputType READ getOutputType WRITE setOutputType)
 
   public:
     SIMPL_SHARED_POINTERS(WriteASCIIData)
@@ -66,6 +68,9 @@ class SIMPLib_EXPORT WriteASCIIData : public AbstractFilter
     SIMPL_FILTER_PARAMETER(QString, OutputPath)
     Q_PROPERTY(QString OutputPath READ getOutputPath WRITE setOutputPath)
 
+    SIMPL_FILTER_PARAMETER(QString, OutputFilePath)
+    Q_PROPERTY(QString OutputFilePath READ getOutputFilePath WRITE setOutputFilePath)
+
     SIMPL_FILTER_PARAMETER(int, Delimiter)
     Q_PROPERTY(int Delimiter READ getDelimiter WRITE setDelimiter)
 
@@ -74,6 +79,9 @@ class SIMPLib_EXPORT WriteASCIIData : public AbstractFilter
 
     SIMPL_FILTER_PARAMETER(int, MaxValPerLine)
     Q_PROPERTY(int MaxValPerLine READ getMaxValPerLine WRITE setMaxValPerLine)
+
+    SIMPL_FILTER_PARAMETER(int, OutputType)
+    Q_PROPERTY(int OutputType READ getOutputType WRITE setOutputType)
 
     enum DelimiterType
     {
@@ -197,9 +205,22 @@ class SIMPLib_EXPORT WriteASCIIData : public AbstractFilter
      * @brief Specific function to write string arrays to a text file
      * @param inputData
      */
-    void writeStringArray(IDataArray::Pointer inputData, QString outputFile, char delimiter);
+    void writeStringArray(const IDataArray::Pointer& inputData, const QString& outputFile, char delimiter);
 
+    /**
+     * @brief m_SelectedWeakPtrVector
+     */
     QVector<IDataArray::WeakPointer> m_SelectedWeakPtrVector;
+
+    /**
+     * @brief writeMultifileOutput
+     */
+    void writeMultiFileOutput();
+
+    /**
+     * @brief writeSingleFileOutput
+     */
+    void writeSingleFileOutput();
 
   public:
     WriteASCIIData(const WriteASCIIData&) = delete; // Copy Constructor Not Implemented

--- a/Source/SIMPLib/CoreFilters/WriteASCIIData.h
+++ b/Source/SIMPLib/CoreFilters/WriteASCIIData.h
@@ -53,7 +53,7 @@ class SIMPLib_EXPORT WriteASCIIData : public AbstractFilter
     PYB11_PROPERTY(int Delimiter READ getDelimiter WRITE setDelimiter)
     PYB11_PROPERTY(QString FileExtension READ getFileExtension WRITE setFileExtension)
     PYB11_PROPERTY(int MaxValPerLine READ getMaxValPerLine WRITE setMaxValPerLine)
-    PYB11_PROPERTY(int OutputType READ getOutputType WRITE setOutputType)
+    PYB11_PROPERTY(int OutputStyle READ getOutputStyle WRITE setOutputStyle)
 
   public:
     SIMPL_SHARED_POINTERS(WriteASCIIData)
@@ -80,8 +80,8 @@ class SIMPLib_EXPORT WriteASCIIData : public AbstractFilter
     SIMPL_FILTER_PARAMETER(int, MaxValPerLine)
     Q_PROPERTY(int MaxValPerLine READ getMaxValPerLine WRITE setMaxValPerLine)
 
-    SIMPL_FILTER_PARAMETER(int, OutputType)
-    Q_PROPERTY(int OutputType READ getOutputType WRITE setOutputType)
+    SIMPL_FILTER_PARAMETER(int, OutputStyle)
+    Q_PROPERTY(int OutputStyle READ getOutputStyle WRITE setOutputStyle)
 
     enum DelimiterType
     {
@@ -90,6 +90,12 @@ class SIMPLib_EXPORT WriteASCIIData : public AbstractFilter
       Space = 2,
       Colon = 3,
       Tab = 4
+    };
+
+    enum OutputType
+    {
+      MultiFile = 0,
+      SingleFile = 1
     };
 
     /**

--- a/Source/SIMPLib/Documentation/SIMPLibFilters/CoreFilters/WriteASCIIData.md
+++ b/Source/SIMPLib/Documentation/SIMPLibFilters/CoreFilters/WriteASCIIData.md
@@ -1,5 +1,4 @@
-Export ASCII Data 
-=============
+# Export ASCII Data #
 
 ## Group (Subgroup) ##
 
@@ -9,32 +8,34 @@ IO (Output)
 
 This **Filter** writes an array to a file as ASCII representations. The user may select the file extension and the maximum number of tuples printed per line. The user may also select the file delimiter from an enumerated list of values.  For example, if an array has only 1 component (a simple scalar array) and the user selects "1" for the _Maximum Tuples Per Line_ parameter then only a single vale will appear on each line. If the user selects an array that has 3 components (an array of 3D coordinates representing X, Y, Z locations in space) and the user selected 1 tuple per line, then the file will actually contain 3 values per line (the X, Y, Z values). If that same user selected 3 tuples per line then 9 values would be printed per line, and so on. More than one array to export may be selected at a time. All arrays may be selected or deselected at once with the _Select/Deselect All_ checkbox.  Each exported array is written as a separate file.  All file names will match the array name.
 
+The user may select to output a folder of files (MultiFile mode) or a single file that has all the data in column form.
+
 
 ### Example Output ###
 
-Phases.txt (one component) with 3 tuples/line, comma delimited:     
+Phases.txt (one component) with 3 tuples/line, comma delimited:
 
 	1,1,1
 	1,1,1
-	1,1,1  
 	1,1,1
-	   .. 
+	1,1,1
+	   ..
 
-EulerAngles.txt (three components) with 3 tuples/line, comma delimited:     
+EulerAngles.txt (three components) with 3 tuples/line, comma delimited:
 
 	0.785398,0,0.785398,0.785398,0,0.785398,0.785398,0,0.785398
 	0.785398,0,0.785398,0.785398,0,0.785398,0.785398,0,0.785398
-	0.785398,0,0.785398,0.785398,0,0.785398,0.785398,0,0.785398  
 	0.785398,0,0.785398,0.785398,0,0.785398,0.785398,0,0.785398
-	   .. 
+	0.785398,0,0.785398,0.785398,0,0.785398,0.785398,0,0.785398
+	   ..
 
-EulerAngles.txt (three components) with 1 tuple/line, space delimited:     
+EulerAngles.txt (three components) with 1 tuple/line, space delimited:
 
 	0.785398 0 0.785398
 	0.785398 0 0.785398
-	0.785398 0 0.785398  
 	0.785398 0 0.785398
-	   .. 
+	0.785398 0 0.785398
+	   ..
 
 ### Delimiter ###
 
@@ -49,11 +50,13 @@ Choice of delimiter is as follows:
 ## Parameters ##
 
 | Name             | Type | Description |
-|------------------|------|------------|
-| Output Path | File Path | The output file path |
-| File Extension | String | File extension for output file(s) |
+|------------------|------|---------_---|
+| Output Path      | File Path | The output file path |
+| File Extension   | String | File extension for output file(s) |
 | Maximum Tuples Per Line | int32_t | Number of tuples to print on each line |
-| Delimiter | Enumeration | The delimeter separating the data |
+| OutputType       | Int  | 0=MultiFile, 1=Single File |
+| OutputFilePath   | String | In Single File Mode, the complete path to the output file |
+| Delimiter        | Enumeration | The delimeter separating the data |
 
 ## Required Geometry ##
 
@@ -71,7 +74,7 @@ None
 
 ## Example Pipelines ##
 
-
+PrebuiltPipelines/Examples/INL Export
 
 ## License & Copyright ##
 

--- a/Source/SIMPLib/Documentation/SIMPLibFilters/CoreFilters/WriteASCIIData.md
+++ b/Source/SIMPLib/Documentation/SIMPLibFilters/CoreFilters/WriteASCIIData.md
@@ -50,7 +50,7 @@ Choice of delimiter is as follows:
 ## Parameters ##
 
 | Name             | Type | Description |
-|------------------|------|---------_---|
+|------------------|------|-------------|
 | Output Path      | File Path | The output file path |
 | File Extension   | String | File extension for output file(s) |
 | Maximum Tuples Per Line | int32_t | Number of tuples to print on each line |


### PR DESCRIPTION
Added the ability for the filter to write a single file with all the data arranged
in a column format. The original mode is called 'Multi File Export' and is the
default.
Documentation is updated.
Unit Test Updated.
DREAM.3D updated to use this filter in an Example Pipeline (INL Export).

Updates #309. Fixes #309

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>