### PR TITLE
Fixed SVPipelineView execution lock on error

### DIFF
--- a/Source/SIMPLib/Filtering/FilterPipeline.cpp
+++ b/Source/SIMPLib/Filtering/FilterPipeline.cpp
@@ -859,6 +859,7 @@ DataContainerArray::Pointer FilterPipeline::execute()
         emit pipelineFinished();
         disconnectSignalsSlots();
         m_State = FilterPipeline::State::Idle;
+        m_ExecutionResult = FilterPipeline::ExecutionResult::Failed;
         return m_Dca;
       }
     }

--- a/Source/SIMPLib/Filtering/FilterPipeline.h
+++ b/Source/SIMPLib/Filtering/FilterPipeline.h
@@ -96,7 +96,8 @@ public:
   {
     Invalid,
     Completed,
-    Canceled
+    Canceled,
+    Failed
   };
 
   typedef QList<AbstractFilter::Pointer> FilterContainerType;

--- a/Source/SVWidgetsLib/Widgets/SVPipelineView.cpp
+++ b/Source/SVWidgetsLib/Widgets/SVPipelineView.cpp
@@ -552,18 +552,19 @@ void SVPipelineView::cancelPipeline()
 // -----------------------------------------------------------------------------
 void SVPipelineView::finishPipeline()
 {
-  if(m_PipelineInFlight->getExecutionResult() == FilterPipeline::ExecutionResult::Canceled)
+  switch(m_PipelineInFlight->getExecutionResult())
   {
+  case FilterPipeline::ExecutionResult::Canceled:
     emit stdOutMessage(SVStyle::Instance()->WrapTextWithHtmlStyle("*************** PIPELINE CANCELED ***************", true));
-  }
-  else if (m_PipelineInFlight->getExecutionResult() == FilterPipeline::ExecutionResult::Completed)
-  {
+    break;
+  case FilterPipeline::ExecutionResult::Completed:
     emit stdOutMessage(SVStyle::Instance()->WrapTextWithHtmlStyle("*************** PIPELINE FINISHED ***************", true));
-  }
-  else
-  {
-    // We should never hit this
-    return;
+    break;
+  case FilterPipeline::ExecutionResult::Failed:
+    emit stdOutMessage(SVStyle::Instance()->WrapTextWithHtmlStyle("*************** PIPELINE FAILED ***************", true));
+    break;
+  case FilterPipeline::ExecutionResult::Invalid:
+    break;
   }
   emit stdOutMessage(SVStyle::Instance()->WrapTextWithHtmlStyle("", false));
 


### PR DESCRIPTION
* Fixed a bug where, if a FilterPipeline failed during execution, the pipeline view would be permanently locked in the Executing and Canceling states.  During this, filters cannot be added or reordered, and all filter input widgets are disabled.  The user can get to the Canceling state, but once there, cannot leave.
* Added Failed value to FilterPipeline::ExecutionResult enum.
* SVPipelineView now uses a switch statement instead of if else blocks to handle the pipeline's execution result.

Updates BlueQuartzSoftware/DREAM3D#893
Fixes BlueQuartzSoftware/DREAM3D#893