### PR TITLE
Reduce the creation of filters through factories when not needed.

### DIFF
--- a/Source/SIMPLib/Filtering/FilterFactory.hpp
+++ b/Source/SIMPLib/Filtering/FilterFactory.hpp
@@ -87,7 +87,12 @@ public:
   {
     return m_CompiledLibraryName;
   }
-  
+
+  QString getFilterHtmlSummary() const override
+  {
+    return m_HtmlSummary;
+  }
+
   QUuid getUuid() const override
   {
     return m_Uuid;
@@ -104,6 +109,7 @@ protected:
     m_BrandingString = w->getBrandingString();
     m_CompiledLibraryName = w->getCompiledLibraryName();
     m_Uuid = w->getUuid();
+    m_HtmlSummary = w->generateHtmlSummary();
   }
 
 private:
@@ -113,8 +119,12 @@ private:
   QString m_HumanName;
   QString m_BrandingString;
   QString m_CompiledLibraryName;
+  QString m_HtmlSummary;
   QUuid m_Uuid;
 
-  FilterFactory(const FilterFactory&);  // Copy Constructor Not Implemented
-  void operator=(const FilterFactory&); // Move assignment Not Implemented
+public:
+  FilterFactory(const FilterFactory&) = delete;            // Copy Constructor Not Implemented
+  FilterFactory(FilterFactory&&) = delete;                 // Move Constructor Not Implemented
+  FilterFactory& operator=(const FilterFactory&) = delete; // Copy Assignment Not Implemented
+  FilterFactory& operator=(FilterFactory&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/Filtering/IFilterFactory.hpp
+++ b/Source/SIMPLib/Filtering/IFilterFactory.hpp
@@ -121,10 +121,20 @@ public:
     Q_ASSERT(false);
     return "";
   }
-  
+
+  /**
+   * @brief getFilterHtmlSummary
+   * @return
+   */
+  virtual QString getFilterHtmlSummary() const
+  {
+    Q_ASSERT(false);
+    return "";
+  }
+
   /**
    * @brief getUuid
-   * @return 
+   * @return
    */
   virtual QUuid getUuid() const
   {
@@ -135,8 +145,10 @@ public:
 protected:
   IFilterFactory() = default;
 
-private:
-  IFilterFactory(const IFilterFactory&); // Copy Constructor Not Implemented
-  void operator=(const IFilterFactory&); // Move assignment Not Implemented
+public:
+  IFilterFactory(const IFilterFactory&) = delete;            // Copy Constructor Not Implemented
+  IFilterFactory(IFilterFactory&&) = delete;                 // Move Constructor Not Implemented
+  IFilterFactory& operator=(const IFilterFactory&) = delete; // Copy Assignment Not Implemented
+  IFilterFactory& operator=(IFilterFactory&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SVWidgetsLib/Widgets/FilterLibraryToolboxWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/FilterLibraryToolboxWidget.cpp
@@ -141,9 +141,8 @@ void FilterLibraryToolboxWidget::refreshFilterGroups()
       {
         iter.next();
         IFilterFactory::Pointer factory = iter.value();
-        AbstractFilter::Pointer filter = factory->create();
         QTreeWidgetItem* filterTreeItem = new QTreeWidgetItem(filterSubGroup);
-        filterTreeItem->setText(0, filter->getHumanLabel());
+        filterTreeItem->setText(0, factory->getFilterHumanLabel());
 
 #if 0
         if(groupName.compare(SIMPL::FilterGroups::Unsupported) == 0)
@@ -170,8 +169,8 @@ void FilterLibraryToolboxWidget::refreshFilterGroups()
         filterTreeItem->setIcon(0, icon);
 #endif
         filterTreeItem->setData(0, Qt::UserRole, QVariant(FILTER_NODE_TYPE));
-        filterTreeItem->setData(0, Qt::UserRole + 1, QVariant(filter->getNameOfClass()));
-        filterTreeItem->setToolTip(0, filter->generateHtmlSummary());
+        filterTreeItem->setData(0, Qt::UserRole + 1, QVariant(factory->getFilterClassName()));
+        filterTreeItem->setToolTip(0, factory->getFilterHtmlSummary());
       }
     }
   }

