### PR TITLE
Enhanced the error message returned when json parsing errors happen.

### DIFF
--- a/Source/SVWidgetsLib/Widgets/SVStyle.cpp
+++ b/Source/SVWidgetsLib/Widgets/SVStyle.cpp
@@ -753,7 +753,8 @@ QString SVStyle::WrapTextWithHtmlStyle(const QString& msg, bool bold) const
 {
   QString formattedMessage;
   QTextStream out(&formattedMessage);
-
+  QString msg2 = msg;
+  msg2 = msg2.replace("\n", "<br>");
   if(bold)
   {
     out << "<b ";
@@ -762,7 +763,7 @@ QString SVStyle::WrapTextWithHtmlStyle(const QString& msg, bool bold) const
     out << "<span ";
   }
   out << "style=\"color: " << getQLabel_color().name(QColor::HexRgb) << ";\">";
-  out << msg;
+  out << msg2;
   if(bold)
   {
     out << " </b>";


### PR DESCRIPTION
Added more text to the error message based on Qt5's message.
Adjusted the SVStyle to replace newline characters with <br> when creating HTML
wrapped messages.
Return early in SVPipelineView when trying to read a pipeline file that fails.

updates #308. fixes #308.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>