### PR TITLE
Fix crash in RawBinaryReader when using large SkipHeaderBytes values

### DIFF
--- a/Source/SIMPLib/CoreFilters/RawBinaryReader.cpp
+++ b/Source/SIMPLib/CoreFilters/RawBinaryReader.cpp
@@ -99,7 +99,7 @@ int32_t SanityCheckFileSizeVersusAllocatedSize(size_t allocatedBytes, size_t fil
 template <typename T> int32_t readBinaryFile(RawBinaryReader* filter)
 {
 
-  DataArray<T>::Pointer p = filter->getDataContainerArray()->getPrereqIDataArrayFromPath<DataArray<T>, AbstractFilter>(filter, filter->getCreatedAttributeArrayPath());
+  typename DataArray<T>::Pointer p = filter->getDataContainerArray()->getPrereqIDataArrayFromPath<DataArray<T>, AbstractFilter>(filter, filter->getCreatedAttributeArrayPath());
   QString filename = filter->getInputFile();
   int64_t skipHeaderBytes = filter->getSkipHeaderBytes();
 

--- a/Source/SIMPLib/CoreFilters/RawBinaryReader.cpp
+++ b/Source/SIMPLib/CoreFilters/RawBinaryReader.cpp
@@ -59,7 +59,6 @@
 #define RBR_READ_EOF -1030
 #define RBR_NO_ERROR 0
 
-
 #ifdef CMP_WORDS_BIGENDIAN
 #define SWAP_ARRAY(array)                                                                                                                                                                              \
   if(filter->getEndian() == 0)                                                                                                                                                                                    \

--- a/Source/SIMPLib/CoreFilters/RawBinaryReader.h
+++ b/Source/SIMPLib/CoreFilters/RawBinaryReader.h
@@ -1,5 +1,5 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+* Copyright (c) 2009-2019 BlueQuartz Software, LLC
 *
 * Redistribution and use in source and binary forms, with or without modification,
 * are permitted provided that the following conditions are met:
@@ -30,6 +30,7 @@
 *    United States Air Force Prime Contract FA8650-07-D-5800
 *    United States Air Force Prime Contract FA8650-10-D-5210
 *    United States Prime Contract Navy N00173-07-C-2068
+*    United States Air Force Prime Contract FA8650-15-D-5231
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 

--- a/Source/SIMPLib/CoreFilters/RawBinaryReader.h
+++ b/Source/SIMPLib/CoreFilters/RawBinaryReader.h
@@ -50,7 +50,7 @@ class SIMPLib_EXPORT RawBinaryReader : public AbstractFilter
     PYB11_PROPERTY(SIMPL::NumericTypes::Type ScalarType READ getScalarType WRITE setScalarType)
     PYB11_PROPERTY(int Endian READ getEndian WRITE setEndian)
     PYB11_PROPERTY(int NumberOfComponents READ getNumberOfComponents WRITE setNumberOfComponents)
-    PYB11_PROPERTY(int SkipHeaderBytes READ getSkipHeaderBytes WRITE setSkipHeaderBytes)
+    PYB11_PROPERTY(uint64_t SkipHeaderBytes READ getSkipHeaderBytes WRITE setSkipHeaderBytes)
     PYB11_PROPERTY(QString InputFile READ getInputFile WRITE setInputFile)
 
   public:
@@ -72,8 +72,8 @@ class SIMPLib_EXPORT RawBinaryReader : public AbstractFilter
     SIMPL_FILTER_PARAMETER(int, NumberOfComponents)
     Q_PROPERTY(int NumberOfComponents READ getNumberOfComponents WRITE setNumberOfComponents)
 
-    SIMPL_FILTER_PARAMETER(int, SkipHeaderBytes)
-    Q_PROPERTY(int SkipHeaderBytes READ getSkipHeaderBytes WRITE setSkipHeaderBytes)
+    SIMPL_FILTER_PARAMETER(uint64_t, SkipHeaderBytes)
+    Q_PROPERTY(uint64_t SkipHeaderBytes READ getSkipHeaderBytes WRITE setSkipHeaderBytes)
 
     SIMPL_FILTER_PARAMETER(QString, InputFile)
     Q_PROPERTY(QString InputFile READ getInputFile WRITE setInputFile)

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RawBinaryReaderTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RawBinaryReaderTest.cpp
@@ -776,7 +776,7 @@ public:
   // testCase6: This tests when skipHeaderBytes equals the file size
   template <typename T, size_t N> void testCase6_Execute(const QString& name, SIMPL::NumericTypes::Type scalarType)
   {
-    int dataArraySize = 0;
+    int dataArraySize = 1000;
     int junkArraySize = k_ArraySize * N;
     int skipHeaderBytes = junkArraySize * sizeof(T);
     int err = 0;
@@ -885,8 +885,7 @@ public:
     DREAM3D_REGISTER_TEST(testCase3())
     DREAM3D_REGISTER_TEST(testCase4())
     DREAM3D_REGISTER_TEST(testCase5())
-// Broken when moving away from Boost
-// DREAM3D_REGISTER_TEST(testCase6())
+    DREAM3D_REGISTER_TEST(testCase6())
 
 #if REMOVE_TEST_FILES
     DREAM3D_REGISTER_TEST(RemoveTestFiles())

--- a/Source/SIMPLib/FilterParameters/SourceList.cmake
+++ b/Source/SIMPLib/FilterParameters/SourceList.cmake
@@ -76,6 +76,7 @@ set(SIMPLib_${SUBDIR_NAME}_HDRS
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/StringFilterParameter.h
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/ThirdOrderPolynomial.h
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/ThirdOrderPolynomialFilterParameter.h
+  ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/UInt64FilterParameter.h
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/UnknownFilterParameter.h
 )
 
@@ -137,6 +138,7 @@ set(SIMPLib_${SUBDIR_NAME}_SRCS
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/ShapeTypeSelectionFilterParameter.cpp
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/StringFilterParameter.cpp
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/ThirdOrderPolynomialFilterParameter.cpp
+  ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/UInt64FilterParameter.cpp
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/UnknownFilterParameter.cpp
 )
 

--- a/Source/SIMPLib/FilterParameters/UInt64FilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/UInt64FilterParameter.cpp
@@ -46,14 +46,14 @@ UInt64FilterParameter::~UInt64FilterParameter() = default;
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-UInt64FilterParameter::Pointer UInt64FilterParameter::New(const QString& humanLabel, const QString& propertyName, const uint64_t& defaultValue, Category category, SetterCallbackType setterCallback,
+UInt64FilterParameter::Pointer UInt64FilterParameter::New(const QString& humanLabel, const QString& propertyName, uint64_t defaultValue, Category category, SetterCallbackType setterCallback,
                                                           GetterCallbackType getterCallback, int groupIndex)
 {
 
   UInt64FilterParameter::Pointer ptr = UInt64FilterParameter::New();
   ptr->setHumanLabel(humanLabel);
   ptr->setPropertyName(propertyName);
-  ptr->setDefaultValue(defaultValue);
+  ptr->setDefaultValue(static_cast<quint64>(defaultValue));
   ptr->setCategory(category);
   ptr->setGroupIndex(groupIndex);
   ptr->setSetterCallback(setterCallback);

--- a/Source/SIMPLib/FilterParameters/UInt64FilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/UInt64FilterParameter.cpp
@@ -1,0 +1,100 @@
+/* ============================================================================
+* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-07-D-5800
+*    United States Air Force Prime Contract FA8650-10-D-5210
+*    United States Prime Contract Navy N00173-07-C-2068
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "UInt64FilterParameter.h"
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+UInt64FilterParameter::UInt64FilterParameter() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+UInt64FilterParameter::~UInt64FilterParameter() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+UInt64FilterParameter::Pointer UInt64FilterParameter::New(const QString& humanLabel, const QString& propertyName, const uint64_t& defaultValue, Category category, SetterCallbackType setterCallback,
+                                                          GetterCallbackType getterCallback, int groupIndex)
+{
+
+  UInt64FilterParameter::Pointer ptr = UInt64FilterParameter::New();
+  ptr->setHumanLabel(humanLabel);
+  ptr->setPropertyName(propertyName);
+  ptr->setDefaultValue(defaultValue);
+  ptr->setCategory(category);
+  ptr->setGroupIndex(groupIndex);
+  ptr->setSetterCallback(setterCallback);
+  ptr->setGetterCallback(getterCallback);
+
+  return ptr;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString UInt64FilterParameter::getWidgetType() const
+{
+  return QString("UInt64Widget");
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void UInt64FilterParameter::readJson(const QJsonObject& json)
+{
+  QJsonValue jsonValue = json[getPropertyName()];
+  if(!jsonValue.isUndefined() && m_SetterCallback)
+  {
+    bool ok = false;
+    QString strvalue = jsonValue.toString();
+    m_SetterCallback(strvalue.toULongLong(&ok));
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void UInt64FilterParameter::writeJson(QJsonObject& json)
+{
+  if(m_GetterCallback)
+  {
+    uint64_t value = m_GetterCallback();
+    QString strvalue = QString::number(value);
+    json[getPropertyName()] = strvalue; // Store the value as a string so we maintain all the fidelity of the value
+  }
+}

--- a/Source/SIMPLib/FilterParameters/UInt64FilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/UInt64FilterParameter.cpp
@@ -1,5 +1,5 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+* Copyright (c) 2019-2019 BlueQuartz Software, LLC
 *
 * Redistribution and use in source and binary forms, with or without modification,
 * are permitted provided that the following conditions are met:
@@ -27,9 +27,7 @@
 * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *
 * The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
+*    United States Air Force Prime Contract FA8650-15-D-5231
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 

--- a/Source/SIMPLib/FilterParameters/UInt64FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/UInt64FilterParameter.h
@@ -1,0 +1,139 @@
+/* ============================================================================
+ * Copyright (c) 2019-2019 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <QtCore/QJsonObject>
+
+#include "SIMPLib/FilterParameters/FilterParameter.h"
+
+/**
+ * @brief SIMPL_NEW_INTEGER_FP This macro is a short-form way of instantiating an instance of
+ * UInt64FilterParameter. There are 4 required parameters and 1 optional parameter
+ * that are always passed to this macro in the following order: HumanLabel, PropertyName, Category,
+ * FilterName (class name), GroupIndex (optional).
+ *
+ * Therefore, the macro should be written like this (this is a concrete example):
+ * SIMPL_NEW_INTEGER_FP("HumanLabel", PropertyName, Category, FilterName, GroupIndex)
+ *
+ * Example 1 (instantiated within a filter called [GenericExample](@ref genericexample), with optional GroupIndex parameter):
+ * SIMPL_NEW_INTEGER_FP("Max Iterations", MaxIterations, FilterParameter::Parameter, GenericExample, 0);
+ */
+#define SIMPL_NEW_UINT64_FP(...) \
+  SIMPL_EXPAND(_FP_GET_OVERRIDE(__VA_ARGS__, \
+  SIMPL_NEW_FP_9, SIMPL_NEW_FP_8, SIMPL_NEW_FP_7, SIMPL_NEW_FP_6, SIMPL_NEW_FP_5, SIMPL_NEW_FP_4)\
+  (UInt64FilterParameter, __VA_ARGS__))
+
+/**
+ * @brief The UInt64FilterParameter class is used by filters to instantiate an IntWidget.  By instantiating an instance of
+ * this class in a filter's setupFilterParameters() method, an IntWidget will appear in the filter's "filter input" section in the DREAM3D GUI.
+ */
+class SIMPLib_EXPORT UInt64FilterParameter : public FilterParameter
+{
+  public:
+    SIMPL_SHARED_POINTERS(UInt64FilterParameter)
+    SIMPL_STATIC_NEW_MACRO(UInt64FilterParameter)
+    SIMPL_TYPE_MACRO_SUPER_OVERRIDE(UInt64FilterParameter, FilterParameter)
+
+    using SetterCallbackType = std::function<void(uint64_t)>;
+    using GetterCallbackType = std::function<uint64_t(void)>;
+
+    /**
+     * @brief New This function instantiates an instance of the UInt64FilterParameter. Although this function is available to be used,
+     * the preferable way to instantiate an instance of this class is to use the SIMPL_NEW_INTEGER_FP(...) macro at the top of this file.
+
+     * @param humanLabel The name that the users of DREAM.3D see for this filter parameter
+     * @param propertyName The internal property name for this filter parameter.
+     * @param defaultValue The value that this filter parameter will be initialized to by default.
+     * @param category The category for the filter parameter in the DREAM.3D user interface.  There
+     * are three categories: Parameter, Required Arrays, and Created Arrays.
+     * @param setterCallback The method in the AbstractFilter subclass that <i>sets</i> the value of the property
+    * that this FilterParameter subclass represents.
+     * @param getterCallback The method in the AbstractFilter subclass that <i>gets</i> the value of the property
+    * that this FilterParameter subclass represents.
+     * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
+     * @return
+     */
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const uint64_t& defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                       int groupIndex = -1);
+
+    ~UInt64FilterParameter() override;
+
+    /**
+   * @brief getWidgetType Returns the type of widget that displays and controls
+   * this FilterParameter subclass
+   * @return
+   */
+    QString getWidgetType() const override;
+
+    /**
+     * @brief readJson Reads this filter parameter's corresponding property out of a QJsonObject.
+     * @param json The QJsonObject that the filter parameter reads from.
+     */
+    void readJson(const QJsonObject& json) override;
+
+    /**
+     * @brief writeJson Writes this filter parameter's corresponding property to a QJsonObject.
+     * @param json The QJsonObject that the filter parameter writes to.
+     */
+    void writeJson(QJsonObject& json) override;
+
+    /**
+    * @param SetterCallback The method in the AbstractFilter subclass that <i>sets</i> the value of the property
+    * that this FilterParameter subclass represents.
+    * from the filter parameter.
+    */
+    SIMPL_INSTANCE_PROPERTY(SetterCallbackType, SetterCallback)
+
+    /**
+    * @param GetterCallback The method in the AbstractFilter subclass that <i>gets</i> the value of the property
+    * that this FilterParameter subclass represents.
+    * @return The GetterCallback
+    */
+    SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
+
+
+    protected:
+      /**
+       * @brief UInt64FilterParameter The default constructor.  It is protected because this
+       * filter parameter should only be instantiated using its New(...) function or short-form macro.
+       */
+      UInt64FilterParameter();
+
+    public:
+      UInt64FilterParameter(const UInt64FilterParameter&) = delete;            // Copy Constructor Not Implemented
+      UInt64FilterParameter(UInt64FilterParameter&&) = delete;                 // Move Constructor Not Implemented
+      UInt64FilterParameter& operator=(const UInt64FilterParameter&) = delete; // Copy Assignment Not Implemented
+      UInt64FilterParameter& operator=(UInt64FilterParameter&&) = delete;      // Move Assignment Not Implemented
+};
+

--- a/Source/SIMPLib/FilterParameters/UInt64FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/UInt64FilterParameter.h
@@ -84,7 +84,7 @@ class SIMPLib_EXPORT UInt64FilterParameter : public FilterParameter
      * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
      * @return
      */
-    static Pointer New(const QString& humanLabel, const QString& propertyName, const uint64_t& defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+    static Pointer New(const QString& humanLabel, const QString& propertyName, uint64_t defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
                        int groupIndex = -1);
 
     ~UInt64FilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/UInt64FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/UInt64FilterParameter.h
@@ -27,7 +27,7 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * The code contained herein was partially funded by the followig contracts:
- *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-15-D-5231
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/SourceList.cmake
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/SourceList.cmake
@@ -43,6 +43,7 @@ set(SIMPLView_PARAMETER_WIDGETS
     SeparatorWidget
     StringWidget
     ThirdOrderPolynomialWidget
+    UInt64Widget
 )
 
 set(SIMPLView_PARAMETER_WIDGETS_NO_UI

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/UInt64Widget.ui
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/UInt64Widget.ui
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UInt64Widget</class>
+ <widget class="QWidget" name="UInt64Widget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>566</width>
+    <height>28</height>
+   </rect>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Property</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="SVLineEdit" name="value">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>24</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="errorLabel">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SVLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header location="global">SVControlWidgets.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UInt64Widget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UInt64Widget.cpp
@@ -1,0 +1,156 @@
+/* ============================================================================
+* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-07-D-5800
+*    United States Air Force Prime Contract FA8650-10-D-5210
+*    United States Prime Contract Navy N00173-07-C-2068
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "UInt64Widget.h"
+
+#include <QtCore/QMetaProperty>
+
+#include "SIMPLib/FilterParameters/UInt64FilterParameter.h"
+
+#include "SVWidgetsLib/Core/SVWidgetsLibConstants.h"
+#include "SVWidgetsLib/Widgets/SVStyle.h"
+
+#include "FilterParameterWidgetsDialogs.h"
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+UInt64Widget::UInt64Widget(FilterParameter* parameter, AbstractFilter* filter, QWidget* parent)
+: FilterParameterWidget(parameter, filter, parent)
+{
+  m_FilterParameter = dynamic_cast<UInt64FilterParameter*>(parameter);
+  Q_ASSERT_X(m_FilterParameter != nullptr, "NULL Pointer", "UInt64Widget can ONLY be used with a UInt64FilterParameter object");
+
+  setupUi(this);
+  setupGui();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+UInt64Widget::~UInt64Widget() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void UInt64Widget::setupGui()
+{
+  // Catch when the filter is about to execute the preflight
+  connect(getFilter(), SIGNAL(preflightAboutToExecute()), this, SLOT(beforePreflight()));
+
+  // Catch when the filter is finished running the preflight
+  connect(getFilter(), SIGNAL(preflightExecuted()), this, SLOT(afterPreflight()));
+
+  // Catch when the filter wants its values updated
+  connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
+
+  connect(value, SIGNAL(textChanged(const QString&)), this, SLOT(widgetChanged(const QString&)));
+
+  QIntValidator* xVal = new QIntValidator(value);
+  value->setValidator(xVal);
+
+  if(getFilterParameter() != nullptr)
+  {
+    label->setText(getFilterParameter()->getHumanLabel());
+
+    QString str = getFilter()->property(PROPERTY_NAME_AS_CHAR).toString();
+    value->setText(str);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void UInt64Widget::widgetChanged(const QString& text)
+{
+  emit parametersChanged();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void UInt64Widget::filterNeedsInputParameters(AbstractFilter* filter)
+{
+  bool ok = true;
+  int defValue = getFilterParameter()->getDefaultValue().toInt();
+  uint64_t i = defValue;
+
+  // Next make sure there is something in the
+  if(!value->text().isEmpty())
+  {
+    i = value->text().toULongLong(&ok);
+    //  make sure we can convert the entered value to a 32 bit signed int
+    if(!ok)
+    {
+      SVStyle::Instance()->LineEditBackgroundErrorStyle(value);
+      SVStyle::Instance()->SetErrorColor("QLabel", errorLabel);
+      errorLabel->setText("Value entered is beyond the representable range for a 64 bit integer. The filter will use the default value of " + getFilterParameter()->getDefaultValue().toString());
+      errorLabel->show();
+      i = defValue;
+    }
+    else
+    {
+      errorLabel->hide();
+      SVStyle::Instance()->LineEditClearStyle(value);
+    }
+  }
+  else
+  {
+    SVStyle::Instance()->LineEditBackgroundErrorStyle(value);
+    SVStyle::Instance()->SetErrorColor("QLabel", errorLabel);
+    errorLabel->setText("No value entered. Filter will use default value of " + getFilterParameter()->getDefaultValue().toString());
+    errorLabel->show();
+  }
+
+  UInt64FilterParameter::SetterCallbackType setter = m_FilterParameter->getSetterCallback();
+  if(setter)
+  {
+    setter(i);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void UInt64Widget::beforePreflight()
+{
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void UInt64Widget::afterPreflight()
+{
+}

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UInt64Widget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UInt64Widget.cpp
@@ -1,5 +1,5 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+* Copyright (c) 2019-2019 BlueQuartz Software, LLC
 *
 * Redistribution and use in source and binary forms, with or without modification,
 * are permitted provided that the following conditions are met:
@@ -27,9 +27,7 @@
 * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *
 * The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
+*    United States Air Force Prime Contract FA8650-15-D-5231
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UInt64Widget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UInt64Widget.h
@@ -1,5 +1,5 @@
 /* ============================================================================
-* Copyright (c) 2019 BlueQuartz Software, LLC
+* Copyright (c) 2019-2019 BlueQuartz Software, LLC
 *
 * Redistribution and use in source and binary forms, with or without modification,
 * are permitted provided that the following conditions are met:
@@ -27,7 +27,7 @@
 * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *
 * The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
+*    United States Air Force Prime Contract FA8650-15-D-5231
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UInt64Widget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UInt64Widget.h
@@ -1,0 +1,95 @@
+/* ============================================================================
+* Copyright (c) 2019 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-07-D-5800
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+
+#include <QtCore/QObject>
+#include <QtCore/QPointer>
+#include <QtWidgets/QWidget>
+
+#include "SVWidgetsLib/QtSupport/QtSFaderWidget.h"
+
+#include "SIMPLib/Filtering/AbstractFilter.h"
+
+#include "SVWidgetsLib/SVWidgetsLib.h"
+#include "SVWidgetsLib/FilterParameterWidgets/FilterParameterWidget.h"
+
+#include "SVWidgetsLib/ui_UInt64Widget.h"
+
+class QLineEdit;
+class UInt64FilterParameter;
+
+/**
+* @brief
+* @author
+* @version
+*/
+class SVWidgetsLib_EXPORT UInt64Widget : public FilterParameterWidget, private Ui::UInt64Widget
+{
+    Q_OBJECT
+
+  public:
+    /**
+    * @brief Constructor
+    * @param parameter The FilterParameter object that this widget represents
+    * @param filter The instance of the filter that this parameter is a part of
+    * @param parent The parent QWidget for this Widget
+    */
+    UInt64Widget(FilterParameter* parameter, AbstractFilter* filter = nullptr, QWidget* parent = nullptr);
+
+    ~UInt64Widget() override;
+
+    /**
+    * @brief This method does additional GUI widget connections
+    */
+    void setupGui() override;
+
+  public slots:
+    void widgetChanged(const QString& msg);
+    void beforePreflight();
+    void afterPreflight();
+    void filterNeedsInputParameters(AbstractFilter* filter);
+
+  private:
+    UInt64FilterParameter* m_FilterParameter;
+
+  public:
+    UInt64Widget(const UInt64Widget&) = delete;      // Copy Constructor Not Implemented
+    UInt64Widget(UInt64Widget&&) = delete;           // Move Constructor Not Implemented
+    UInt64Widget& operator=(const UInt64Widget&) = delete; // Copy Assignment Not Implemented
+    UInt64Widget& operator=(UInt64Widget&&) = delete;      // Move Assignment Not Implemented
+};
+
+
+


### PR DESCRIPTION
The issue appeared because the assumption was that the amount of data eventually
read would be larger than the number of header bytes to skip. Implemented a UInt64
filter parameter and matching widget. This new filter parameter is used for the
RawBinaryReader so that the use can have offsets larger than 2GB (2^31). The original
value was stored in an int32_t which would eventually be inadequate.

#fixes #329. closes #329. updates #329

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>