--- a/Source/SVWidgetsLib/Widgets/FilterListToolboxWidget.h
+++ b/Source/SVWidgetsLib/Widgets/FilterListToolboxWidget.h
@@ -44,8 +44,9 @@
 #include <QtGui/QKeyEvent>
 
 #include "SIMPLib/Filtering/FilterManager.h"
-#include "SVWidgetsLib/SVWidgetsLib.h"
+#include "SIMPLib/Filtering/IFilterFactory.hpp"
 
+#include "SVWidgetsLib/SVWidgetsLib.h"
 #include "SVWidgetsLib/QtSupport/QtSSettings.h"
 
 #include "ui_FilterListToolboxWidget.h"
@@ -132,13 +133,13 @@ class SVWidgetsLib_EXPORT FilterListToolboxWidget : public QWidget, private Ui::
 
     FilterManager::Collection  m_LoadedFilters;
 
-    QMap<QString, AbstractFilter::Pointer> getHumanNameMap(QList<AbstractFilter::Pointer> list);
+    QMap<QString, IFilterFactory::Pointer> getHumanNameMap(const QList<IFilterFactory::Pointer>& list);
 
-    void matchFiltersToSearchGroup(std::vector<AbstractFilter::Pointer> filters, QSet<AbstractFilter*> &addedFiltersSet, QStringList searchTokens, FilterListView::SearchGroup searchGroup);
+    void matchFiltersToSearchGroup(std::vector<IFilterFactory::Pointer> filters, QSet<IFilterFactory*>& addedFiltersSet, const QStringList& searchTokens, FilterListView::SearchGroup searchGroup);
 
-    int getMatchingWordCountForFilter(QStringList searchTokens, AbstractFilter::Pointer filter, FilterListView::SearchGroup searchGroup);
+    int getMatchingWordCountForFilter(QStringList searchTokens, IFilterFactory::Pointer filter, FilterListView::SearchGroup searchGroup);
 
-    int getMatchingRelevanceForFilter(QStringList searchTokens, AbstractFilter::Pointer filter, FilterListView::SearchGroup searchGroup);
+    int getMatchingRelevanceForFilter(QStringList searchTokens, IFilterFactory::Pointer filter, FilterListView::SearchGroup searchGroup);
 
   public:
     FilterListToolboxWidget(const FilterListToolboxWidget&) = delete; // Copy Constructor Not Implemented

--- a/Source/SVWidgetsLib/Widgets/FilterListView.cpp
+++ b/Source/SVWidgetsLib/Widgets/FilterListView.cpp
@@ -93,15 +93,15 @@ void FilterListView::connectSignalsSlots()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void FilterListView::addFilter(AbstractFilter::Pointer filter)
+void FilterListView::addFilter(const IFilterFactory::Pointer& factory)
 {
-  addFilter(filter, QModelIndex());
+  addFilter(factory, QModelIndex());
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void FilterListView::addFilter(AbstractFilter::Pointer filter, SearchGroup group)
+void FilterListView::addFilter(const IFilterFactory::Pointer& factory, SearchGroup group)
 {
   if(!m_SearchGroupIndexMap.contains(group))
   {
@@ -109,19 +109,19 @@ void FilterListView::addFilter(AbstractFilter::Pointer filter, SearchGroup group
   }
 
   QModelIndex groupIndex = m_SearchGroupIndexMap[group];
-  addFilter(filter, groupIndex);
+  addFilter(factory, groupIndex);
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void FilterListView::addFilter(AbstractFilter::Pointer filter, const QModelIndex &parent)
+void FilterListView::addFilter(const IFilterFactory::Pointer& factory, const QModelIndex& parent)
 {
-  QString humanName = filter->getHumanLabel();
+  QString humanName = factory->getFilterHumanLabel();
   QString iconName(":/Groups/");
-  iconName.append(filter->getGroupName());
+  iconName.append(factory->getFilterGroup());
 
-  QIcon icon = SVStyle::Instance()->IconForGroup(filter->getGroupName());
+  QIcon icon = SVStyle::Instance()->IconForGroup(factory->getFilterGroup());
 
   // Create the QListWidgetItem and add it to the filterListView
   FilterListModel* model = getFilterListModel();
@@ -137,10 +137,10 @@ void FilterListView::addFilter(AbstractFilter::Pointer filter, const QModelIndex
   // Set an "internal" QString that is the name of the filter. We need this value
   // when the item is clicked in order to retreive the Filter Widget from the
   // filter widget manager.
-  model->setData(index, filter->getNameOfClass(), FilterListModel::Roles::ClassNameRole);
+  model->setData(index, factory->getFilterClassName(), FilterListModel::Roles::ClassNameRole);
 
   // Allow a basic mouse hover tool tip that gives some summary information on the filter.
-  model->setData(index, filter->generateHtmlSummary(), Qt::ToolTipRole);
+  model->setData(index, factory->getFilterHtmlSummary(), Qt::ToolTipRole);
 }
 
 // -----------------------------------------------------------------------------
@@ -213,7 +213,7 @@ QModelIndex FilterListView::findIndexByName(const QString &name)
     }
   }
 
-  return QModelIndex();
+  return {};
 }
 
 // -----------------------------------------------------------------------------
@@ -327,9 +327,9 @@ QModelIndex FilterListView::findNextSelectableIndex()
       return selectedIndexes[0];
   }
 
