### PR TITLE
Implement proper DataArrayPath checking during preflight.

### DIFF
--- a/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.cpp
+++ b/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.cpp
@@ -323,19 +323,33 @@ void ImportHDF5Dataset::dataCheck()
       return;
     }
 
-    IDataArray::Pointer dPtr = readIDataArray(parentId, objectName, am->getNumberOfTuples(), cDims, getInPreflight());
-    if(nullptr != dPtr)
+    if(am->doesAttributeArrayExist(objectName))
     {
-      am->addAttributeArray(dPtr->getName(), dPtr);
+      setErrorCondition(-20010);
+      ss.clear();
+
+      DataArrayPath dap = getSelectedAttributeMatrix();
+      dap.setDataArrayName(objectName);
+
+      stream << tr("The selected dataset '") << dap.serialize("/") << tr("' already exists.");
+      notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
     }
     else
     {
-      setErrorCondition(-20009);
-      ss.clear();
-      stream << tr("The selected datatset is not a supported type for importing. Please select a different data set");
-      notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
+      IDataArray::Pointer dPtr = readIDataArray(parentId, objectName, am->getNumberOfTuples(), cDims, getInPreflight());
+      if(nullptr != dPtr)
+      {
+        am->addAttributeArray(dPtr->getName(), dPtr);
+      }
+      else
+      {
+        setErrorCondition(-20009);
+        ss.clear();
+        stream << tr("The selected datatset is not a supported type for importing. Please select a different data set");
+        notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
+      }
     }
-  } // End Switch statement
+  } // End For Loop over dataset imoprt info list
 
   // The sentinel will close the HDF5 File and any groups that were open.
 }

--- a/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/AbstractIOFileWidget.cpp
@@ -41,6 +41,7 @@
 
 #include <QtGui/QPainter>
 #include <QtGui/QKeyEvent>
+
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QMenu>
 
@@ -241,9 +242,8 @@ void AbstractIOFileWidget::on_m_LineEdit_editingFinished()
   {
     absPathLabel->hide();
   }
-  
-  SVStyle* style = SVStyle::Instance();
-  style->LineEditClearStyle(m_LineEdit);
+
+  verifyPathExists(path, m_LineEdit);
   m_CurrentText = m_LineEdit->text();
   emit parametersChanged(); // This should force the preflight to run because we are emitting a signal
 }
@@ -301,7 +301,7 @@ void AbstractIOFileWidget::on_m_LineEdit_fileDropped(const QString& text)
   SIMPLDataPathValidator* validator = SIMPLDataPathValidator::Instance();
   QString inputPath = validator->convertToAbsolutePath(text);
 
-  setValue(text);
+  m_LineEdit->setText(text);
   // Set/Remove the red outline if the file does exist
   verifyPathExists(inputPath, m_LineEdit);
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.h
@@ -50,6 +50,9 @@ class IH5DataWindow;
 class QDockWidget;
 class ImportHDF5DatasetFilterParameter;
 class ImportHDF5Dataset;
+class QtSLineEdit;
+class QKeyEvent;
+class QAction;
 
 /**
  * @brief The ImportHDF5DatasetWidget class
@@ -65,10 +68,11 @@ public:
    * @brief getCurrentFile
    * @return
    */
-  QString getCurrentFile()
-  {
-    return m_CurrentOpenFile;
-  }
+  QString getCurrentFile() const;
+
+  Q_PROPERTY(QPixmap Icon READ getIcon WRITE setIcon)
+  void setIcon(const QPixmap& path);
+  QPixmap getIcon();
 
   /**
    * @brief verifyPathExists
@@ -76,7 +80,7 @@ public:
    * @param lineEdit
    * @return
    */
-  bool verifyPathExists(QString filePath, QtSFSDropLabel* lineEdit);
+  bool verifyPathExists(const QString& filePath, QtSLineEdit* lineEdit);
 
 public slots:
   void beforePreflight();
@@ -84,31 +88,36 @@ public slots:
   void filterNeedsInputParameters(AbstractFilter* filter);
 
   /**
-   * @brief on_value_fileDropped
-   * @param text
-   */
-  void on_value_fileDropped(const QString& text);
-
-  /**
    * @brief on_selectBtn_clicked
    */
   void on_selectBtn_clicked();
 
-  /**
-   * @brief on_showLocationBtn_clicked
-   */
-  void on_showLocationBtn_clicked();
+  void on_value_fileDropped(const QString& text);
+  void on_value_editingFinished();
+  void on_value_textChanged(const QString& text);
+  void on_value_returnPressed();
 
 protected:
   /**
-   * @brief Drag and drop implementation
+   * @brief
+   * @param event
    */
-  void dragEnterEvent(QDragEnterEvent*) override;
+  void keyPressEvent(QKeyEvent* event) override;
+
+  /**
+   * @brief setupMenuField
+   */
+  void setupMenuField();
 
   /**
    * @brief Drag and drop implementation
    */
-  void dropEvent(QDropEvent*) override;
+  void dragEnterEvent(QDragEnterEvent* dragEvent) override;
+
+  /**
+   * @brief Drag and drop implementation
+   */
+  void dropEvent(QDropEvent* dropEvent) override;
 
   /**
    * @brief Initializes some of the GUI elements with selections or other GUI related items
@@ -120,7 +129,7 @@ protected:
    * with values from the passed in hdf5 file
    * @param hdf5File
    */
-  bool initWithFile(QString hdf5File);
+  bool initWithFile(const QString& hdf5File);
 
   /**
   * @brief Returns the best guess at component dimensions for the given path.  This requires a valid AttributeMatrix, ImageGeometry, and HDF5 path
@@ -129,8 +138,32 @@ protected:
   */
   std::tuple<herr_t, QString> bestGuessCDims(const QString& path);
 
+  /**
+   * @brief setValue
+   * @param val
+   */
+  void setValue(const QString& val);
+
+  /**
+   * @brief getValue
+   * @return
+   */
+  QString getValue();
+
+  /**
+   * @brief setErrorText
+   * @param value
+   */
+  void setErrorText(const QString& value);
+
+  /**
+   * @brief getErrorText
+   * @return
+   */
+  QString getErrorText() const;
+
 protected slots:
-  void on_cDimsLE_valueChanged(QString text);
+  void on_cDimsLE_valueChanged(const QString& text);
 
 private slots:
   /**
@@ -147,22 +180,51 @@ private:
   hid_t m_FileId;
   QMap<QString, QString> m_ComponentDimsMap;
   QStringList m_CurrentPathsWithErrors;
-
   ImportHDF5Dataset* m_Filter = nullptr;
-
   ImportHDF5DatasetFilterParameter* m_FilterParameter = nullptr;
+  QPixmap m_Icon = QPixmap(QLatin1String(":/SIMPL/icons/images/caret-bottom.png"));
+  QAction* m_ShowFileAction = nullptr;
+  QString m_CurrentText = "";
 
   /**
    * @brief Updates the QGraphicsView based on the current Data Dimension and Data record values
    * @param path The path to the HDF data set
    */
-  void _updateViewFromHDFPath(std::string path);
+  void _updateViewFromHDFPath(const std::string& path);
 
+  /**
+   * @brief updateAttributeTable
+   * @param datasetPath
+   * @return
+   */
   herr_t updateAttributeTable(const QString& datasetPath);
+
+  /**
+   * @brief updateGeneralTable
+   * @param path
+   * @return
+   */
   herr_t updateGeneralTable(const QString& path);
+
+  /**
+   * @brief updateComponentDimensions
+   * @param datasetPath
+   * @return
+   */
   herr_t updateComponentDimensions(const QString& datasetPath);
+
+  /**
+   * @brief addRow
+   * @param table
+   * @param row
+   * @param key
+   * @param value
+   */
   void addRow(QTableWidget* table, int row, const QString& key, const QString& value);
 
+  /**
+   * @brief initializeHDF5Paths
+   */
   void initializeHDF5Paths();
 
   /**

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/ImportHDF5DatasetWidget.ui
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/ImportHDF5DatasetWidget.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>666</width>
-    <height>442</height>
+    <width>769</width>
+    <height>503</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0">
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0">
    <property name="leftMargin">
     <number>3</number>
    </property>
@@ -27,89 +27,51 @@
     <number>3</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="selectBtn">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="1" column="1" colspan="2">
+      <widget class="SVSmallLabel" name="absPathLabel">
+       <property name="font">
+        <font>
+         <italic>false</italic>
+        </font>
+       </property>
        <property name="text">
-        <string>Select ...</string>
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QtSFSDropLabel" name="value">
+     <item row="0" column="2">
+      <widget class="QPushButton" name="selectBtn">
+       <property name="text">
+        <string>Select...</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QtSLineEdit" name="value">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="mouseTracking">
-        <bool>true</bool>
-       </property>
-       <property name="acceptDrops">
-        <bool>true</bool>
-       </property>
-       <property name="styleSheet">
-        <string notr="true"/>
-       </property>
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="SVIconPushButton" name="showLocationBtn">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>24</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>24</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Click to show the file's location</string>
-       </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="humanLabel">
        <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../../../Resources/SIMPL.qrc">
-         <normaloff>:/SIMPL/icons/images/arrow_right_black.png</normaloff>:/SIMPL/icons/images/arrow_right_black.png</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>24</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="flat">
-        <bool>true</bool>
+        <string>Input File</string>
        </property>
       </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </item>
@@ -308,19 +270,16 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <widget class="QLabel" name="errorLabel">
+     <property name="text">
+      <string>Error:</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>SVIconPushButton</class>
-   <extends>QPushButton</extends>
-   <header location="global">SVControlWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QtSFSDropLabel</class>
-   <extends>QLabel</extends>
-   <header location="global">QtSFSDropLabel.h</header>
-  </customwidget>
   <customwidget>
    <class>SVTreeView</class>
    <extends>QTreeView</extends>
@@ -337,6 +296,16 @@
    <extends>QTabWidget</extends>
    <header location="global">SVControlWidgets.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QtSLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header location="global">QtSLineEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>SVSmallLabel</class>
+   <extends>QLabel</extends>
+   <header location="global">SVControlWidgets.h</header>
   </customwidget>
  </customwidgets>
  <resources>


### PR DESCRIPTION
The ImportHDF5DatasetWidget was also updated to be consistent with the features
of the AbstractIOWidget where we can drag-and-drop files, show absolute paths, and
reveal the file in the operating system's file navigation(macOS Find, Windows Explorer).

AbstractIOFileWidget also received a small update to fix a logic error when verifying
that a file exists.

updates #316

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>