-    return model->index(selectedIndexes[0].row() + 1, FilterListModel::Column::Contents, parent);
+  return model->index(selectedIndexes[0].row() + 1, FilterListModel::Column::Contents, parent);
 
-  return QModelIndex();
+  return {};
 }
 
 // -----------------------------------------------------------------------------
@@ -365,7 +365,7 @@ QModelIndex FilterListView::findPreviousSelectableIndex()
     return model->index(selectedIndexes[0].row() - 1, FilterListModel::Column::Contents, parent);
   }
 
-  return QModelIndex();
+  return {};
 }
 
 // -----------------------------------------------------------------------------
@@ -386,7 +386,7 @@ void FilterListView::mousePressEvent(QMouseEvent* event)
 // -----------------------------------------------------------------------------
 void FilterListView::mouseMoveEvent(QMouseEvent* event)
 {
-  if(event->buttons() & Qt::LeftButton)
+  if((event->buttons() & Qt::LeftButton) != 0)
   {
     int distance = (event->pos() - m_StartPos).manhattanLength();
     if(distance >= QApplication::startDragDistance())

--- a/Source/SVWidgetsLib/Widgets/FilterListView.h
+++ b/Source/SVWidgetsLib/Widgets/FilterListView.h
@@ -40,7 +40,7 @@
 #include <QtWidgets/QTreeView>
 
 #include "SIMPLib/Filtering/AbstractFilter.h"
-
+#include "SIMPLib/Filtering/IFilterFactory.hpp"
 #include "SVWidgetsLib/SVWidgetsLib.h"
 
 class FilterListModel;
@@ -78,14 +78,14 @@ class SVWidgetsLib_EXPORT FilterListView : public QTreeView
      * @brief addFilter
      * @param filter
      */
-    void addFilter(AbstractFilter::Pointer filter);
+    void addFilter(const IFilterFactory::Pointer& factory);
 
     /**
      * @brief addFilter
      * @param filter
      * @param group
      */
-    void addFilter(AbstractFilter::Pointer filter, SearchGroup group);
+    void addFilter(const IFilterFactory::Pointer& factory, SearchGroup group);
 
     /**
      * @brief addGroup
@@ -150,7 +150,7 @@ class SVWidgetsLib_EXPORT FilterListView : public QTreeView
      * @param filter
      * @param parent
      */
-    void addFilter(AbstractFilter::Pointer filter, const QModelIndex &parent);
+    void addFilter(const IFilterFactory::Pointer &factory, const QModelIndex &parent);
 
     /**
      * @brief connectSignalsSlots


### PR DESCRIPTION
When plugins are loaded, a FilterFactory<T> is created and stored for each filter that is in the plugin. If the developer only needs items such as human label, Html summary or other textual items then it is better and quicker to just use the FilterFactory itself instead of instantiating an entirely new Filter object. This leads to a speed up when launching currently.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>