### PR TITLE
WIP: Update IGeometryGrid API for set/get Dimension/Origin/Spacing

### DIFF
--- a/Source/SIMPLib/Common/SIMPLArray.hpp
+++ b/Source/SIMPLib/Common/SIMPLArray.hpp
@@ -187,15 +187,15 @@ public:
   /**
    * @brief Converts to another container type. The output type that is being used needs to have the "push_back()" method implemented.
    *
-   *   For STL containers this includes Vector, List, Deque. QVector and QList will also work.
+   *   For STL containers this includes Vector, Deque. QVector will also work.
    */
   template <typename OutContainerType>
   OutContainerType toContainer()
   {
-    OutContainerType dest;
-    for(const auto& value : m_Array)
+    OutContainerType dest(Dimension);
+    for(typename OutContainerType::size_type i = 0; i < Dimension; i++)
     {
-      dest.push_back(value);
+      dest[i] = m_Array[i];
     }
     return dest;
   }

--- a/Source/SIMPLib/Common/SIMPLArray.hpp
+++ b/Source/SIMPLib/Common/SIMPLArray.hpp
@@ -251,6 +251,24 @@ public:
   {
     return std::make_tuple(getX(), getY());
   }
+
+  template <typename OutType>
+  IVec2<OutType> convertType()
+  {
+    return IVec2<OutType>(static_cast<OutType>((*this)[0]), static_cast<OutType>((*this)[1]));
+  }
+
+  /**
+   * @brief Converts to a different container type such as std::vector or QVector. The container must have a constructor that takes a single value of size.
+   */
+  template <typename ContainerType>
+  ContainerType toContainer()
+  {
+    ContainerType c(2);
+    c[0] = (*this)[0];
+    c[1] = (*this)[1];
+    return c;
+  }
 };
 
 using FloatVec2Type = IVec2<float>;
@@ -258,7 +276,8 @@ using IntVec2Type = IVec2<int>;
 using SizeVec2Type = IVec2<size_t>;
 
 // -----------------------------------------------------------------------------
-template <typename T> class IVec3 : public SIMPLArray<T, 3>
+template <typename T>
+class IVec3 : public SIMPLArray<T, 3>
 {
   using ParentType = SIMPLArray<T, 3>;
 public:
@@ -337,11 +356,28 @@ public:
   {
     return std::make_tuple(getX(), getY(), getZ());
   }
-};
 
-using FloatVec3Type = IVec3<float>;
-using IntVec3Type = IVec3<int>;
-using SizeVec3Type = IVec3<size_t>;
+  /**
+   * @brief Converts to a new SIMPLArray with a different storage data type
+   */
+  template <typename OutType>
+  IVec3<OutType> convertType()
+  {
+    return IVec3<OutType>(static_cast<OutType>((*this)[0]), static_cast<OutType>((*this)[1]), static_cast<OutType>((*this)[2]));
+  }
+  /**
+   * @brief Converts to a different container type such as std::vector or QVector. The container must have a constructor that takes a single value of size.
+   */
+  template <typename ContainerType>
+  ContainerType toContainer()
+  {
+    ContainerType c(3);
+    c[0] = (*this)[0];
+    c[1] = (*this)[1];
+    c[2] = (*this)[2];
+    return c;
+  }
+};
 
 // -----------------------------------------------------------------------------
 template <typename T> class IVec4 : public SIMPLArray<T, 4>
@@ -432,9 +468,133 @@ public:
   {
     return std::make_tuple(getX(), getY(), getZ(), getW());
   }
+
+  /**
+   * @brief Converts this array into another array using a static_cast<OutType> mechanism
+   */
+  template <typename OutType>
+  IVec4<OutType> convertType()
+  {
+    return IVec4<OutType>(static_cast<OutType>((*this)[0]), static_cast<OutType>((*this)[1]), static_cast<OutType>((*this)[2]), static_cast<OutType>((*this)[3]));
+  }
+  /**
+   * @brief Converts to a different container type such as std::vector or QVector. The container must have a constructor that takes a single value of size.
+   */
+  template <typename ContainerType>
+  ContainerType toContainer()
+  {
+    ContainerType c(4);
+    c[0] = (*this)[0];
+    c[1] = (*this)[1];
+    c[2] = (*this)[2];
+    c[3] = (*this)[3];
+    return c;
+  }
 };
+
+// -----------------------------------------------------------------------------
+template <typename T>
+class IVec6 : public SIMPLArray<T, 6>
+{
+  using ParentType = SIMPLArray<T, 6>;
+
+public:
+  IVec6(const IVec6&) = default;
+  IVec6(IVec6&&) noexcept = default;
+  IVec6& operator=(const IVec6&) = default;
+  IVec6& operator=(IVec6&&) noexcept = default;
+  ~IVec6() = default;
+
+  /**
+   * @brief IVec6 Default constructor initializes all values to ZERO.
+   */
+  IVec6()
+  {
+    (*this)[0] = static_cast<T>(0);
+    (*this)[1] = static_cast<T>(0);
+    (*this)[2] = static_cast<T>(0);
+    (*this)[3] = static_cast<T>(0);
+    (*this)[4] = static_cast<T>(0);
+    (*this)[5] = static_cast<T>(0);
+  }
+
+  IVec6(T x, T y, T z, T a, T b, T c)
+  {
+    (*this)[0] = x;
+    (*this)[1] = y;
+    (*this)[2] = z;
+    (*this)[3] = a;
+    (*this)[4] = b;
+    (*this)[5] = c;
+  }
+
+  IVec6(std::array<T, 6> data)
+  {
+    (*this)[0] = data[0];
+    (*this)[1] = data[1];
+    (*this)[2] = data[2];
+    (*this)[3] = data[3];
+    (*this)[4] = data[4];
+    (*this)[5] = data[5];
+  }
+  IVec6(std::tuple<T, T> data)
+  {
+    (*this)[0] = std::get<0>(data);
+    (*this)[1] = std::get<1>(data);
+    (*this)[2] = std::get<2>(data);
+    (*this)[3] = std::get<3>(data);
+    (*this)[4] = std::get<4>(data);
+    (*this)[5] = std::get<5>(data);
+  }
+  IVec6(const T* data)
+  {
+    (*this)[0] = data[0];
+    (*this)[1] = data[1];
+    (*this)[2] = data[2];
+    (*this)[3] = data[3];
+    (*this)[4] = data[4];
+    (*this)[5] = data[5];
+  }
+
+  std::tuple<T, T> toTuple() const
+  {
+    return std::make_tuple((*this)[0], (*this)[1], (*this)[2], (*this)[3], (*this)[4], (*this)[5]);
+  }
+
+  /**
+   * @brief Converts this array into another array using a static_cast<OutType> mechanism
+   */
+  template <typename OutType>
+  IVec6<OutType> convertType()
+  {
+    return IVec6<OutType>(static_cast<OutType>((*this)[0]), static_cast<OutType>((*this)[1]), static_cast<OutType>((*this)[2]), static_cast<OutType>((*this)[3]), static_cast<OutType>((*this)[4]),
+                          static_cast<OutType>((*this)[5]));
+  }
+
+  /**
+   * @brief Converts to a different container type such as std::vector or QVector. The container must have a constructor that takes a single value of size.
+   */
+  template <typename ContainerType>
+  ContainerType toContainer()
+  {
+    ContainerType c(6);
+    c[0] = (*this)[0];
+    c[1] = (*this)[1];
+    c[2] = (*this)[2];
+    c[3] = (*this)[3];
+    c[4] = (*this)[4];
+    c[5] = (*this)[5];
+    return c;
+  }
+};
+
+using FloatVec3Type = IVec3<float>;
+using IntVec3Type = IVec3<int>;
+using SizeVec3Type = IVec3<size_t>;
 
 using QuaternionType = IVec4<float>;
 using FloatVec4Type = IVec4<float>;
 using IntVec4Type = IVec4<int>;
 using SizeVec4Type = IVec4<size_t>;
+
+using FloatVec6Type = IVec6<float>;

--- a/Source/SIMPLib/Common/SIMPLArray.hpp
+++ b/Source/SIMPLib/Common/SIMPLArray.hpp
@@ -54,6 +54,18 @@ public:
   SIMPLArray& operator=(SIMPLArray&&) noexcept = default;
   ~SIMPLArray() = default;
 
+  /**
+   * @brief Constructor using a random access container type as the input. This will copy the data
+   */
+  template <typename InType>
+  SIMPLArray(const InType& data)
+  {
+    for(size_t i = 0; i < Dimension; i++)
+    {
+      m_Array[i] = data[i];
+    }
+  }
+
   //========================================= STL INTERFACE COMPATIBILITY =================================
   using size_type = size_t;
   using value_type = T;
@@ -62,8 +74,8 @@ public:
   using iterator_category = std::input_iterator_tag;
   using pointer = T*;
   using difference_type = value_type;
-  using iterator = typename std::array<T, 3>::iterator;
-  using const_iterator = typename std::array<T, 3>::const_iterator;
+  using iterator = typename std::array<T, Dimension>::iterator;
+  using const_iterator = typename std::array<T, Dimension>::const_iterator;
   //========================================= END STL INTERFACE COMPATIBILITY ==============================
 
   /**
@@ -172,6 +184,22 @@ public:
     return m_Array == rhs.m_Array;
   }
 
+  /**
+   * @brief Converts to another container type. The output type that is being used needs to have the "push_back()" method implemented.
+   *
+   *   For STL containers this includes Vector, List, Deque. QVector and QList will also work.
+   */
+  template <typename OutContainerType>
+  OutContainerType toContainer()
+  {
+    OutContainerType dest;
+    for(const auto& value : m_Array)
+    {
+      dest.push_back(value);
+    }
+    return dest;
+  }
+
 protected:
   void setValue(size_t i, value_type value)
   {
@@ -203,24 +231,49 @@ public:
     (*this)[0] = static_cast<T>(0);
     (*this)[1] = static_cast<T>(0);
   }
-
+  /**
+   * @brief IVec2
+   * @param x
+   * @param y
+   */
   IVec2(T x, T y)
   {
     (*this)[0] = x;
     (*this)[1] = y;
   }
-
-  IVec2(std::array<T, 2> data)
+  /**
+   * @brief IVec2
+   * @param data
+   */
+  IVec2(const std::array<T, 2>& data)
   {
     (*this)[0] = data[0];
     (*this)[1] = data[1];
   }
-  IVec2(std::tuple<T, T> data)
+  /**
+   * @brief IVec2
+   * @param data
+   */
+  IVec2(const std::tuple<T, T>& data)
   {
     (*this)[0] = std::get<0>(data);
     (*this)[1] = std::get<1>(data);
   }
+  /**
+   * @brief IVec2
+   * @param data
+   */
   IVec2(const T* data)
+  {
+    (*this)[0] = data[0];
+    (*this)[1] = data[1];
+  }
+
+  /**
+   * @brief IVec2
+   * @param data
+   */
+  IVec2(const std::vector<T>& data)
   {
     (*this)[0] = data[0];
     (*this)[1] = data[1];
@@ -251,23 +304,13 @@ public:
   {
     return std::make_tuple(getX(), getY());
   }
-
+  /**
+   *
+   */
   template <typename OutType>
   IVec2<OutType> convertType()
   {
     return IVec2<OutType>(static_cast<OutType>((*this)[0]), static_cast<OutType>((*this)[1]));
-  }
-
-  /**
-   * @brief Converts to a different container type such as std::vector or QVector. The container must have a constructor that takes a single value of size.
-   */
-  template <typename ContainerType>
-  ContainerType toContainer()
-  {
-    ContainerType c(2);
-    c[0] = (*this)[0];
-    c[1] = (*this)[1];
-    return c;
   }
 };
 
@@ -296,27 +339,53 @@ public:
     (*this)[1] = static_cast<T>(0);
     (*this)[2] = static_cast<T>(0);
   }
-
+  /**
+   * @brief IVec3
+   * @param x
+   * @param y
+   * @param z
+   */
   IVec3(T x, T y, T z)
   {
     (*this)[0] = x;
     (*this)[1] = y;
     (*this)[2] = z;
   }
-
-  IVec3(std::array<T, 3> data)
+  /**
+   * @brief IVec3
+   * @param data
+   */
+  IVec3(const std::array<T, 3>& data)
   {
     (*this)[0] = data[0];
     (*this)[1] = data[1];
     (*this)[2] = data[2];
   }
-  IVec3(std::tuple<T, T, T> data)
+  /**
+   * @brief IVec3
+   * @param data
+   */
+  IVec3(const std::tuple<T, T, T>& data)
   {
     (*this)[0] = std::get<0>(data);
     (*this)[1] = std::get<1>(data);
     (*this)[2] = std::get<2>(data);
   }
+  /**
+   * @brief IVec3
+   * @param data
+   */
   IVec3(const T* data)
+  {
+    (*this)[0] = data[0];
+    (*this)[1] = data[1];
+    (*this)[2] = data[2];
+  }
+  /**
+   * @brief IVec3
+   * @param data
+   */
+  IVec3(const std::vector<T>& data)
   {
     (*this)[0] = data[0];
     (*this)[1] = data[1];
@@ -365,18 +434,6 @@ public:
   {
     return IVec3<OutType>(static_cast<OutType>((*this)[0]), static_cast<OutType>((*this)[1]), static_cast<OutType>((*this)[2]));
   }
-  /**
-   * @brief Converts to a different container type such as std::vector or QVector. The container must have a constructor that takes a single value of size.
-   */
-  template <typename ContainerType>
-  ContainerType toContainer()
-  {
-    ContainerType c(3);
-    c[0] = (*this)[0];
-    c[1] = (*this)[1];
-    c[2] = (*this)[2];
-    return c;
-  }
 };
 
 // -----------------------------------------------------------------------------
@@ -400,7 +457,13 @@ public:
     (*this)[2] = static_cast<T>(0);
     (*this)[3] = static_cast<T>(0);
   }
-
+  /**
+   * @brief IVec4
+   * @param x
+   * @param y
+   * @param z
+   * @param w
+   */
   IVec4(T x, T y, T z, T w)
   {
     (*this)[0] = x;
@@ -408,22 +471,44 @@ public:
     (*this)[2] = z;
     (*this)[3] = w;
   }
-
-  IVec4(std::array<T, 4> data)
+  /**
+   * @brief IVec4
+   * @param data
+   */
+  IVec4(const std::array<T, 4>& data)
   {
     (*this)[0] = data[0];
     (*this)[1] = data[1];
     (*this)[2] = data[2];
     (*this)[3] = data[3];
   }
-  IVec4(std::tuple<T, T> data)
+  /**
+   * @brief IVec4
+   * @param data
+   */
+  IVec4(const std::tuple<T, T, T, T>& data)
   {
     (*this)[0] = std::get<0>(data);
     (*this)[1] = std::get<1>(data);
     (*this)[2] = std::get<2>(data);
     (*this)[3] = std::get<3>(data);
   }
+  /**
+   * @brief IVec4
+   * @param data
+   */
   IVec4(const T* data)
+  {
+    (*this)[0] = data[0];
+    (*this)[1] = data[1];
+    (*this)[2] = data[2];
+    (*this)[3] = data[3];
+  }
+  /**
+   * @brief IVec4
+   * @param data
+   */
+  IVec4(const std::vector<T>& data)
   {
     (*this)[0] = data[0];
     (*this)[1] = data[1];
@@ -464,7 +549,7 @@ public:
     (*this)[3] = w;
   }
 
-  std::tuple<T, T> toTuple() const
+  std::tuple<T, T, T, T> toTuple() const
   {
     return std::make_tuple(getX(), getY(), getZ(), getW());
   }
@@ -476,19 +561,6 @@ public:
   IVec4<OutType> convertType()
   {
     return IVec4<OutType>(static_cast<OutType>((*this)[0]), static_cast<OutType>((*this)[1]), static_cast<OutType>((*this)[2]), static_cast<OutType>((*this)[3]));
-  }
-  /**
-   * @brief Converts to a different container type such as std::vector or QVector. The container must have a constructor that takes a single value of size.
-   */
-  template <typename ContainerType>
-  ContainerType toContainer()
-  {
-    ContainerType c(4);
-    c[0] = (*this)[0];
-    c[1] = (*this)[1];
-    c[2] = (*this)[2];
-    c[3] = (*this)[3];
-    return c;
   }
 };
 
@@ -517,7 +589,15 @@ public:
     (*this)[4] = static_cast<T>(0);
     (*this)[5] = static_cast<T>(0);
   }
-
+  /**
+   * @brief IVec6
+   * @param x
+   * @param y
+   * @param z
+   * @param a
+   * @param b
+   * @param c
+   */
   IVec6(T x, T y, T z, T a, T b, T c)
   {
     (*this)[0] = x;
@@ -527,8 +607,11 @@ public:
     (*this)[4] = b;
     (*this)[5] = c;
   }
-
-  IVec6(std::array<T, 6> data)
+  /**
+   * @brief IVec6
+   * @param data
+   */
+  IVec6(const std::array<T, 6>& data)
   {
     (*this)[0] = data[0];
     (*this)[1] = data[1];
@@ -537,7 +620,11 @@ public:
     (*this)[4] = data[4];
     (*this)[5] = data[5];
   }
-  IVec6(std::tuple<T, T> data)
+  /**
+   * @brief IVec6
+   * @param data
+   */
+  IVec6(const std::tuple<T, T, T, T, T, T>& data)
   {
     (*this)[0] = std::get<0>(data);
     (*this)[1] = std::get<1>(data);
@@ -546,6 +633,10 @@ public:
     (*this)[4] = std::get<4>(data);
     (*this)[5] = std::get<5>(data);
   }
+  /**
+   * @brief IVec6
+   * @param data
+   */
   IVec6(const T* data)
   {
     (*this)[0] = data[0];
@@ -555,8 +646,21 @@ public:
     (*this)[4] = data[4];
     (*this)[5] = data[5];
   }
+  /**
+   * @brief IVec6
+   * @param data
+   */
+  IVec6(const std::vector<T>& data)
+  {
+    (*this)[0] = data[0];
+    (*this)[1] = data[1];
+    (*this)[2] = data[2];
+    (*this)[3] = data[3];
+    (*this)[4] = data[4];
+    (*this)[5] = data[5];
+  }
 
-  std::tuple<T, T> toTuple() const
+  std::tuple<T, T, T, T, T, T> toTuple() const
   {
     return std::make_tuple((*this)[0], (*this)[1], (*this)[2], (*this)[3], (*this)[4], (*this)[5]);
   }
@@ -570,22 +674,6 @@ public:
     return IVec6<OutType>(static_cast<OutType>((*this)[0]), static_cast<OutType>((*this)[1]), static_cast<OutType>((*this)[2]), static_cast<OutType>((*this)[3]), static_cast<OutType>((*this)[4]),
                           static_cast<OutType>((*this)[5]));
   }
-
-  /**
-   * @brief Converts to a different container type such as std::vector or QVector. The container must have a constructor that takes a single value of size.
-   */
-  template <typename ContainerType>
-  ContainerType toContainer()
-  {
-    ContainerType c(6);
-    c[0] = (*this)[0];
-    c[1] = (*this)[1];
-    c[2] = (*this)[2];
-    c[3] = (*this)[3];
-    c[4] = (*this)[4];
-    c[5] = (*this)[5];
-    return c;
-  }
 };
 
 using FloatVec3Type = IVec3<float>;
@@ -598,3 +686,4 @@ using IntVec4Type = IVec4<int>;
 using SizeVec4Type = IVec4<size_t>;
 
 using FloatVec6Type = IVec6<float>;
+using IntVec6Type = IVec6<int32_t>;

--- a/Source/SIMPLib/Common/Testing/Cxx/SIMPLArrayTest.cpp
+++ b/Source/SIMPLib/Common/Testing/Cxx/SIMPLArrayTest.cpp
@@ -95,11 +95,9 @@ public:
     DREAM3D_REQUIRED(i3[1], ==, 5)
 
     std::vector<int32_t> oVec = i3.toContainer<std::vector<int32_t>>();
-    std::list<int32_t> oList = i3.toContainer<std::list<int32_t>>();
     std::deque<int32_t> oDeque = i3.toContainer<std::deque<int32_t>>();
 
     QVector<int32_t> oQVec = i3.toContainer<QVector<int32_t>>();
-    QList<int32_t> oQList = i3.toContainer<QList<int32_t>>();
   }
 
   // -----------------------------------------------------------------------------
@@ -136,11 +134,9 @@ public:
     DREAM3D_REQUIRED(i3[2], ==, 6)
 
     std::vector<int32_t> oVec = i3.toContainer<std::vector<int32_t>>();
-    std::list<int32_t> oList = i3.toContainer<std::list<int32_t>>();
     std::deque<int32_t> oDeque = i3.toContainer<std::deque<int32_t>>();
 
     QVector<int32_t> oQVec = i3.toContainer<QVector<int32_t>>();
-    QList<int32_t> oQList = i3.toContainer<QList<int32_t>>();
   }
 
   // -----------------------------------------------------------------------------
@@ -183,11 +179,9 @@ public:
     DREAM3D_REQUIRED(i3[3], ==, 7)
 
     std::vector<int32_t> oVec = i3.toContainer<std::vector<int32_t>>();
-    std::list<int32_t> oList = i3.toContainer<std::list<int32_t>>();
     std::deque<int32_t> oDeque = i3.toContainer<std::deque<int32_t>>();
 
     QVector<int32_t> oQVec = i3.toContainer<QVector<int32_t>>();
-    QList<int32_t> oQList = i3.toContainer<QList<int32_t>>();
   }
 
   // -----------------------------------------------------------------------------
@@ -215,16 +209,14 @@ public:
     DREAM3D_REQUIRED(i3[0], ==, 4)
     DREAM3D_REQUIRED(i3[1], ==, 5)
     DREAM3D_REQUIRED(i3[2], ==, 6)
-    DREAM3D_REQUIRED(i3[0], ==, 7)
-    DREAM3D_REQUIRED(i3[1], ==, 8)
-    DREAM3D_REQUIRED(i3[2], ==, 9)
+    DREAM3D_REQUIRED(i3[3], ==, 7)
+    DREAM3D_REQUIRED(i3[4], ==, 8)
+    DREAM3D_REQUIRED(i3[5], ==, 9)
 
     std::vector<int32_t> oVec = i3.toContainer<std::vector<int32_t>>();
-    std::list<int32_t> oList = i3.toContainer<std::list<int32_t>>();
     std::deque<int32_t> oDeque = i3.toContainer<std::deque<int32_t>>();
 
     QVector<int32_t> oQVec = i3.toContainer<QVector<int32_t>>();
-    QList<int32_t> oQList = i3.toContainer<QList<int32_t>>();
   }
   // -----------------------------------------------------------------------------
   //

--- a/Source/SIMPLib/Common/Testing/Cxx/SIMPLArrayTest.cpp
+++ b/Source/SIMPLib/Common/Testing/Cxx/SIMPLArrayTest.cpp
@@ -30,7 +30,14 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+#include <deque>
+#include <forward_list>
 #include <iostream>
+#include <list>
+#include <vector>
+
+#include <QtCore/QList>
+#include <QtCore/QVector>
 
 #include "SIMPLib/Common/SIMPLArray.hpp"
 #include "SIMPLib/SIMPLib.h"
@@ -38,16 +45,16 @@
 #include "SIMPLib/Testing/SIMPLTestFileLocations.h"
 #include "SIMPLib/Testing/UnitTestSupport.hpp"
 
-class AbstractVecTest
+class SIMPLArrayTest
 {
 public:
-  AbstractVecTest() = default;
-  virtual ~AbstractVecTest() = default;
+  SIMPLArrayTest() = default;
+  virtual ~SIMPLArrayTest() = default;
 
-  AbstractVecTest(const AbstractVecTest&) = delete;            // Copy Constructor Not Implemented
-  AbstractVecTest(AbstractVecTest&&) = delete;                 // Move Constructor Not Implemented
-  AbstractVecTest& operator=(const AbstractVecTest&) = delete; // Copy Assignment Not Implemented
-  AbstractVecTest& operator=(AbstractVecTest&&) = delete;      // Move Assignment Not Implemented
+  SIMPLArrayTest(const SIMPLArrayTest&) = delete;            // Copy Constructor Not Implemented
+  SIMPLArrayTest(SIMPLArrayTest&&) = delete;                 // Move Constructor Not Implemented
+  SIMPLArrayTest& operator=(const SIMPLArrayTest&) = delete; // Copy Assignment Not Implemented
+  SIMPLArrayTest& operator=(SIMPLArrayTest&&) = delete;      // Move Assignment Not Implemented
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
@@ -86,6 +93,13 @@ public:
     DREAM3D_REQUIRED(i3.size(), ==, 2)
     DREAM3D_REQUIRED(i3[0], ==, 4)
     DREAM3D_REQUIRED(i3[1], ==, 5)
+
+    std::vector<int32_t> oVec = i3.toContainer<std::vector<int32_t>>();
+    std::list<int32_t> oList = i3.toContainer<std::list<int32_t>>();
+    std::deque<int32_t> oDeque = i3.toContainer<std::deque<int32_t>>();
+
+    QVector<int32_t> oQVec = i3.toContainer<QVector<int32_t>>();
+    QList<int32_t> oQList = i3.toContainer<QList<int32_t>>();
   }
 
   // -----------------------------------------------------------------------------
@@ -120,6 +134,97 @@ public:
     DREAM3D_REQUIRED(i3[0], ==, 4)
     DREAM3D_REQUIRED(i3[1], ==, 5)
     DREAM3D_REQUIRED(i3[2], ==, 6)
+
+    std::vector<int32_t> oVec = i3.toContainer<std::vector<int32_t>>();
+    std::list<int32_t> oList = i3.toContainer<std::list<int32_t>>();
+    std::deque<int32_t> oDeque = i3.toContainer<std::deque<int32_t>>();
+
+    QVector<int32_t> oQVec = i3.toContainer<QVector<int32_t>>();
+    QList<int32_t> oQList = i3.toContainer<QList<int32_t>>();
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void TestVec4()
+  {
+    FloatVec4Type f3(1.0f, 2.0f, 3.0f, 4.0f);
+
+    std::array<int32_t, 4> i32Array = {
+        1,
+        2,
+        3,
+        4,
+    };
+    IntVec4Type i3(i32Array);
+
+    std::tuple<int32_t, int32_t, int32_t, int32_t> tpl = std::make_tuple(1, 2, 3, 4);
+    i3 = tpl;
+
+    std::vector<int32_t> iv3 = {4, 5, 6, 7};
+    i3 = iv3.data();
+
+    int32_t x = i3.getX();
+    DREAM3D_REQUIRED(x, ==, 4)
+    int32_t y = i3.getY();
+    DREAM3D_REQUIRED(y, ==, 5)
+    int32_t z = i3.getZ();
+    DREAM3D_REQUIRED(z, ==, 6)
+
+    tpl = i3.toTuple();
+    DREAM3D_REQUIRED(std::get<0>(tpl), ==, 4)
+    DREAM3D_REQUIRED(std::get<1>(tpl), ==, 5)
+    DREAM3D_REQUIRED(std::get<2>(tpl), ==, 6)
+
+    DREAM3D_REQUIRED(i3.size(), ==, 4)
+    DREAM3D_REQUIRED(i3[0], ==, 4)
+    DREAM3D_REQUIRED(i3[1], ==, 5)
+    DREAM3D_REQUIRED(i3[2], ==, 6)
+    DREAM3D_REQUIRED(i3[3], ==, 7)
+
+    std::vector<int32_t> oVec = i3.toContainer<std::vector<int32_t>>();
+    std::list<int32_t> oList = i3.toContainer<std::list<int32_t>>();
+    std::deque<int32_t> oDeque = i3.toContainer<std::deque<int32_t>>();
+
+    QVector<int32_t> oQVec = i3.toContainer<QVector<int32_t>>();
+    QList<int32_t> oQList = i3.toContainer<QList<int32_t>>();
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void TestVec6()
+  {
+    FloatVec6Type f3(1.0f, 2.0f, 3.0f, 6.0f, 7.0f, 8.0f);
+
+    std::array<int32_t, 6> i32Array = {1, 2, 3, 4, 5, 6};
+    IntVec6Type i3(i32Array);
+
+    std::tuple<int32_t, int32_t, int32_t, int32_t, int32_t, int32_t> tpl = std::make_tuple(1, 2, 3, 5, 6, 7);
+    i3 = tpl;
+
+    std::vector<int32_t> iv3 = {4, 5, 6, 7, 8, 9};
+    i3 = iv3.data();
+
+    tpl = i3.toTuple();
+    DREAM3D_REQUIRED(std::get<0>(tpl), ==, 4)
+    DREAM3D_REQUIRED(std::get<1>(tpl), ==, 5)
+    DREAM3D_REQUIRED(std::get<2>(tpl), ==, 6)
+
+    DREAM3D_REQUIRED(i3.size(), ==, 6)
+    DREAM3D_REQUIRED(i3[0], ==, 4)
+    DREAM3D_REQUIRED(i3[1], ==, 5)
+    DREAM3D_REQUIRED(i3[2], ==, 6)
+    DREAM3D_REQUIRED(i3[0], ==, 7)
+    DREAM3D_REQUIRED(i3[1], ==, 8)
+    DREAM3D_REQUIRED(i3[2], ==, 9)
+
+    std::vector<int32_t> oVec = i3.toContainer<std::vector<int32_t>>();
+    std::list<int32_t> oList = i3.toContainer<std::list<int32_t>>();
+    std::deque<int32_t> oDeque = i3.toContainer<std::deque<int32_t>>();
+
+    QVector<int32_t> oQVec = i3.toContainer<QVector<int32_t>>();
+    QList<int32_t> oQList = i3.toContainer<QList<int32_t>>();
   }
   // -----------------------------------------------------------------------------
   //
@@ -128,12 +233,14 @@ public:
   {
     int err = EXIT_SUCCESS;
 
-    std::cout << "#### AbstractVecTest Starting ####" << std::endl;
+    std::cout << "#### SIMPLArrayTest Starting ####" << std::endl;
 #if !REMOVE_TEST_FILES
     DREAM3D_REGISTER_TEST(RemoveTestFiles())
 #endif
     DREAM3D_REGISTER_TEST(TestVec2())
     DREAM3D_REGISTER_TEST(TestVec3())
+    DREAM3D_REGISTER_TEST(TestVec4())
+    DREAM3D_REGISTER_TEST(TestVec6())
 
 #if REMOVE_TEST_FILES
     DREAM3D_REGISTER_TEST(RemoveTestFiles())

--- a/Source/SIMPLib/Common/Testing/Cxx/SourceList.cmake
+++ b/Source/SIMPLib/Common/Testing/Cxx/SourceList.cmake
@@ -1,6 +1,6 @@
 
 set(TEST_${SUBDIR_NAME}_NAMES
-  AbstractVecTest
+  SIMPLArrayTest
 )
 
 SIMPL_ADD_UNIT_TEST("${TEST_${SUBDIR_NAME}_NAMES}" "${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/Testing/Cxx")

--- a/Source/SIMPLib/CoreFilters/ApplyImageTransforms.cpp
+++ b/Source/SIMPLib/CoreFilters/ApplyImageTransforms.cpp
@@ -145,8 +145,7 @@ void ApplyImageTransforms::execute()
     DataContainer::Pointer dc = getDataContainerArray()->getDataContainer(dcName);
     ImageGeom::Pointer imageGeom = dc->getGeometryAs<ImageGeom>();
 
-    FloatVec3Type origin;
-    imageGeom->getOrigin(origin);
+    FloatVec3Type origin = imageGeom->getOrigin();
 
     ::ITransformContainer::Pointer iTransformContainer = imageGeom->getTransformContainer();
     if (iTransformContainer)

--- a/Source/SIMPLib/CoreFilters/CreateImageGeometry.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateImageGeometry.cpp
@@ -138,9 +138,9 @@ void CreateImageGeometry::dataCheck()
   }
 
   ImageGeom::Pointer image = ImageGeom::CreateGeometry("ImageGeometry");
-  image->setDimensions(std::make_tuple(m_Dimensions[0], m_Dimensions[1], m_Dimensions[2]));
-  image->setSpacing(std::make_tuple(m_Spacing[0], m_Spacing[1], m_Spacing[2]));
-  image->setOrigin(std::make_tuple(m_Origin[0], m_Origin[1], m_Origin[2]));
+  image->setDimensions(m_Dimensions.convertType<size_t>());
+  image->setSpacing(m_Spacing);
+  image->setOrigin(m_Origin);
   m->setGeometry(image);
 }
 

--- a/Source/SIMPLib/CoreFilters/ExtractVertexGeometry.cpp
+++ b/Source/SIMPLib/CoreFilters/ExtractVertexGeometry.cpp
@@ -181,10 +181,10 @@ void ExtractVertexGeometry::dataCheck()
   {
     vertexDataContainer = getDataContainerArray()->createNonPrereqDataContainer<AbstractFilter>(this, getVertexDataContainerName(), DataContainerID);
     IGeometryGrid::Pointer imageGeom = std::dynamic_pointer_cast<IGeometryGrid>(fromGeometry);
-    SIMPL::Tuple3SVec imageDims = imageGeom->getDimensions();
-    VertexGeom::Pointer vertexGeom = VertexGeom::CreateGeometry(static_cast<int64_t>(std::get<0>(imageDims) * std::get<1>(imageDims) * std::get<2>(imageDims)), "VertexGeometry", !getInPreflight());
+    SizeVec3Type imageDims = imageGeom->getDimensions();
+    VertexGeom::Pointer vertexGeom = VertexGeom::CreateGeometry(imageDims[0] * imageDims[1] * imageDims[2], "VertexGeometry", !getInPreflight());
     vertexDataContainer->setGeometry(vertexGeom);
-    elementCount = std::get<0>(imageDims) * std::get<1>(imageDims) * std::get<2>(imageDims);
+    elementCount = imageDims[0] * imageDims[1] * imageDims[2];
   }
   else
   {
@@ -277,12 +277,9 @@ void ExtractVertexGeometry::execute()
   IGeometryGrid::Pointer sourceGeometry = getDataContainerArray()->getDataContainer(getSelectedDataContainerName())->getGeometryAs<IGeometryGrid>();
 
   float coords[3] = {0.0f, 0.0f, 0.0f};
-  size_t xPoints = 0;
-  size_t yPoints = 0;
-  size_t zPoints = 0;
 
-  std::tie(xPoints, yPoints, zPoints) = sourceGeometry->getDimensions();
-  size_t cellCount = xPoints * yPoints * zPoints;
+  SizeVec3Type dims = sourceGeometry->getDimensions();
+  size_t cellCount = std::accumulate(dims.begin(), dims.end(), static_cast<size_t>(1), std::multiplies<size_t>());
 
   VertexGeom::Pointer vertexGeom = getDataContainerArray()->getDataContainer(getVertexDataContainerName())->getGeometryAs<VertexGeom>();
   SharedVertexList::Pointer vertices = vertexGeom->getVertices();
@@ -294,9 +291,6 @@ void ExtractVertexGeometry::execute()
     sourceGeometry->getCoords(idx, coords);
     vertices->setTuple(idx, coords);
   }
-
-  // The moving or copying of the Cell DataArrays was already handled in the dataCheck() method.
-
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLib/CoreFilters/InitializeData.cpp
+++ b/Source/SIMPLib/CoreFilters/InitializeData.cpp
@@ -229,8 +229,7 @@ void InitializeData::dataCheck()
 
   DataContainer::Pointer m = getDataContainerArray()->getDataContainer(attributeMatrixPath.getDataContainerName());
 
-  size_t udims[3] = {0, 0, 0};
-  std::tie(udims[0], udims[1], udims[2]) = m->getGeometryAs<ImageGeom>()->getDimensions();
+  // SizeVec3Type udims = m->getGeometryAs<ImageGeom>()->getDimensions();
 
   QString attrMatName = attributeMatrixPath.getAttributeMatrixName();
   QList<QString> voxelArrayNames = DataArrayPath::GetDataArrayNames(m_CellAttributeMatrixPaths);
@@ -359,8 +358,7 @@ void InitializeData::execute()
   DataArrayPath attributeMatrixPath(m_CellAttributeMatrixPaths[0].getDataContainerName(), m_CellAttributeMatrixPaths[0].getAttributeMatrixName(), "");
   DataContainer::Pointer m = getDataContainerArray()->getDataContainer(attributeMatrixPath.getDataContainerName());
 
-  size_t udims[3] = {0, 0, 0};
-  std::tie(udims[0], udims[1], udims[2]) = m->getGeometryAs<ImageGeom>()->getDimensions();
+  SizeVec3Type udims = m->getGeometryAs<ImageGeom>()->getDimensions();
 
   int64_t dims[3] = {
       static_cast<int64_t>(udims[0]), static_cast<int64_t>(udims[1]), static_cast<int64_t>(udims[2]),

--- a/Source/SIMPLib/CoreFilters/RequiredZThickness.cpp
+++ b/Source/SIMPLib/CoreFilters/RequiredZThickness.cpp
@@ -120,8 +120,7 @@ void RequiredZThickness::dataCheck()
     return;
   }
 
-  size_t dims[3] = {0, 0, 0};
-  std::tie(dims[0], dims[1], dims[2]) = image->getDimensions();
+  SizeVec3Type dims = image->getDimensions();
 
   if(dims[2] < getNumZVoxels() && m_PreflightCheck)
   {
@@ -179,8 +178,7 @@ void RequiredZThickness::execute()
 
   ImageGeom::Pointer image = dataContainer->getGeometryAs<ImageGeom>();
 
-  size_t dims[3] = {0, 0, 0};
-  std::tie(dims[0], dims[1], dims[2]) = image->getDimensions();
+  SizeVec3Type dims = image->getDimensions();
 
   if(dims[2] < getNumZVoxels())
   {

--- a/Source/SIMPLib/CoreFilters/ScaleVolume.cpp
+++ b/Source/SIMPLib/CoreFilters/ScaleVolume.cpp
@@ -274,8 +274,7 @@ void ScaleVolume::execute()
     DataContainer::Pointer m = getDataContainerArray()->getDataContainer(getDataContainerName());
     ImageGeom::Pointer image = m->getGeometryAs<ImageGeom>();
 
-    FloatVec3Type spacing = {0.0f, 0.0f, 0.0f};
-    image->getSpacing(spacing);
+    FloatVec3Type spacing = image->getSpacing();
     spacing[0] *= m_ScaleFactor[0];
     spacing[1] *= m_ScaleFactor[1];
     spacing[2] *= m_ScaleFactor[2];

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CopyObjectTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CopyObjectTest.cpp
@@ -293,18 +293,18 @@ public:
         ImageGeom::Pointer oldImageGeom = std::dynamic_pointer_cast<ImageGeom>(oldGeom);
         ImageGeom::Pointer newImageGeom = std::dynamic_pointer_cast<ImageGeom>(newGeom);
 
-        SIMPL::Tuple3SVec oldDims = oldImageGeom->getDimensions();
-        SIMPL::Tuple3SVec newDims = newImageGeom->getDimensions();
+        SizeVec3Type oldDims = oldImageGeom->getDimensions();
+        SizeVec3Type newDims = newImageGeom->getDimensions();
         bool sameDims = (oldDims == newDims);
         DREAM3D_REQUIRE_EQUAL(sameDims, true)
 
-        SIMPL::Tuple3FVec oldRes = oldImageGeom->getSpacing();
-        SIMPL::Tuple3FVec newRes = newImageGeom->getSpacing();
+        FloatVec3Type oldRes = oldImageGeom->getSpacing();
+        FloatVec3Type newRes = newImageGeom->getSpacing();
         bool sameRes = (oldRes == newRes);
         DREAM3D_REQUIRE_EQUAL(sameRes, true)
 
-        SIMPL::Tuple3FVec oldOrigin = oldImageGeom->getOrigin();
-        SIMPL::Tuple3FVec newOrigin = newImageGeom->getOrigin();
+        FloatVec3Type oldOrigin = oldImageGeom->getOrigin();
+        FloatVec3Type newOrigin = newImageGeom->getOrigin();
         bool sameOrigin = (oldOrigin == newOrigin);
         DREAM3D_REQUIRE_EQUAL(sameOrigin, true)
       }
@@ -313,8 +313,8 @@ public:
         RectGridGeom::Pointer oldRectGridGeom = std::dynamic_pointer_cast<RectGridGeom>(oldGeom);
         RectGridGeom::Pointer newRectGridGeom = std::dynamic_pointer_cast<RectGridGeom>(newGeom);
 
-        SIMPL::Tuple3SVec oldDims = oldRectGridGeom->getDimensions();
-        SIMPL::Tuple3SVec newDims = newRectGridGeom->getDimensions();
+        SizeVec3Type oldDims = oldRectGridGeom->getDimensions();
+        SizeVec3Type newDims = newRectGridGeom->getDimensions();
         bool sameDims = (oldDims == newDims);
         DREAM3D_REQUIRE_EQUAL(sameDims, true)
 
@@ -766,7 +766,7 @@ public:
     // Image
 
     ImageGeom::Pointer imageGeom = ImageGeom::CreateGeometry(SIMPL::Geometry::ImageGeometry);
-    imageGeom->setDimensions(std::forward_as_tuple(5, 5, 5));
+    imageGeom->setDimensions(SizeVec3Type(5, 5, 5));
     imageGeom->setSpacing(FloatVec3Type(5, 5, 5));
     imageGeom->setOrigin(FloatVec3Type(5, 5, 5));
     imageGeom->setName("Image Geom");

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateGeometryTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateGeometryTest.cpp
@@ -173,21 +173,21 @@ public:
 
     ImageGeom::Pointer imageGeom = dc->getGeometryAs<ImageGeom>();
 
-    SIMPL::Tuple3SVec dim = imageGeom->getDimensions();
-    SIMPL::Tuple3FVec origin = imageGeom->getOrigin();
-    SIMPL::Tuple3FVec res = imageGeom->getSpacing();
+    SizeVec3Type dim = imageGeom->getDimensions();
+    FloatVec3Type origin = imageGeom->getOrigin();
+    FloatVec3Type res = imageGeom->getSpacing();
 
-    DREAM3D_REQUIRE_EQUAL(std::get<0>(dim), numDimensions[0])
-    DREAM3D_REQUIRE_EQUAL(std::get<1>(dim), numDimensions[1])
-    DREAM3D_REQUIRE_EQUAL(std::get<2>(dim), numDimensions[2])
+    DREAM3D_REQUIRE_EQUAL(dim[0], numDimensions[0])
+    DREAM3D_REQUIRE_EQUAL(dim[1], numDimensions[1])
+    DREAM3D_REQUIRE_EQUAL(dim[2], numDimensions[2])
 
-    DREAM3D_REQUIRE_EQUAL(std::get<0>(origin), originPos[0])
-    DREAM3D_REQUIRE_EQUAL(std::get<1>(origin), originPos[1])
-    DREAM3D_REQUIRE_EQUAL(std::get<2>(origin), originPos[2])
+    DREAM3D_REQUIRE_EQUAL(origin[0], originPos[0])
+    DREAM3D_REQUIRE_EQUAL(origin[1], originPos[1])
+    DREAM3D_REQUIRE_EQUAL(origin[2], originPos[2])
 
-    DREAM3D_REQUIRE_EQUAL(std::get<0>(res), imgResolution[0])
-    DREAM3D_REQUIRE_EQUAL(std::get<1>(res), imgResolution[1])
-    DREAM3D_REQUIRE_EQUAL(std::get<2>(res), imgResolution[2])
+    DREAM3D_REQUIRE_EQUAL(res[0], imgResolution[0])
+    DREAM3D_REQUIRE_EQUAL(res[1], imgResolution[1])
+    DREAM3D_REQUIRE_EQUAL(res[2], imgResolution[2])
 
     removeGeometry(dc);
   }

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateImageGeometryTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateImageGeometryTest.cpp
@@ -174,8 +174,7 @@ public:
     DREAM3D_REQUIRE(nullptr != geometry.get());
 
     {
-      FloatVec3Type res;
-      geometry->getSpacing(res);
+      FloatVec3Type res = geometry->getSpacing();
 
       DREAM3D_REQUIRE_EQUAL(res[0], imgResolution[0]);
       DREAM3D_REQUIRE_EQUAL(res[1], imgResolution[1]);
@@ -183,8 +182,7 @@ public:
     }
 
     {
-      FloatVec3Type origin;
-      geometry->getOrigin(origin);
+      FloatVec3Type origin = geometry->getOrigin();
 
       DREAM3D_REQUIRE_EQUAL(origin[0], originPos[0]);
       DREAM3D_REQUIRE_EQUAL(origin[1], originPos[1]);
@@ -192,8 +190,7 @@ public:
     }
 
     {
-      SizeVec3Type dims;
-      geometry->getDimensions(dims);
+      SizeVec3Type dims = geometry->getDimensions();
 
       DREAM3D_REQUIRE_EQUAL(dims[0], numDimensions[0]);
       DREAM3D_REQUIRE_EQUAL(dims[1], numDimensions[1]);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/FindDerivativesFilterTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/FindDerivativesFilterTest.cpp
@@ -203,10 +203,10 @@ public:
     QuadGeom::Pointer quads = QuadGeom::CreateGeometry(1, vertices4, "QuadGeom");
     TetrahedralGeom::Pointer tets = TetrahedralGeom::CreateGeometry(1, vertices5, "TetrahedralGeom");
 
-    image->setDimensions(std::make_tuple(10, 10, 10));
-    image->setOrigin(std::make_tuple(0.0f, 0.0f, 0.0f));
-    image->setSpacing(std::make_tuple(1.0f, 1.0f, 1.0f));
-    rectGrid->setDimensions(std::make_tuple(10, 10, 10));
+    image->setDimensions(10, 10, 10);
+    image->setOrigin(0.0f, 0.0f, 0.0f);
+    image->setSpacing(1.0f, 1.0f, 1.0f);
+    rectGrid->setDimensions(SizeVec3Type(10, 10, 10));
     FloatArrayType::Pointer xBounds = FloatArrayType::CreateArray(11, SIMPL::Geometry::xBoundsList);
     FloatArrayType::Pointer yBounds = FloatArrayType::CreateArray(11, SIMPL::Geometry::yBoundsList);
     FloatArrayType::Pointer zBounds = FloatArrayType::CreateArray(11, SIMPL::Geometry::zBoundsList);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ScaleVolumeTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ScaleVolumeTest.cpp
@@ -258,8 +258,7 @@ public:
 
     DREAM3D_REQUIRE(imgGeom != nullptr);
 
-    FloatVec3Type spacing;
-    imgGeom->getSpacing(spacing);
+    FloatVec3Type spacing = imgGeom->getSpacing();
 
     DREAM3D_REQUIRE_EQUAL(spacing[0], ScaleVolumeTestConsts::SCALE[0]);
     DREAM3D_REQUIRE_EQUAL(spacing[1], ScaleVolumeTestConsts::SCALE[1]);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/SetOriginResolutionImageGeomTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/SetOriginResolutionImageGeomTest.cpp
@@ -252,8 +252,7 @@ public:
 
     DREAM3D_REQUIRE(imgGeom != nullptr);
 
-    FloatVec3Type origin;
-    imgGeom->getOrigin(origin);
+    FloatVec3Type origin = imgGeom->getOrigin();
     DREAM3D_REQUIRE_EQUAL(origin[0], SetOriginResolutionImageGeometryTest::ORIGIN[0]);
     DREAM3D_REQUIRE_EQUAL(origin[1], SetOriginResolutionImageGeometryTest::ORIGIN[1]);
     DREAM3D_REQUIRE_EQUAL(origin[2], SetOriginResolutionImageGeometryTest::ORIGIN[2]);
@@ -278,14 +277,11 @@ public:
 
     DREAM3D_REQUIRE(imgGeom != nullptr);
 
-    float xRes = 0.0f;
-    float yRes = 0.0f;
-    float zRes = 0.0f;
-    std::tie(xRes, yRes, zRes) = imgGeom->getSpacing();
+    FloatVec3Type spacing = imgGeom->getSpacing();
 
-    DREAM3D_REQUIRE_EQUAL(xRes, SetOriginResolutionImageGeometryTest::RESOLUTION[0]);
-    DREAM3D_REQUIRE_EQUAL(yRes, SetOriginResolutionImageGeometryTest::RESOLUTION[1]);
-    DREAM3D_REQUIRE_EQUAL(zRes, SetOriginResolutionImageGeometryTest::RESOLUTION[2]);
+    DREAM3D_REQUIRE_EQUAL(spacing[0], SetOriginResolutionImageGeometryTest::RESOLUTION[0]);
+    DREAM3D_REQUIRE_EQUAL(spacing[1], SetOriginResolutionImageGeometryTest::RESOLUTION[1]);
+    DREAM3D_REQUIRE_EQUAL(spacing[2], SetOriginResolutionImageGeometryTest::RESOLUTION[2]);
   }
 
   // -----------------------------------------------------------------------------
@@ -332,7 +328,9 @@ public:
     DREAM3D_REGISTER_TEST(TestNullGeometry());
   }
 
-private:
-  SetOriginResolutionImageGeomTest(const SetOriginResolutionImageGeomTest&); // Copy Constructor Not Implemented
-  void operator=(const SetOriginResolutionImageGeomTest&);                   // Move assignment Not Implemented
+public:
+  SetOriginResolutionImageGeomTest(const SetOriginResolutionImageGeomTest&) = delete;            // Copy Constructor Not Implemented
+  SetOriginResolutionImageGeomTest(SetOriginResolutionImageGeomTest&&) = delete;                 // Move Constructor Not Implemented
+  SetOriginResolutionImageGeomTest& operator=(const SetOriginResolutionImageGeomTest&) = delete; // Copy Assignment Not Implemented
+  SetOriginResolutionImageGeomTest& operator=(SetOriginResolutionImageGeomTest&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/SIMPLib/Geometry/IGeometry.cpp
+++ b/Source/SIMPLib/Geometry/IGeometry.cpp
@@ -379,6 +379,45 @@ QString IGeometry::LengthUnitToString(IGeometry::LengthUnit t)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+QVector<QString> IGeometry::GetAllLengthUnitStrings()
+{
+  QVector<QString> lengthUnits;
+
+  lengthUnits.push_back(SIMPL::Geometry::k_Yoctometer);  // ("Yoctometer");
+  lengthUnits.push_back(SIMPL::Geometry::k_Zeptometer);  // ("Zeptometer");
+  lengthUnits.push_back(SIMPL::Geometry::k_Attometer);   // ("Attometer");
+  lengthUnits.push_back(SIMPL::Geometry::k_Femtometer);  // ("Femtometer");
+  lengthUnits.push_back(SIMPL::Geometry::k_Picometer);   // ("Picometer");
+  lengthUnits.push_back(SIMPL::Geometry::k_Nanometer);   // ("Nanometer");
+  lengthUnits.push_back(SIMPL::Geometry::k_Micrometer);  // ("Micrometer");
+  lengthUnits.push_back(SIMPL::Geometry::k_Millimeter);  // ("Millimeter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Centimeter);  // ("Centimeter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Decimeter);   // ("Decimeter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Meter);       // ("Meter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Decameter);   // ("Decameter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Hectometer);  // ("Hectometer");
+  lengthUnits.push_back(SIMPL::Geometry::k_Kilometer);   // ("Kilometer");
+  lengthUnits.push_back(SIMPL::Geometry::k_Megameter);   // ("Megameter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Gigameter);   // ("Gigameter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Terameter);   // ("Terameter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Petameter);   // ("Petameter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Exameter);    // ("Exameter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Zettameter);  // ("Zettameter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Yottameter);  // ("Yottameter");
+  lengthUnits.push_back(SIMPL::Geometry::k_Angstrom);    // ("Angstrom");
+  lengthUnits.push_back(SIMPL::Geometry::k_Mil);         // ("Mil");
+  lengthUnits.push_back(SIMPL::Geometry::k_Inch);        // ("Inch");
+  lengthUnits.push_back(SIMPL::Geometry::k_Foot);        // ("Foot");
+  lengthUnits.push_back(SIMPL::Geometry::k_Mile);        // ("Mile");
+  lengthUnits.push_back(SIMPL::Geometry::k_Fathom);      // ("Fathom");
+  lengthUnits.push_back(SIMPL::Geometry::k_Unspecified); // ("Unspecified");
+  lengthUnits.push_back(SIMPL::Geometry::k_Unknown);     // ("Unknown");
+  return lengthUnits;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void IGeometry::setName(const QString& name)
 {
   m_Name = name;

--- a/Source/SIMPLib/Geometry/IGeometry.h
+++ b/Source/SIMPLib/Geometry/IGeometry.h
@@ -197,6 +197,12 @@ class SIMPLib_EXPORT IGeometry : public Observable
      */
     static QString LengthUnitToString(IGeometry::LengthUnit t);
 
+    /**
+     * @brief GetAllLengthUnitStrings Returns all the Length Units as a vector of strings. This would be suitable to display as a list to a user.
+     * @return
+     */
+    static QVector<QString> GetAllLengthUnitStrings();
+
     SIMPL_INSTANCE_PROPERTY(float, TimeValue)
     SIMPL_INSTANCE_PROPERTY(bool, EnableTimeSeries)
     SIMPL_INSTANCE_PROPERTY(ITransformContainer::Pointer, TransformContainer)

--- a/Source/SIMPLib/Geometry/IGeometryGrid.h
+++ b/Source/SIMPLib/Geometry/IGeometryGrid.h
@@ -41,12 +41,6 @@
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
 #include "SIMPLib/Geometry/IGeometry.h"
 
-namespace SIMPL
-{
-using Tuple3FVec = std::tuple<float, float, float>;
-using Tuple6FVec = std::tuple<float, float, float, float, float, float>;
-using Tuple3SVec = std::tuple<size_t, size_t, size_t>;
-}
 
 /**
  * @brief The IGeometryGrid class extends IGeometry for grid type geometries
@@ -64,10 +58,7 @@ class SIMPLib_EXPORT IGeometryGrid : public IGeometry
     ~IGeometryGrid() override;
 
     virtual void setDimensions(const SizeVec3Type& dims) = 0;
-    virtual void setDimensions(SizeVec3Type& dims) = 0;
-    virtual void setDimensions(const SIMPL::Tuple3SVec& dims) = 0; // Needed for Python Interface
-
-    virtual SIMPL::Tuple3SVec getDimensions() const = 0;
+    virtual SizeVec3Type getDimensions() const = 0;
 
     virtual size_t getXPoints() = 0;
     virtual size_t getYPoints() = 0;

--- a/Source/SIMPLib/Geometry/ImageGeom.cpp
+++ b/Source/SIMPLib/Geometry/ImageGeom.cpp
@@ -63,7 +63,7 @@
 class FindImageDerivativesImpl
 {
 public:
-  FindImageDerivativesImpl(ImageGeom* image, DoubleArrayType::Pointer field, DoubleArrayType::Pointer derivs)
+  FindImageDerivativesImpl(ImageGeom* image, const DoubleArrayType::Pointer& field, const DoubleArrayType::Pointer& derivs)
   : m_Image(image)
   , m_Field(field)
   , m_Derivatives(derivs)
@@ -234,7 +234,7 @@ public:
   }
 #endif
 
-  void computeIndices(int32_t differenceType, int32_t directionType, size_t& index1, size_t& index2, size_t dims[3], size_t x, size_t y, size_t z, double xp[3], double xm[3]) const
+  void computeIndices(int32_t differenceType, int32_t directionType, size_t& index1, size_t& index2, const size_t dims[3], size_t x, size_t y, size_t z, double xp[3], double xm[3]) const
 
   {
     size_t tmpIndex1 = 0;
@@ -337,7 +337,7 @@ public:
   }
 
   void findValuesForFiniteDifference(int32_t differenceType, int32_t directionType, size_t x, size_t y, size_t z, size_t dims[3], double xp[3], double xm[3], double& factor, int32_t numComps,
-                                     std::vector<double>& plusValues, std::vector<double>& minusValues, double* field) const
+                                     std::vector<double>& plusValues, std::vector<double>& minusValues, const double* field) const
   {
     size_t index1 = 0;
     size_t index2 = 0;
@@ -1003,11 +1003,11 @@ int ImageGeom::writeXdmf(QTextStream& out, QString dcName, QString hdfFileName)
 
   out << "  <!-- *************** START OF " << dcName << " *************** -->"
       << "\n";
-  out << "  <Grid Name=\"" << dcName << "\" GridType=\"Uniform\">"
+  out << "  <Grid Name=\"" << dcName << R"(" GridType="Uniform">)"
       << "\n";
   if(getEnableTimeSeries())
   {
-    out << "    <Time TimeType=\"Single\" Value=\"" << getTimeValue() << "\"/>\n";
+    out << R"(    <Time TimeType="Single" Value=")" << getTimeValue() << "\"/>\n";
   }
   out << "    <Topology TopologyType=\"3DCoRectMesh\" Dimensions=\"" << volDims[2] + 1 << " " << volDims[1] + 1 << " " << volDims[0] + 1 << " \"></Topology>"
       << "\n";
@@ -1111,7 +1111,7 @@ IGeometry::Pointer ImageGeom::deepCopy(bool forceNoAllocate)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-int ImageGeom::gatherMetaData(hid_t parentId, size_t volDims[3], float spacing[3], float origin[3], unsigned int spatialDims, QString geomName, bool preflight)
+int ImageGeom::gatherMetaData(hid_t parentId, size_t volDims[3], float spacing[3], float origin[3], unsigned int spatialDims, const QString& geomName, bool preflight)
 {
   int err = QH5Lite::readPointerDataset(parentId, H5_DIMENSIONS, volDims);
   if(err < 0)
@@ -1144,7 +1144,7 @@ int ImageGeom::gatherMetaData(hid_t parentId, size_t volDims[3], float spacing[3
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ImageGeom::ErrorType ImageGeom::computeCellIndex(float coords[3], size_t index[3])
+ImageGeom::ErrorType ImageGeom::computeCellIndex(const float coords[3], size_t index[3])
 {
   ImageGeom::ErrorType err = ImageGeom::ErrorType::NoError;
   for(size_t i = 0; i < 3; i++)
@@ -1169,7 +1169,7 @@ ImageGeom::ErrorType ImageGeom::computeCellIndex(float coords[3], size_t index[3
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ImageGeom::ErrorType ImageGeom::computeCellIndex(float coords[3], size_t& index)
+ImageGeom::ErrorType ImageGeom::computeCellIndex(const float coords[], size_t& index)
 {
   ImageGeom::ErrorType err = ImageGeom::ErrorType::NoError;
   size_t cell[3] = {0, 0, 0};

--- a/Source/SIMPLib/Geometry/ImageGeom.cpp
+++ b/Source/SIMPLib/Geometry/ImageGeom.cpp
@@ -519,7 +519,8 @@ void ImageGeom::getBoundingBox(float* boundingBox)
 // -----------------------------------------------------------------------------
 FloatVec6Type ImageGeom::getBoundingBox()
 {
-  return {{m_Origin[0], m_Origin[0] + (m_Dimensions[0] * m_Spacing[0]), m_Origin[1], m_Origin[1] + (m_Dimensions[1] * m_Spacing[1]), m_Origin[2], m_Origin[2] + (m_Dimensions[2] * m_Spacing[2])}};
+  return FloatVec6Type(m_Origin[0], m_Origin[0] + (m_Dimensions[0] * m_Spacing[0]), m_Origin[1], m_Origin[1] + (m_Dimensions[1] * m_Spacing[1]), m_Origin[2],
+                       m_Origin[2] + (m_Dimensions[2] * m_Spacing[2]));
 }
 
 // -----------------------------------------------------------------------------
@@ -1034,6 +1035,7 @@ QString ImageGeom::getInfoString(SIMPL::InfoStringFormat format)
 {
   QString info;
   QTextStream ss(&info);
+  QString lengthUnit = IGeometry::LengthUnitToString(static_cast<IGeometry::LengthUnit>(getUnits()));
 
   int64_t volDims[3] = {static_cast<int64_t>(getXPoints()), static_cast<int64_t>(getYPoints()), static_cast<int64_t>(getZPoints())};
   FloatVec3Type spacing = getSpacing();
@@ -1054,7 +1056,14 @@ QString ImageGeom::getInfoString(SIMPL::InfoStringFormat format)
     ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Origin:</th><td>)" << origin[0] << ", " << origin[1] << ", " << origin[2] << "</td></tr>";
     ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Spacing:</th><td>)" << spacing[0] << ", " << spacing[1] << ", " << spacing[2] << "</td></tr>";
 
-    ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Bounds:</th><td>)"
+    float vol = (volDims[0] * spacing[0]) * (volDims[1] * spacing[1]) * (volDims[2] * spacing[2]);
+    QLocale usa(QLocale::English, QLocale::UnitedStates);
+
+    ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Volume:</th><td>)" << usa.toString(vol) << " " << lengthUnit
+       << "s ^3"
+          "</td></tr>";
+
+    ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Bounds (Cell Centered):</th><td>)"
        << "<p>X Range: " << (origin[0] - halfRes[0]) << " to " << (origin[0] - halfRes[0] + volDims[0] * spacing[0]) << " (delta: " << (volDims[0] * spacing[0]) << ")</p>"
        << "<p>Y Range: " << (origin[1] - halfRes[1]) << " to " << (origin[1] - halfRes[1] + volDims[1] * spacing[1]) << " (delta: " << (volDims[1] * spacing[1]) << ")</p>"
        << "<p>Z Range: " << (origin[2] - halfRes[2]) << " to " << (origin[2] - halfRes[2] + volDims[2] * spacing[2]) << " (delta: " << (volDims[2] * spacing[2]) << ")</p>"

--- a/Source/SIMPLib/Geometry/ImageGeom.cpp
+++ b/Source/SIMPLib/Geometry/ImageGeom.cpp
@@ -90,8 +90,7 @@ public:
     std::vector<double> dValuesdEta(numComps);
     std::vector<double> dValuesdZeta(numComps);
 
-    size_t dims[3] = {0, 0, 0};
-    std::tie(dims[0], dims[1], dims[2]) = m_Image->getDimensions();
+    SizeVec3Type dims = m_Image->getDimensions();
 
     int64_t counter = 0;
     size_t totalElements = m_Image->getNumberOfElements();
@@ -106,19 +105,19 @@ public:
           //  Xi derivatives (X)
           if(dims[0] == 1)
           {
-            findValuesForFiniteDifference(TwoDimensional, XDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(TwoDimensional, XDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(x == 0)
           {
-            findValuesForFiniteDifference(LeftSide, XDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(LeftSide, XDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(x == (dims[0] - 1))
           {
-            findValuesForFiniteDifference(RightSide, XDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(RightSide, XDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else
           {
-            findValuesForFiniteDifference(Centered, XDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(Centered, XDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
 
           xxi = factor * (xp[0] - xm[0]);
@@ -132,19 +131,19 @@ public:
           //  Eta derivatives (Y)
           if(dims[1] == 1)
           {
-            findValuesForFiniteDifference(TwoDimensional, YDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(TwoDimensional, YDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(y == 0)
           {
-            findValuesForFiniteDifference(LeftSide, YDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(LeftSide, YDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(y == (dims[1] - 1))
           {
-            findValuesForFiniteDifference(RightSide, YDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(RightSide, YDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else
           {
-            findValuesForFiniteDifference(Centered, YDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(Centered, YDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
 
           xeta = factor * (xp[0] - xm[0]);
@@ -158,19 +157,19 @@ public:
           //  Zeta derivatives (Z)
           if(dims[2] == 1)
           {
-            findValuesForFiniteDifference(TwoDimensional, ZDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(TwoDimensional, ZDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(z == 0)
           {
-            findValuesForFiniteDifference(LeftSide, ZDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(LeftSide, ZDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(z == (dims[2] - 1))
           {
-            findValuesForFiniteDifference(RightSide, ZDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(RightSide, ZDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else
           {
-            findValuesForFiniteDifference(Centered, ZDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(Centered, ZDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
 
           xzeta = factor * (xp[0] - xm[0]);
@@ -436,7 +435,7 @@ ImageGeom::Pointer ImageGeom::CreateGeometry(const QString& name)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-SIMPL::Tuple3FVec ImageGeom::getSpacing() const
+FloatVec3Type ImageGeom::getSpacing() const
 {
   return m_Spacing.toTuple();
 }
@@ -444,25 +443,7 @@ SIMPL::Tuple3FVec ImageGeom::getSpacing() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void ImageGeom::getSpacing(FloatVec3Type& spacing) const
-{
-  spacing[0] = m_Spacing[0];
-  spacing[1] = m_Spacing[1];
-  spacing[2] = m_Spacing[2];
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
 void ImageGeom::setSpacing(const FloatVec3Type& spacing)
-{
-  m_Spacing = spacing;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void ImageGeom::setSpacing(FloatVec3Type& spacing)
 {
   m_Spacing = spacing;
 }
@@ -480,7 +461,7 @@ void ImageGeom::setSpacing(float x, float y, float z)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-SIMPL::Tuple3FVec ImageGeom::getOrigin() const
+FloatVec3Type ImageGeom::getOrigin() const
 {
   return m_Origin.toTuple();
 }
@@ -488,25 +469,7 @@ SIMPL::Tuple3FVec ImageGeom::getOrigin() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void ImageGeom::getOrigin(FloatVec3Type& origin) const
-{
-  origin[0] = m_Origin[0];
-  origin[1] = m_Origin[1];
-  origin[2] = m_Origin[2];
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
 void ImageGeom::setOrigin(const FloatVec3Type& origin)
-{
-  m_Origin = origin;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void ImageGeom::setOrigin(FloatVec3Type& origin)
 {
   m_Origin = origin;
 }
@@ -521,27 +484,16 @@ void ImageGeom::setOrigin(float x, float y, float z)
   m_Origin[2] = z;
 }
 
-SIMPL::Tuple3SVec ImageGeom::getDimensions() const
+SizeVec3Type ImageGeom::getDimensions() const
 {
   return m_Dimensions.toTuple();
-}
-void ImageGeom::getDimensions(SizeVec3Type& dims) const
-{
-  dims = m_Dimensions;
 }
 
 void ImageGeom::setDimensions(const SizeVec3Type& dims)
 {
   m_Dimensions = dims;
 }
-void ImageGeom::setDimensions(SizeVec3Type& dims)
-{
-  m_Dimensions = dims;
-}
-void ImageGeom::setDimensions(const SIMPL::Tuple3SVec& dims)
-{
-  m_Dimensions = dims;
-}
+
 void ImageGeom::setDimensions(size_t x, size_t y, size_t z)
 {
   m_Dimensions[0] = x;
@@ -565,10 +517,9 @@ void ImageGeom::getBoundingBox(float* boundingBox)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-SIMPL::Tuple6FVec ImageGeom::getBoundingBox()
+FloatVec6Type ImageGeom::getBoundingBox()
 {
-  return std::make_tuple(m_Origin[0], m_Origin[0] + (m_Dimensions[0] * m_Spacing[0]), m_Origin[1], m_Origin[1] + (m_Dimensions[1] * m_Spacing[1]), m_Origin[2],
-                         m_Origin[2] + (m_Dimensions[2] * m_Spacing[2]));
+  return {{m_Origin[0], m_Origin[0] + (m_Dimensions[0] * m_Spacing[0]), m_Origin[1], m_Origin[1] + (m_Dimensions[1] * m_Spacing[1]), m_Origin[2], m_Origin[2] + (m_Dimensions[2] * m_Spacing[2])}};
 }
 
 // -----------------------------------------------------------------------------
@@ -868,8 +819,7 @@ void ImageGeom::deleteElementCentroids()
 // -----------------------------------------------------------------------------
 int ImageGeom::findElementSizes()
 {
-  FloatVec3Type res = {0.0f, 0.0f, 0.0f};
-  std::tie(res[0], res[1], res[2]) = getSpacing();
+  FloatVec3Type res = getSpacing();
 
   if(res[0] <= 0.0f || res[1] <= 0.0f || res[2] <= 0.0f)
   {
@@ -964,8 +914,7 @@ void ImageGeom::getShapeFunctions(double pCoords[3], double* shape)
 void ImageGeom::findDerivatives(DoubleArrayType::Pointer field, DoubleArrayType::Pointer derivatives, Observable* observable)
 {
   m_ProgressCounter = 0;
-  size_t dims[3] = {0, 0, 0};
-  std::tie(dims[0], dims[1], dims[2]) = getDimensions();
+  SizeVec3Type dims = getDimensions();
 
   if(observable != nullptr)
   {
@@ -1006,10 +955,8 @@ int ImageGeom::writeGeometryToHDF5(hid_t parentId, bool SIMPL_NOT_USED(writeXdmf
 {
   herr_t err = 0;
   int64_t volDims[3] = {static_cast<int64_t>(getXPoints()), static_cast<int64_t>(getYPoints()), static_cast<int64_t>(getZPoints())};
-  FloatVec3Type spacing = {0.0f, 0.0f, 0.0f};
-  std::tie(spacing[0], spacing[1], spacing[2]) = getSpacing();
-  FloatVec3Type origin = {0.0f, 0.0f, 0.0f};
-  std::tie(origin[0], origin[1], origin[2]) = getOrigin();
+  FloatVec3Type spacing = getSpacing();
+  FloatVec3Type origin = getOrigin();
 
   int32_t rank = 1;
   hsize_t dims[1] = {3};
@@ -1051,10 +998,8 @@ int ImageGeom::writeXdmf(QTextStream& out, QString dcName, QString hdfFileName)
   herr_t err = 0;
 
   int64_t volDims[3] = {static_cast<int64_t>(getXPoints()), static_cast<int64_t>(getYPoints()), static_cast<int64_t>(getZPoints())};
-  FloatVec3Type spacing = {0.0f, 0.0f, 0.0f};
-  std::tie(spacing[0], spacing[1], spacing[2]) = getSpacing();
-  FloatVec3Type origin = {0.0f, 0.0f, 0.0f};
-  std::tie(origin[0], origin[1], origin[2]) = getOrigin();
+  FloatVec3Type spacing = getSpacing();
+  FloatVec3Type origin = getOrigin();
 
   out << "  <!-- *************** START OF " << dcName << " *************** -->"
       << "\n";
@@ -1091,11 +1036,8 @@ QString ImageGeom::getInfoString(SIMPL::InfoStringFormat format)
   QTextStream ss(&info);
 
   int64_t volDims[3] = {static_cast<int64_t>(getXPoints()), static_cast<int64_t>(getYPoints()), static_cast<int64_t>(getZPoints())};
-  FloatVec3Type spacing = {0.0f, 0.0f, 0.0f};
-  std::tie(spacing[0], spacing[1], spacing[2]) = getSpacing();
-  std::tie(spacing[0], spacing[1], spacing[2]) = getSpacing();
-  FloatVec3Type origin = {0.0f, 0.0f, 0.0f};
-  std::tie(origin[0], origin[1], origin[2]) = getOrigin();
+  FloatVec3Type spacing = getSpacing();
+  FloatVec3Type origin = getOrigin();
 
   float halfRes[3] = {spacing[0] / 2.0f, spacing[1] / 2.0f, spacing[2] / 2.0f};
 
@@ -1152,12 +1094,9 @@ IGeometry::Pointer ImageGeom::deepCopy(bool forceNoAllocate)
 {
   ImageGeom::Pointer imageCopy = ImageGeom::CreateGeometry(getName());
 
-  std::tuple<size_t, size_t, size_t> volDims = std::make_tuple(static_cast<size_t>(0), static_cast<size_t>(0), static_cast<size_t>(0));
-  std::tuple<float, float, float> spacing = std::make_tuple(1.0f, 1.0f, 1.0f);
-  std::tuple<float, float, float> origin = std::make_tuple(0.0f, 0.0f, 0.0f);
-  volDims = getDimensions();
-  spacing = getSpacing();
-  origin = getOrigin();
+  SizeVec3Type volDims = getDimensions();
+  FloatVec3Type spacing = getSpacing();
+  FloatVec3Type origin = getOrigin();
   imageCopy->setDimensions(volDims);
   imageCopy->setSpacing(spacing);
   imageCopy->setOrigin(origin);

--- a/Source/SIMPLib/Geometry/ImageGeom.h
+++ b/Source/SIMPLib/Geometry/ImageGeom.h
@@ -39,12 +39,6 @@
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
 #include "SIMPLib/Geometry/IGeometryGrid.h"
 
-namespace SIMPL {
-  using Tuple3FVec = std::tuple<float,float,float>;
-  using Tuple6FVec = std::tuple<float,float,float,float,float,float>;
-  using Tuple3SVec = std::tuple<size_t,size_t,size_t>;
-}
-
 /**
  * @brief The ImageGeom class represents a structured rectlinear grid
  */
@@ -58,19 +52,19 @@ class SIMPLib_EXPORT ImageGeom : public IGeometryGrid
   PYB11_ENUMERATION(ErrorType)
 
   PYB11_METHOD(void setDimensions OVERLOAD size_t,x size_t,y size_t,z)
-  PYB11_METHOD(SIMPL::Tuple3SVec getDimensions OVERLOAD CONST_METHOD)
+  PYB11_METHOD(SizeVec3Type getDimensions OVERLOAD CONST_METHOD)
 
   PYB11_METHOD(void setSpacing OVERLOAD float,x float,y float,z)
-  PYB11_METHOD(SIMPL::Tuple3FVec getSpacing OVERLOAD CONST_METHOD)
+  PYB11_METHOD(FloatVec3Type getSpacing OVERLOAD CONST_METHOD)
 
   PYB11_METHOD(size_t getXPoints)
   PYB11_METHOD(size_t getYPoints)
   PYB11_METHOD(size_t getZPoints)
 
   PYB11_METHOD(void setOrigin OVERLOAD float,x float,y float,z)
-  PYB11_METHOD(SIMPL::Tuple3FVec getOrigin OVERLOAD CONST_METHOD)
+  PYB11_METHOD(FloatVec3Type getOrigin OVERLOAD CONST_METHOD)
 
-  PYB11_METHOD(SIMPL::Tuple6FVec getBoundingBox OVERLOAD)
+  PYB11_METHOD(FloatVec6Type getBoundingBox OVERLOAD)
   // clang-format on
 
 public:
@@ -103,21 +97,15 @@ public:
   /**
    * @brief Sets/Gets the Spacing property
    */
-  // SIMPL_INSTANCE_VEC3_PROPERTY(float, Spacing)
-  SIMPL::Tuple3FVec getSpacing() const;
-  void getSpacing(FloatVec3Type& spacing) const;
+  FloatVec3Type getSpacing() const;
   void setSpacing(const FloatVec3Type& spacing);
-  void setSpacing(FloatVec3Type& spacing);
   void setSpacing(float x, float y, float z);
 
   /**
    * @brief Sets/Gets the Origin property
    */
-  // SIMPL_INSTANCE_VEC3_PROPERTY(float, Origin)
-  SIMPL::Tuple3FVec getOrigin() const;
-  void getOrigin(FloatVec3Type& origin) const;
+  FloatVec3Type getOrigin() const;
   void setOrigin(const FloatVec3Type& origin);
-  void setOrigin(FloatVec3Type& origin);
   void setOrigin(float x, float y, float z);
 
   /**
@@ -132,7 +120,7 @@ public:
    * @param boundingBox The bounding box will be stored in the input argument in the following order:
    * xMin, xMax, yMin, yMax, zMin, zMax
    */
-  SIMPL::Tuple6FVec getBoundingBox();
+  FloatVec6Type getBoundingBox();
 
   // -----------------------------------------------------------------------------
   // Inherited from IGeometry
@@ -283,12 +271,9 @@ public:
   // -----------------------------------------------------------------------------
   // Inherited from IGeometryGrid
   // -----------------------------------------------------------------------------
-  SIMPL::Tuple3SVec getDimensions() const override;
-  void getDimensions(SizeVec3Type& dims) const;
+  SizeVec3Type getDimensions() const override;
 
   void setDimensions(const SizeVec3Type& dims) override;
-  void setDimensions(SizeVec3Type& dims) override;
-  void setDimensions(const SIMPL::Tuple3SVec& dims) override;
   void setDimensions(size_t x, size_t y, size_t z);
 
   size_t getXPoints() override;

--- a/Source/SIMPLib/Geometry/ImageGeom.h
+++ b/Source/SIMPLib/Geometry/ImageGeom.h
@@ -321,7 +321,7 @@ public:
    * @return Int error code. There can be multiple failure mechanisms when doing
    * this calculation. Any return value != ErrorType::NoError is a failure to compute the indices.
    */
-  ErrorType computeCellIndex(float coords[3], size_t index[3]);
+  ErrorType computeCellIndex(const float coords[], size_t index[3]);
 
   /**
    * @brief computeCellIndex This method will compute the X, Y & Z Index based
@@ -345,7 +345,7 @@ public:
    * @return Int error code. There can be multiple failure mechanisms when doing
    * this calculation. Any return value != ErrorType::NoError is a failure to compute the indices.
    */
-  ErrorType computeCellIndex(float coords[3], size_t& index);
+  ErrorType computeCellIndex(const float coords[3], size_t& index);
 
 protected:
   ImageGeom();
@@ -361,7 +361,7 @@ protected:
    * @param preflight
    * @return
    */
-  int gatherMetaData(hid_t parentid, size_t volDims[3], float spacing[3], float origin[3], unsigned int spatialDims, QString geomName, bool preflight);
+  int gatherMetaData(hid_t parentid, size_t volDims[3], float spacing[3], float origin[3], unsigned int spatialDims, const QString& geomName, bool preflight);
 
   /**
    * @brief setElementsContaingVert

--- a/Source/SIMPLib/Geometry/RectGridGeom.cpp
+++ b/Source/SIMPLib/Geometry/RectGridGeom.cpp
@@ -90,8 +90,7 @@ public:
     std::vector<double> dValuesdEta(numComps);
     std::vector<double> dValuesdZeta(numComps);
 
-    size_t dims[3] = {0, 0, 0};
-    std::tie(dims[0], dims[1], dims[2]) = m_RectGrid->getDimensions();
+    SizeVec3Type dims = m_RectGrid->getDimensions();
 
     int64_t counter = 0;
     size_t totalElements = m_RectGrid->getNumberOfElements();
@@ -106,19 +105,19 @@ public:
           //  Xi derivatives (X)
           if(dims[0] == 1)
           {
-            findValuesForFiniteDifference(TwoDimensional, XDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(TwoDimensional, XDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(x == 0)
           {
-            findValuesForFiniteDifference(LeftSide, XDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(LeftSide, XDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(x == (dims[0] - 1))
           {
-            findValuesForFiniteDifference(RightSide, XDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(RightSide, XDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else
           {
-            findValuesForFiniteDifference(Centered, XDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(Centered, XDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
 
           xxi = factor * (xp[0] - xm[0]);
@@ -132,19 +131,19 @@ public:
           //  Eta derivatives (Y)
           if(dims[1] == 1)
           {
-            findValuesForFiniteDifference(TwoDimensional, YDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(TwoDimensional, YDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(y == 0)
           {
-            findValuesForFiniteDifference(LeftSide, YDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(LeftSide, YDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(y == (dims[1] - 1))
           {
-            findValuesForFiniteDifference(RightSide, YDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(RightSide, YDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else
           {
-            findValuesForFiniteDifference(Centered, YDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(Centered, YDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
 
           xeta = factor * (xp[0] - xm[0]);
@@ -158,19 +157,19 @@ public:
           //  Zeta derivatives (Z)
           if(dims[2] == 1)
           {
-            findValuesForFiniteDifference(TwoDimensional, ZDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(TwoDimensional, ZDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(z == 0)
           {
-            findValuesForFiniteDifference(LeftSide, ZDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(LeftSide, ZDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else if(z == (dims[2] - 1))
           {
-            findValuesForFiniteDifference(RightSide, ZDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(RightSide, ZDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
           else
           {
-            findValuesForFiniteDifference(Centered, ZDirection, x, y, z, dims, xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
+            findValuesForFiniteDifference(Centered, ZDirection, x, y, z, dims.data(), xp, xm, factor, numComps, plusValues, minusValues, fieldPtr);
           }
 
           xzeta = factor * (xp[0] - xm[0]);
@@ -437,7 +436,7 @@ RectGridGeom::Pointer RectGridGeom::CreateGeometry(const QString& name)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-SIMPL::Tuple3SVec RectGridGeom::getDimensions() const
+SizeVec3Type RectGridGeom::getDimensions() const
 {
   return m_Dimensions.toTuple();
 }
@@ -445,31 +444,7 @@ SIMPL::Tuple3SVec RectGridGeom::getDimensions() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void RectGridGeom::getDimensions(SizeVec3Type& dims) const
-{
-  dims = m_Dimensions;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
 void RectGridGeom::setDimensions(const SizeVec3Type& dims)
-{
-  m_Dimensions = dims;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void RectGridGeom::setDimensions(SizeVec3Type& dims)
-{
-  m_Dimensions = dims;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void RectGridGeom::setDimensions(const SIMPL::Tuple3SVec& dims)
 {
   m_Dimensions = dims;
 }
@@ -997,8 +972,7 @@ void RectGridGeom::getShapeFunctions(double pCoords[3], double* shape)
 void RectGridGeom::findDerivatives(DoubleArrayType::Pointer field, DoubleArrayType::Pointer derivatives, Observable* observable)
 {
   m_ProgressCounter = 0;
-  size_t dims[3] = {0, 0, 0};
-  std::tie(dims[0], dims[1], dims[2]) = getDimensions();
+  SizeVec3Type dims = getDimensions();
 
   if(observable != nullptr)
   {
@@ -1179,8 +1153,7 @@ IGeometry::Pointer RectGridGeom::deepCopy(bool forceNoAllocate)
 
   RectGridGeom::Pointer copy = RectGridGeom::CreateGeometry(getName());
 
-  size_t volDims[3] = { 0, 0, 0 };
-  std::tie(volDims[0], volDims[1], volDims[2]) = getDimensions();
+  SizeVec3Type volDims = getDimensions();
   copy->setDimensions(volDims);
   copy->setXBounds(xBounds);
   copy->setYBounds(yBounds);

--- a/Source/SIMPLib/Geometry/RectGridGeom.h
+++ b/Source/SIMPLib/Geometry/RectGridGeom.h
@@ -214,12 +214,8 @@ class SIMPLib_EXPORT RectGridGeom : public IGeometryGrid
 // -----------------------------------------------------------------------------
 // Inherited from IGeometryGrid
 // -----------------------------------------------------------------------------
-    SIMPL::Tuple3SVec getDimensions() const override;
-    void getDimensions(SizeVec3Type& dims) const;
-
     void setDimensions(const SizeVec3Type& dims) override;
-    void setDimensions(SizeVec3Type& dims) override;
-    void setDimensions(const SIMPL::Tuple3SVec& dims) override;
+    SizeVec3Type getDimensions() const override;
 
     size_t getXPoints() override;
     size_t getYPoints() override;

--- a/Source/SIMPLib/Geometry/Testing/Cxx/ImageGeomTest.cpp
+++ b/Source/SIMPLib/Geometry/Testing/Cxx/ImageGeomTest.cpp
@@ -40,7 +40,7 @@ public:
 
     geom->setDimensions(dims);
     geom->setOrigin(origin);
-    geom->getSpacing(res);
+    geom->setSpacing(res);
 
     float coords[3] = {3.5f, 9.23f, 12.78f};
     size_t indices[3] = {0, 0, 0};

--- a/Source/SIMPLib/Geometry/Testing/Cxx/ImageGeomTest.cpp
+++ b/Source/SIMPLib/Geometry/Testing/Cxx/ImageGeomTest.cpp
@@ -1,12 +1,11 @@
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <iostream>
 
 #include <QtCore/QFile>
 
 #include "SIMPLib/Geometry/ImageGeom.h"
-
 #include "SIMPLib/Testing/SIMPLTestFileLocations.h"
 #include "SIMPLib/Testing/UnitTestSupport.hpp"
 
@@ -42,7 +41,7 @@ public:
     geom->setOrigin(origin);
     geom->setSpacing(res);
 
-    float coords[3] = {3.5f, 9.23f, 12.78f};
+    float coords[3] = {2.5f, 9.23f, 12.78f};
     size_t indices[3] = {0, 0, 0};
     size_t index = 0;
     ImageGeom::ErrorType err = geom->computeCellIndex(coords, indices);
@@ -64,7 +63,7 @@ public:
     DREAM3D_REQUIRE(err == ImageGeom::ErrorType::XOutOfBoundsHigh)
 
     // Y Coord out of bounds
-    coords[0] = 3.5f;
+    coords[0] = 2.9f;
     coords[1] = 4.0f;
     err = geom->computeCellIndex(coords, indices);
     DREAM3D_REQUIRE(err == ImageGeom::ErrorType::YOutOfBoundsLow)
@@ -77,7 +76,7 @@ public:
     DREAM3D_REQUIRE(err == ImageGeom::ErrorType::YOutOfBoundsHigh)
 
     // Z Coord out of bounds
-    coords[0] = 3.5f;
+    coords[0] = 2.5f;
     coords[1] = 9.23f;
     coords[2] = 5.0f;
     err = geom->computeCellIndex(coords, indices);

--- a/Source/SIMPLib/ITK/Dream3DTemplateAliasMacro.h
+++ b/Source/SIMPLib/ITK/Dream3DTemplateAliasMacro.h
@@ -329,8 +329,7 @@
       ImageGeom::Pointer imageGeometry = getDataContainerArray()->getPrereqGeometryFromDataContainer<ImageGeom, AbstractFilter>(this, path.getDataContainerName());                                    \
       if(nullptr != imageGeometry)                                                                                                                                                                     \
       {                                                                                                                                                                                                \
-        QVector<size_t> tDims(3, 0);                                                                                                                                                                   \
-        std::tie(tDims[0], tDims[1], tDims[2]) = imageGeometry->getDimensions();                                                                                                                       \
+        QVector<size_t> tDims = imageGeometry->getDimensions().toContainer<QVector<size_t>>();                                                                                                         \
         if(getErrorCode() >= 0)                                                                                                                                                                        \
         {                                                                                                                                                                                              \
           QString type = ptr->getTypeAsString();                                                                                                                                                       \

--- a/Source/SIMPLib/ITK/itkBridge.h
+++ b/Source/SIMPLib/ITK/itkBridge.h
@@ -108,16 +108,14 @@ public:
     region.SetSize(size);
     importFilter->SetRegion(region);
 
-    FloatVec3Type sampleOrigin(0.0f, 0.0f, 0.0f);
-    m->getGeometryAs<ImageGeom>()->getOrigin(sampleOrigin);
+    FloatVec3Type sampleOrigin = m->getGeometryAs<ImageGeom>()->getOrigin();
     double origin[ImageProcessingConstants::ImageDimension];
     origin[0] = sampleOrigin[0]; // X coordinate
     origin[1] = sampleOrigin[1]; // Y coordinate
     origin[2] = sampleOrigin[2]; // Z coordinate
     importFilter->SetOrigin(origin);
 
-    FloatVec3Type voxelResolution(0.0f, 0.0f, 0.0f);
-    m->getGeometryAs<ImageGeom>()->getSpacing(voxelResolution);
+    FloatVec3Type voxelResolution = m->getGeometryAs<ImageGeom>()->getSpacing();
     double spacing[ImageProcessingConstants::ImageDimension];
     spacing[0] = voxelResolution[0]; // along X direction
     spacing[1] = voxelResolution[1]; // along Y direction
@@ -253,16 +251,14 @@ public:
     region.SetSize(size);
     importFilter->SetRegion(region);
 
-    FloatVec3Type sampleOrigin = {0.0f, 0.0f, 0.0f};
-    m->getGeometryAs<ImageGeom>()->getOrigin(sampleOrigin);
+    FloatVec3Type sampleOrigin = m->getGeometryAs<ImageGeom>()->getOrigin();
     double origin[ImageProcessingConstants::ImageDimension];
     origin[0] = sampleOrigin[0]; // X coordinate
     origin[1] = sampleOrigin[1]; // Y coordinate
     origin[2] = sampleOrigin[2]; // Z coordinate
     importFilter->SetOrigin(origin);
 
-    FloatVec3Type voxelResolution = {0.0f, 0.0f, 0.0f};
-    m->getGeometryAs<ImageGeom>()->getSpacing(voxelResolution);
+    FloatVec3Type voxelResolution = m->getGeometryAs<ImageGeom>()->getSpacing();
     double spacing[ImageProcessingConstants::ImageDimension];
     spacing[0] = voxelResolution[0]; // along X direction
     spacing[1] = voxelResolution[1]; // along Y direction
@@ -357,16 +353,14 @@ public:
     region.SetSize(size);
     importFilter->SetRegion(region);
 
-    FloatVec3Type sampleOrigin = {0.0f, 0.0f, 0.0f};
-    m->getGeometryAs<ImageGeom>()->getOrigin(sampleOrigin);
+    FloatVec3Type sampleOrigin = m->getGeometryAs<ImageGeom>()->getOrigin();
     double origin[ImageProcessingConstants::ImageDimension];
     origin[0] = sampleOrigin[0]; // X coordinate
     origin[1] = sampleOrigin[1]; // Y coordinate
     origin[2] = sampleOrigin[2]; // Z coordinate
     importFilter->SetOrigin(origin);
 
-    FloatVec3Type voxelResolution = {0.0f, 0.0f, 0.0f};
-    m->getGeometryAs<ImageGeom>()->getSpacing(voxelResolution);
+    FloatVec3Type voxelResolution = m->getGeometryAs<ImageGeom>()->getSpacing();
     double spacing[ImageProcessingConstants::ImageDimension];
     spacing[0] = voxelResolution[0]; // along X direction
     spacing[1] = voxelResolution[1]; // along Y direction

--- a/Source/SIMPLib/ITK/itkInPlaceDream3DDataToImageFilter.hxx
+++ b/Source/SIMPLib/ITK/itkInPlaceDream3DDataToImageFilter.hxx
@@ -80,14 +80,11 @@ void InPlaceDream3DDataToImageFilter< PixelType, VDimension >::GenerateOutputInf
     itkExceptionMacro("Error casting geometry!!!");
   }
   // Get data container properties
-  FloatVec3Type torigin;
+  FloatVec3Type torigin = imageGeom->getOrigin();
   // Setting spacing to 0 means dimension is not used. Used to know if
   // image is 2D or 3D. Setting dimensions to 0 leads to crashes
-  FloatVec3Type tspacing;
-  SizeVec3Type tDims;
-  imageGeom->getOrigin(torigin);
-  imageGeom->getSpacing(tspacing);
-  std::tie(tDims[0], tDims[1], tDims[2]) = imageGeom->getDimensions();
+  FloatVec3Type tspacing = imageGeom->getSpacing();
+  SizeVec3Type tDims = imageGeom->getDimensions();
   typename ImageType::PointType origin;
   typename ImageType::SizeType size;
   typename ImageType::SpacingType spacing;

--- a/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.hxx
+++ b/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.hxx
@@ -122,8 +122,7 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   QVector<size_t> cDims = ITKDream3DHelper::GetComponentsDimensions<PixelType>();
   IGeometry::Pointer geom = dataContainer->getGeometry();
   ImageGeom::Pointer imageGeom = std::dynamic_pointer_cast<ImageGeom>(geom);
-  QVector<size_t> tDims(3, 1);
-  std::tie(tDims[0], tDims[1], tDims[2]) = imageGeom->getDimensions();
+  QVector<size_t> tDims = imageGeom->getDimensions().toContainer<QVector<size_t>>();
   AttributeMatrix::Pointer attrMat;
   if( dataContainer->doesAttributeMatrixExist(m_AttributeMatrixArrayName.c_str()))
   {

--- a/Source/SIMPLib/TestFilters/FilterGroup00.cpp
+++ b/Source/SIMPLib/TestFilters/FilterGroup00.cpp
@@ -122,7 +122,7 @@ void TESTCLASSNAME::execute()
 AbstractFilter::Pointer TESTCLASSNAME::newFilterInstance(bool copyFilterParameters) const
 {
   TESTCLASSNAME::Pointer filter = TESTCLASSNAME::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/Wrapping/Python/Examples/Anisotropy/03_Adaptive Alignment Mutual Information - SEM Images.py
+++ b/Wrapping/Python/Examples/Anisotropy/03_Adaptive Alignment Mutual Information - SEM Images.py
@@ -40,7 +40,7 @@ def adaptive_alignment():
     fileListInfo = simpl.FileListInfo(3, 0, 0, 9, 0, sd.GetBuildDirectory() + "/Debug/Data/Anisotropy/tif",
                                       "AlMgSc-TD_", "", "tif")
     err = itkimageprocessingpy.itk_import_image_stack(dca, "SEMAlMgSc Data", "EBSD SEM Scan Data",
-                                                      simpl.FloatVec3(0, 0, 0), simpl.FloatVec3(1, 1, 1),
+                                                      simpl.FloatVec3Type(0, 0, 0), simpl.FloatVec3Type(1, 1, 1),
                                                       "", fileListInfo, 10, "ImageData")
     if err < 0:
         print("ITK Import Image Stack ErrorCondition %d" % err)

--- a/Wrapping/Python/Examples/Confidence_Index_Histogram.py
+++ b/Wrapping/Python/Examples/Confidence_Index_Histogram.py
@@ -22,11 +22,11 @@ def confidence_index_histogram_test():
         print("ReadAngData ErrorCondition: %d" % err)
 
     err = samplingpy.rotate_sample_ref_frame(dca, simpl.DataArrayPath("Small IN100 Slice 1", "EBSD Scan Data", ""),
-                                             simpl.FloatVec3(0.0, 1.0, 0.0), 180.0, False)
+                                             simpl.FloatVec3Type(0.0, 1.0, 0.0), 180.0, False)
     if err < 0:
         print("RotateSampleRefFrame ErrorCondition: %d" % err)
 
-    err = orientationanalysispy.rotate_euler_ref_frame(dca, simpl.FloatVec3(0.0, 0.0, 1.0), 90.0,
+    err = orientationanalysispy.rotate_euler_ref_frame(dca, simpl.FloatVec3Type(0.0, 0.0, 1.0), 90.0,
                                                        simpl.DataArrayPath("Small IN100 Slice 1", "EBSD Scan Data",
                                                                            "EulerAngles"))
     if err < 0:

--- a/Wrapping/Python/Examples/Core Filters/Append_Z_Slice.py
+++ b/Wrapping/Python/Examples/Core Filters/Append_Z_Slice.py
@@ -22,7 +22,7 @@ def append_z_slice():
     file_list_info = simpl.FileListInfo(2, 0, 11, 174, 1, sd.GetBuildDirectory() + "/Debug/Data/Image",
                                         "slice_", "", "tif")
     err = itkimageprocessingpy.itk_import_image_stack(dca, "RoboMet.3D Image Stack", "Optical Data",
-                                                      simpl.FloatVec3(0, 0, 0), simpl.FloatVec3(1, 1, 1),
+                                                      simpl.FloatVec3Type(0, 0, 0), simpl.FloatVec3Type(1, 1, 1),
                                                       "", file_list_info, 164, "ImageData")
     if err < 0:
         print("ITK Import Image Stack ErrorCondition %d" % err)

--- a/Wrapping/Python/Examples/Create_Lambert_Sphere_Surface.py
+++ b/Wrapping/Python/Examples/Create_Lambert_Sphere_Surface.py
@@ -36,9 +36,9 @@ def run_pipeline_test(dca):
     image_geom = simpl.CreateImageGeometry.New()
     image_geom.setDataContainerArray(dca)
     image_geom.SelectedDataContainer = "ImageDataContainer"
-    image_geom.Dimensions = simpl.IntVec3(101, 101, 1)
-    image_geom.Origin = simpl.FloatVec3(0, 0, 0)
-    image_geom.Resolution = simpl.FloatVec3(1, 1, 1)
+    image_geom.Dimensions = simpl.IntVec3Type(101, 101, 1)
+    image_geom.Origin = simpl.FloatVec3Type(0, 0, 0)
+    image_geom.Resolution = simpl.FloatVec3Type(1, 1, 1)
 
     # Create Attribute Matrix
     attribute_matrix = simpl.CreateAttributeMatrix.New()
@@ -110,8 +110,8 @@ def run_pythonic_test(dca):
     if err < 0:
         print("DataContainer ErrorCondition: %d" % err)
 
-    err = simplpy.create_image_geometry(dca, "ImageDataContainer", simpl.IntVec3(101, 101, 1), simpl.FloatVec3(0, 0, 0),
-                                        simpl.FloatVec3(1, 1, 1))
+    err = simplpy.create_image_geometry(dca, "ImageDataContainer", simpl.IntVec3Type(101, 101, 1), simpl.FloatVec3Type(0, 0, 0),
+                                        simpl.FloatVec3Type(1, 1, 1))
     if err < 0:
         print("ImageGeometry ErrorCondition: %d" % err)
 

--- a/Wrapping/Python/Examples/DREAM3DReview/Apply_Transformation_To_Geometry.py
+++ b/Wrapping/Python/Examples/DREAM3DReview/Apply_Transformation_To_Geometry.py
@@ -114,9 +114,9 @@ def apply_transform_to_geom():
     err = dream3dreviewpy.apply_transformation_to_geometry(dca, transformation_matrix,
                                                            simpl.DataArrayPath("", "", ""),
                                                            "DataContainer",
-                                                           5, simpl.FloatVec3(0.0, 0.0, 0.0),
-                                                           0, simpl.FloatVec3(0.0, 0.0, 0.0),
-                                                           simpl.FloatVec3(1.0, 1.0, 2.5))
+                                                           5, simpl.FloatVec3Type(0.0, 0.0, 0.0),
+                                                           0, simpl.FloatVec3Type(0.0, 0.0, 0.0),
+                                                           simpl.FloatVec3Type(1.0, 1.0, 2.5))
     if err < 0:
         print("ApplyTransformationToGeometry -  ErrorCondition: %d" % err)
 

--- a/Wrapping/Python/Examples/DREAM3DReview/Compute_Umeyama_Transform.py
+++ b/Wrapping/Python/Examples/DREAM3DReview/Compute_Umeyama_Transform.py
@@ -120,9 +120,9 @@ def compute_umeyama_transform_test():
     err = dream3dreviewpy.apply_transformation_to_geometry(dca, transformation_matrix,
                                                            simpl.DataArrayPath("", "", ""),
                                                            "DataContainer",
-                                                           2, simpl.FloatVec3(0.0, 0.0, 0.0),
-                                                           0, simpl.FloatVec3(0.0, 0.0, 0.0),
-                                                           simpl.FloatVec3(0.0, 0.0, 0.0))
+                                                           2, simpl.FloatVec3Type(0.0, 0.0, 0.0),
+                                                           0, simpl.FloatVec3Type(0.0, 0.0, 0.0),
+                                                           simpl.FloatVec3Type(0.0, 0.0, 0.0))
     if err < 0:
         print("ApplyTransformationToGeometry #1 -  ErrorCondition: %d" % err)
 
@@ -143,9 +143,9 @@ def compute_umeyama_transform_test():
                                                                                "TransformationData",
                                                                                "TransformationMatrix"),
                                                            "DataContainer",
-                                                           1, simpl.FloatVec3(0.0, 0.0, 0.0),
-                                                           0, simpl.FloatVec3(0.0, 0.0, 0.0),
-                                                           simpl.FloatVec3(0.0, 0.0, 0.0))
+                                                           1, simpl.FloatVec3Type(0.0, 0.0, 0.0),
+                                                           0, simpl.FloatVec3Type(0.0, 0.0, 0.0),
+                                                           simpl.FloatVec3Type(0.0, 0.0, 0.0))
     if err < 0:
         print("ApplyTransformationToGeometry #2 -  ErrorCondition: %d" % err)
 

--- a/Wrapping/Python/Examples/DREAM3DReview/Find_Attribute_Array_Statistics.py
+++ b/Wrapping/Python/Examples/DREAM3DReview/Find_Attribute_Array_Statistics.py
@@ -22,8 +22,8 @@ def find_array_statistics_test():
         print("DataContainer ErrorCondition: %d" % err)
 
     # Create Image Geometry
-    err = simplpy.create_image_geometry(dca, "ImageDataContainer", simpl.IntVec3(101, 101, 1), simpl.FloatVec3(0, 0, 0),
-                                        simpl.FloatVec3(1, 1, 1))
+    err = simplpy.create_image_geometry(dca, "ImageDataContainer", simpl.IntVec3Type(101, 101, 1), simpl.FloatVec3Type(0, 0, 0),
+                                        simpl.FloatVec3Type(1, 1, 1))
     if err < 0:
         print("ImageGeometry ErrorCondition: %d" % err)
 

--- a/Wrapping/Python/Examples/DREAM3DReview/Find_Element_Centroids.py
+++ b/Wrapping/Python/Examples/DREAM3DReview/Find_Element_Centroids.py
@@ -20,8 +20,8 @@ def find_element_centroids():
         print("DataContainer ErrorCondition: %d" % err)
 
     # Create Image Geometry
-    err = simplpy.create_image_geometry(dca, "ImageDataContainer", simpl.IntVec3(101, 101, 1), simpl.FloatVec3(0, 0, 0),
-                                        simpl.FloatVec3(1, 1, 1))
+    err = simplpy.create_image_geometry(dca, "ImageDataContainer", simpl.IntVec3Type(101, 101, 1), simpl.FloatVec3Type(0, 0, 0),
+                                        simpl.FloatVec3Type(1, 1, 1))
     if err < 0:
         print("ImageGeometry ErrorCondition: %d" % err)
 

--- a/Wrapping/Python/Examples/EBSD/Reconstruction/03 SmallIN100 Alignment.py
+++ b/Wrapping/Python/Examples/EBSD/Reconstruction/03 SmallIN100 Alignment.py
@@ -67,7 +67,7 @@ def small_in100_alignment():
         print("AlignSectionsFeatureCentroid %d" % err)
 
     # Generate IPF Colors
-    err = orientation_analysis.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientation_analysis.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                    simpl.DataArrayPath("Small IN100", "EBSD Scan Data", "Phases"),
                                                    simpl.DataArrayPath("Small IN100", "EBSD Scan Data", "EulerAngles"),
                                                    simpl.DataArrayPath("Small IN100", "Phase Data",

--- a/Wrapping/Python/Examples/EBSD/Reconstruction/04 SmallIN100 Presegmentation Processing.py
+++ b/Wrapping/Python/Examples/EBSD/Reconstruction/04 SmallIN100 Presegmentation Processing.py
@@ -83,7 +83,7 @@ def small_in100_presegmentation_processing():
     sc.RemoveArrays(dca, [("Small IN100", "EBSD Scan Data", "IPFColor")])
 
     # Generate IPF Colors
-    err = orientation_analysis.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientation_analysis.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                    simpl.DataArrayPath("Small IN100", "EBSD Scan Data", "Phases"),
                                                    simpl.DataArrayPath("Small IN100", "EBSD Scan Data", "EulerAngles"),
                                                    simpl.DataArrayPath("Small IN100", "Phase Data",

--- a/Wrapping/Python/Examples/EBSD/Statistics/05 SmallIN100 Crystallographic Statistics.py
+++ b/Wrapping/Python/Examples/EBSD/Statistics/05 SmallIN100 Crystallographic Statistics.py
@@ -141,8 +141,8 @@ def small_in100_cryst_stats():
     err = orientation_analysis.find_schmids(dca, simpl.DataArrayPath("Small IN100", "Grain Data", "Phases"),
                                             simpl.DataArrayPath("Small IN100", "Phase Data", "CrystalStructures"),
                                             simpl.DataArrayPath("Small IN100", "Grain Data", "AvgQuats"),
-                                            "Schmids", "SlipSystems", "Poles", "", "", simpl.FloatVec3(1, 1, 1),
-                                            False, False, simpl.FloatVec3(1, 1, 1), simpl.FloatVec3(1, 1, 1))
+                                            "Schmids", "SlipSystems", "Poles", "", "", simpl.FloatVec3Type(1, 1, 1),
+                                            False, False, simpl.FloatVec3Type(1, 1, 1), simpl.FloatVec3Type(1, 1, 1))
     if err < 0:
         print("FindSchmids ErrorCondition %d" % err)
 
@@ -177,7 +177,7 @@ def small_in100_cryst_stats():
                                                                simpl.DataArrayPath("Small IN100", "EBSD Scan Data",
                                                                                    "Quats"),
                                                                "KernelAverageMisorientations",
-                                                               simpl.IntVec3(1, 1, 1))
+                                                               simpl.IntVec3Type(1, 1, 1))
     if err < 0:
         print("FindKernelAvgMisorientations ErrorCondition %d" % err)
 

--- a/Wrapping/Python/Examples/Edax_IPF_Colors.py
+++ b/Wrapping/Python/Examples/Edax_IPF_Colors.py
@@ -26,12 +26,12 @@ def color_data_change_test():
 
     # Rotate Sample Reference Frame
     err = samplingpy.rotate_sample_ref_frame(dca, simpl.DataArrayPath("EBSD Scan", "Scan Data", ""),
-                                             simpl.FloatVec3(0.0, 1.0, 0.0), 180.0, False)
+                                             simpl.FloatVec3Type(0.0, 1.0, 0.0), 180.0, False)
     if err < 0:
         print("RotateSampleRefFrame ErrorCondition: %d" % err)
 
     # Rotate Euler Reference Frame
-    err = orientationanalysispy.rotate_euler_ref_frame(dca, simpl.FloatVec3(0.0, 0.0, 1.0), 90.0,
+    err = orientationanalysispy.rotate_euler_ref_frame(dca, simpl.FloatVec3Type(0.0, 0.0, 1.0), 90.0,
                                                        simpl.DataArrayPath("EBSD Scan", "Scan Data", "EulerAngles"))
     if err < 0:
         print("RotateEulerRefFrame ErrorCondition: %d" % err)
@@ -42,7 +42,7 @@ def color_data_change_test():
         print("MultiThresholdObjects ErrorCondition: %d" % err)
 
     # Generate IPF Colors
-    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                     simpl.DataArrayPath("EBSD Scan", "Scan Data", "Phases"),
                                                     simpl.DataArrayPath("EBSD Scan", "Scan Data", "EulerAngles"),
                                                     simpl.DataArrayPath("EBSD Scan",

--- a/Wrapping/Python/Examples/Export_Small_IN100_ODF_Data.py
+++ b/Wrapping/Python/Examples/Export_Small_IN100_ODF_Data.py
@@ -46,7 +46,7 @@ def pipeline_test(dca):
     rotate_euler_ref_frame = orientationanalysis.RotateEulerRefFrame.New()
     rotate_euler_ref_frame.setDataContainerArray(dca)
     rotate_euler_ref_frame.RotationAngle = 90.0
-    rotate_euler_ref_frame.RotationAxis = simpl.FloatVec3(0.0, 0.0, 1.0)
+    rotate_euler_ref_frame.RotationAxis = simpl.FloatVec3Type(0.0, 0.0, 1.0)
     rotate_euler_ref_frame.CellEulerAnglesArrayPath = simpl.DataArrayPath("Small IN100 Slice 1", "EBSD Scan Data",
                                                                        "EulerAngles")
     rotate_euler_ref_frame.preflight()
@@ -61,7 +61,7 @@ def pipeline_test(dca):
     rotate_sample_ref_frame = sampling.RotateSampleRefFrame.New()
     rotate_sample_ref_frame.setDataContainerArray(dca)
     rotate_sample_ref_frame.RotationAngle = 180.0
-    rotate_sample_ref_frame.RotationAxis = simpl.FloatVec3(0.0, 1.0, 0.0)
+    rotate_sample_ref_frame.RotationAxis = simpl.FloatVec3Type(0.0, 1.0, 0.0)
     rotate_sample_ref_frame.CellAttributeMatrixPath = simpl.DataArrayPath("Small IN100 Slice 1", "EBSD Scan Data", "")
     rotate_sample_ref_frame.preflight()
     print("  Preflight Error Code: %s" % rotate_sample_ref_frame.ErrorCondition)
@@ -143,7 +143,7 @@ def pythonic_test(dca):
     if err < 0:
         print("ReadAngData ErrorCondition: %d" % err)
 
-    err = orientationanalysis.rotate_euler_ref_frame(dca, simpl.FloatVec3(0.0, 0.0, 1.0), 90.0,
+    err = orientationanalysis.rotate_euler_ref_frame(dca, simpl.FloatVec3Type(0.0, 0.0, 1.0), 90.0,
                                                      simpl.DataArrayPath("Small IN100 Slice 1",
                                                                          "EBSD Scan Data", "EulerAngles"))
     if err < 0:
@@ -151,7 +151,7 @@ def pythonic_test(dca):
 
     err = sampling.rotate_sample_ref_frame(dca,
                                            simpl.DataArrayPath("Small IN100 Slice 1", "EBSD Scan Data", ""),
-                                           simpl.FloatVec3(0.0, 1.0, 0.0), 180.0, False)
+                                           simpl.FloatVec3Type(0.0, 1.0, 0.0), 180.0, False)
     if err < 0:
         print("RotateSampleRefFrame ErrorCondition: %d" % err)
 

--- a/Wrapping/Python/Examples/INL_Export.py
+++ b/Wrapping/Python/Examples/INL_Export.py
@@ -27,12 +27,12 @@ def inl_export():
 
     # Rotate Sample Reference Frame
     err = samplingpy.rotate_sample_ref_frame(dca, simpl.DataArrayPath("Small IN100 Slice 1", "EBSD Scan Data", ""),
-                                             simpl.FloatVec3(0.0, 1.0, 0.0), 180.0, False)
+                                             simpl.FloatVec3Type(0.0, 1.0, 0.0), 180.0, False)
     if err < 0:
         print("RotateSampleRefFrame ErrorCondition: %d" % err)
 
     # Rotate Euler Reference Frame
-    err = orientationanalysispy.rotate_euler_ref_frame(dca, simpl.FloatVec3(0.0, 0.0, 1.0), 90.0,
+    err = orientationanalysispy.rotate_euler_ref_frame(dca, simpl.FloatVec3Type(0.0, 0.0, 1.0), 90.0,
                                                        simpl.DataArrayPath("Small IN100 Slice 1", "EBSD Scan Data",
                                                                            "EulerAngles"))
     if err < 0:
@@ -132,7 +132,7 @@ def inl_export():
         print("INL Writer ErrorCondition %d" % err)
 
     # Generate IPF Colors
-    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                     simpl.DataArrayPath("Small IN100 Slice 1",
                                                                         "EBSD Scan Data", "Phases"),
                                                     simpl.DataArrayPath("Small IN100 Slice 1",

--- a/Wrapping/Python/Examples/Image Reconstruction/01 - Image Initial Visualization.py
+++ b/Wrapping/Python/Examples/Image Reconstruction/01 - Image Initial Visualization.py
@@ -21,7 +21,7 @@ def image_initial_visualization():
     file_list_info = simpl.FileListInfo(2, 0, 11, 174, 1, sd.GetBuildDirectory() + "/Debug/Data/Image",
                                         "slice_", "", "tif")
     err = itkimageprocessingpy.itk_import_image_stack(dca, "RoboMet.3D Image Stack", "Optical Data",
-                                                      simpl.FloatVec3(0, 0, 0), simpl.FloatVec3(1, 1, 1),
+                                                      simpl.FloatVec3Type(0, 0, 0), simpl.FloatVec3Type(1, 1, 1),
                                                       "", file_list_info, 164, "ImageData")
     if err < 0:
         print("ITK Import Image Stack ErrorCondition %d" % err)

--- a/Wrapping/Python/Examples/Image Reconstruction/02 - Image Segmentation.py
+++ b/Wrapping/Python/Examples/Image Reconstruction/02 - Image Segmentation.py
@@ -39,7 +39,7 @@ def image_segmentation():
     file_list_info = simpl.FileListInfo(2, 0, 11, 174, 1, sd.GetBuildDirectory() + "/Debug/Data/Image",
                                         "slice_", "", "tif")
     err = itkimageprocessingpy.itk_import_image_stack(dca, data_container_name, attr_matrix_name,
-                                                      simpl.FloatVec3(0, 0, 0), simpl.FloatVec3(1, 1, 1),
+                                                      simpl.FloatVec3Type(0, 0, 0), simpl.FloatVec3Type(1, 1, 1),
                                                       "", file_list_info, 164, "ImageData")
     if err < 0:
         print("ITK Import Image Stack ErrorCondition %d" % err)

--- a/Wrapping/Python/Examples/Import_ASCII.py
+++ b/Wrapping/Python/Examples/Import_ASCII.py
@@ -42,8 +42,8 @@ def import_ascii():
 
     # Create Geometry
     err = sc.CreateGeometry(dca, sc.ArrayHandling.CopyArrays, simpl.IGeometry.Type.Image, "DataContainer", False, 
-                            dimensions=simpl.IntVec3(189, 201, 1), origin=simpl.FloatVec3(0, 0, 0),
-                            resolution=simpl.FloatVec3(0.25, 0.25, 1), cell_attribute_matrix_name="CellData")
+                            dimensions=simpl.IntVec3Type(189, 201, 1), origin=simpl.FloatVec3Type(0, 0, 0),
+                            resolution=simpl.FloatVec3Type(0.25, 0.25, 1), cell_attribute_matrix_name="CellData")
     if err < 0:
         print("Create Geometry -  ErrorCondition: %d" % err)
 
@@ -89,7 +89,7 @@ def import_ascii():
         print("ReplaceValueInArray ErrorCondition %d" % err)
 
     # Generate IPF Colors
-    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                     simpl.DataArrayPath("DataContainer", "CellData", "Phase"),
                                                     simpl.DataArrayPath("DataContainer", "CellData", "Eulers"),
                                                     simpl.DataArrayPath("DataContainer",

--- a/Wrapping/Python/Examples/Misc_Filters.py
+++ b/Wrapping/Python/Examples/Misc_Filters.py
@@ -44,12 +44,12 @@ def misc_filters_test():
 
     # Rotate Sample Reference Frame
     err = samplingpy.rotate_sample_ref_frame(dca, simpl.DataArrayPath("Small IN100 Slice 1", "EBSD_Data", ""),
-                                             simpl.FloatVec3(0.0, 1.0, 0.0), 180.0, False)
+                                             simpl.FloatVec3Type(0.0, 1.0, 0.0), 180.0, False)
     if err < 0:
         print("RotateSampleRefFrame ErrorCondition: %d" % err)
 
     # Rotate Euler Reference Frame
-    err = orientationanalysispy.rotate_euler_ref_frame(dca, simpl.FloatVec3(0.0, 0.0, 1.0), 90.0,
+    err = orientationanalysispy.rotate_euler_ref_frame(dca, simpl.FloatVec3Type(0.0, 0.0, 1.0), 90.0,
                                                        simpl.DataArrayPath("Small IN100 Slice 1", "EBSD_Data",
                                                                            "EulerAngles"))
     if err < 0:

--- a/Wrapping/Python/Examples/Synthetic/01_Single Cubic Phase Equiaxed.py
+++ b/Wrapping/Python/Examples/Synthetic/01_Single Cubic Phase Equiaxed.py
@@ -111,9 +111,9 @@ def single_cubic_phase_equiaxed():
 
     # Initialize Synthetic Volume
     err = syntheticbuilding.initialize_synthetic_volume(dca, "SyntheticVolumeDataContainer", "CellData",
-                                                        "CellEnsembleMatrixName", simpl.IntVec3(128, 128, 128),
-                                                        simpl.FloatVec3(0.5, 0.5, 0.5),
-                                                        simpl.FloatVec3(0, 0, 0),
+                                                        "CellEnsembleMatrixName", simpl.IntVec3Type(128, 128, 128),
+                                                        simpl.FloatVec3Type(0.5, 0.5, 0.5),
+                                                        simpl.FloatVec3Type(0, 0, 0),
                                                         simpl.DataArrayPath("StatsGeneratorDataContainer",
                                                                             "CellEnsembleData", "Statistics"),
                                                         simpl.DataArrayPath("StatsGeneratorDataContainer",
@@ -187,7 +187,7 @@ def single_cubic_phase_equiaxed():
         print("MatchCrystallography ErrorCondition: %d" % err)
 
     # Generate IPF Colors
-    err = orientationanalysis.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientationanalysis.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                   simpl.DataArrayPath("SyntheticVolumeDataContainer",
                                                                       "CellData", "Phases"),
                                                   simpl.DataArrayPath("SyntheticVolumeDataContainer",

--- a/Wrapping/Python/Examples/Synthetic/02_Single Hexagonal Phase Equiaxed.py
+++ b/Wrapping/Python/Examples/Synthetic/02_Single Hexagonal Phase Equiaxed.py
@@ -37,9 +37,9 @@ def single_hexagonal_phase_equiaxed():
 
     # Initialize Synthetic Volume
     err = syntheticbuilding.initialize_synthetic_volume(dca, "SyntheticVolumeDataContainer", "CellData",
-                                                        "CellEnsembleMatrixName", simpl.IntVec3(128, 128, 128),
-                                                        simpl.FloatVec3(0.5, 0.5, 0.5),
-                                                        simpl.FloatVec3(0, 0, 0),
+                                                        "CellEnsembleMatrixName", simpl.IntVec3Type(128, 128, 128),
+                                                        simpl.FloatVec3Type(0.5, 0.5, 0.5),
+                                                        simpl.FloatVec3Type(0, 0, 0),
                                                         simpl.DataArrayPath("StatsGeneratorDataContainer",
                                                                             "CellEnsembleData", "Statistics"),
                                                         simpl.DataArrayPath("StatsGeneratorDataContainer",
@@ -112,7 +112,7 @@ def single_hexagonal_phase_equiaxed():
         print("MatchCrystallography ErrorCondition: %d" % err)
 
     # Generate IPF Colors
-    err = orientationanalysis.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientationanalysis.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                   simpl.DataArrayPath("SyntheticVolumeDataContainer",
                                                                       "CellData", "Phases"),
                                                   simpl.DataArrayPath("SyntheticVolumeDataContainer",

--- a/Wrapping/Python/Examples/Synthetic/03_Single Cubic Phase Rolled.py
+++ b/Wrapping/Python/Examples/Synthetic/03_Single Cubic Phase Rolled.py
@@ -36,9 +36,9 @@ def single_cubic_phase_rolled():
 
     # Initialize Synthetic Volume
     err = syntheticbuilding.initialize_synthetic_volume(dca, "SyntheticVolumeDataContainer", "CellData",
-                                                        "CellEnsembleMatrixName", simpl.IntVec3(128, 128, 128),
-                                                        simpl.FloatVec3(0.5, 0.5, 0.5),
-                                                        simpl.FloatVec3(0, 0, 0),
+                                                        "CellEnsembleMatrixName", simpl.IntVec3Type(128, 128, 128),
+                                                        simpl.FloatVec3Type(0.5, 0.5, 0.5),
+                                                        simpl.FloatVec3Type(0, 0, 0),
                                                         simpl.DataArrayPath("StatsGeneratorDataContainer",
                                                                             "CellEnsembleData", "Statistics"),
                                                         simpl.DataArrayPath("StatsGeneratorDataContainer",
@@ -111,7 +111,7 @@ def single_cubic_phase_rolled():
         print("MatchCrystallography ErrorCondition: %d" % err)
 
     # Generate IPF Colors
-    err = orientationanalysis.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientationanalysis.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                   simpl.DataArrayPath("SyntheticVolumeDataContainer",
                                                                       "CellData", "Phases"),
                                                   simpl.DataArrayPath("SyntheticVolumeDataContainer",

--- a/Wrapping/Python/Examples/Synthetic/04_Two Phase Cubic Hexagonal Particles Equiaxed.py
+++ b/Wrapping/Python/Examples/Synthetic/04_Two Phase Cubic Hexagonal Particles Equiaxed.py
@@ -50,16 +50,16 @@ def two_phase_test():
                                simpl.DynamicTableData([simpl.VectorDouble([0, 0, 0, 0, 0])], ["Euler 1", "Euler 2",
                                                                                               "Euler 3", "Weight",
                                                                                               "Sigma"], ["0"]),
-                               simpl.FloatVec2(10, 80), 50, simpl.FloatVec3(100, 100, 100))
+                               simpl.FloatVec2Type(10, 80), 50, simpl.FloatVec3Type(100, 100, 100))
 
     if err < 0:
         print("Precipitate StatsData ErrorCondition: %d" % err)
 
     # Initialize Synthetic Volume
     err = syntheticbuilding.initialize_synthetic_volume(dca, "SyntheticVolumeDataContainer", "CellData",
-                                                        "CellEnsembleMatrixName", simpl.IntVec3(128, 128, 128),
-                                                        simpl.FloatVec3(0.5, 0.5, 0.5),
-                                                        simpl.FloatVec3(0, 0, 0),
+                                                        "CellEnsembleMatrixName", simpl.IntVec3Type(128, 128, 128),
+                                                        simpl.FloatVec3Type(0.5, 0.5, 0.5),
+                                                        simpl.FloatVec3Type(0, 0, 0),
                                                         simpl.DataArrayPath("StatsGeneratorDataContainer",
                                                                             "CellEnsembleData", "Statistics"),
                                                         simpl.DataArrayPath("StatsGeneratorDataContainer",
@@ -166,7 +166,7 @@ def two_phase_test():
         print("MatchCrystallography ErrorCondition: %d" % err)
 
     # Generate IPF Colors
-    err = orientationanalysis.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientationanalysis.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                   simpl.DataArrayPath("SyntheticVolumeDataContainer",
                                                                       "CellData", "Phases"),
                                                   simpl.DataArrayPath("SyntheticVolumeDataContainer",

--- a/Wrapping/Python/Examples/Synthetic/06_SmallN100_Synthetic.py
+++ b/Wrapping/Python/Examples/Synthetic/06_SmallN100_Synthetic.py
@@ -231,9 +231,9 @@ def small_in100_test():
 
     # Initialize Synthetic Volume
     err = syntheticbuilding.initialize_synthetic_volume(dca, "SyntheticVolumeDataContainer", "EBSD Scan Data",
-                                                        "Phase Data", simpl.IntVec3(128, 128, 128),
-                                                        simpl.FloatVec3(0.25, 0.25, 0.25),
-                                                        simpl.FloatVec3(0, 0, 0),
+                                                        "Phase Data", simpl.IntVec3Type(128, 128, 128),
+                                                        simpl.FloatVec3Type(0.25, 0.25, 0.25),
+                                                        simpl.FloatVec3Type(0, 0, 0),
                                                         simpl.DataArrayPath("Small IN100",
                                                                             "Phase Data", "Statistics"),
                                                         simpl.DataArrayPath("Small IN100",
@@ -307,7 +307,7 @@ def small_in100_test():
         print("MatchCrystallography ErrorCondition: %d" % err)
 
     # Generate IPF Colors
-    err = orientationanalysis.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientationanalysis.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                   simpl.DataArrayPath("SyntheticVolumeDataContainer",
                                                                       "EBSD Scan Data", "Phases"),
                                                   simpl.DataArrayPath("SyntheticVolumeDataContainer",

--- a/Wrapping/Python/Examples/Threshold2_MoveData.py
+++ b/Wrapping/Python/Examples/Threshold2_MoveData.py
@@ -29,11 +29,11 @@ def threshold2_move_data_test():
         print("ReadAngData ErrorCondition: %d" % err)
 
     err = sampling.rotate_sample_ref_frame(dca, simpl.DataArrayPath("Small IN100", "EBSD Scan Data", ""),
-                                           simpl.FloatVec3(0.0, 1.0, 0.0), 180.0, False)
+                                           simpl.FloatVec3Type(0.0, 1.0, 0.0), 180.0, False)
     if err < 0:
         print("RotateSampleRefFrame ErrorCondition: %d" % err)
 
-    err = orientationanalysis.rotate_euler_ref_frame(dca, simpl.FloatVec3(0.0, 0.0, 1.0), 90.0,
+    err = orientationanalysis.rotate_euler_ref_frame(dca, simpl.FloatVec3Type(0.0, 0.0, 1.0), 90.0,
                                                      simpl.DataArrayPath("Small IN100", "EBSD Scan Data",
                                                                          "EulerAngles"))
     if err < 0:
@@ -89,8 +89,8 @@ def threshold2_move_data_test():
         print("PipelineAnnotation 3 ErrorCondition: %d" % err)
 
         # Set Origin & Resolution (Image)
-    err = simplpy.set_origin_resolution_image_geom(dca, "Small IN100", True, simpl.FloatVec3(50, 25, 10),
-                                                   True, simpl.FloatVec3(1, 1, 25))
+    err = simplpy.set_origin_resolution_image_geom(dca, "Small IN100", True, simpl.FloatVec3Type(50, 25, 10),
+                                                   True, simpl.FloatVec3Type(1, 1, 25))
     if err < 0:
         print("SetOriginResolutionImageGeom ErrorCondition: %d" % err)
 
@@ -105,7 +105,7 @@ def threshold2_move_data_test():
         print("PipelineAnnotation 4 ErrorCondition: %d" % err)
 
         # Change Scaling of Volume
-    err = simplpy.scale_volume(dca, "Small IN100", "", True, False, simpl.FloatVec3(2, 2, 2))
+    err = simplpy.scale_volume(dca, "Small IN100", "", True, False, simpl.FloatVec3Type(2, 2, 2))
     if err < 0:
         print("ScaleVolume ErrorCondition: %d" % err)
 

--- a/Wrapping/Python/Examples/Transformation Phase/InsertTransformationPhase.py
+++ b/Wrapping/Python/Examples/Transformation Phase/InsertTransformationPhase.py
@@ -37,9 +37,9 @@ def insert_transformation_phase():
 
     # Initialize Synthetic Volume
     err = syntheticbuildingpy.initialize_synthetic_volume(dca, "SyntheticVolumeDataContainer", "CellData",
-                                                          "CellEnsembleData", simpl.IntVec3(128, 128, 128),
-                                                          simpl.FloatVec3(0.5, 0.5, 0.5),
-                                                          simpl.FloatVec3(0, 0, 0),
+                                                          "CellEnsembleData", simpl.IntVec3Type(128, 128, 128),
+                                                          simpl.FloatVec3Type(0.5, 0.5, 0.5),
+                                                          simpl.FloatVec3Type(0, 0, 0),
                                                           simpl.DataArrayPath("StatsGeneratorDataContainer",
                                                                               "CellEnsembleData", "Statistics"),
                                                           simpl.DataArrayPath("StatsGeneratorDataContainer",
@@ -133,7 +133,7 @@ def insert_transformation_phase():
     # Possible enums: trans_crystal_struct
     # May want to use a "dictionary" for the numerical portion in helper function
     err = transformationphasepy.insert_transformation_phases(dca,
-                                                             1, 1, 60, simpl.FloatVec3(1, 1, 1), True, True, 1, 0.2, 1,
+                                                             1, 1, 60, simpl.FloatVec3Type(1, 1, 1), True, True, 1, 0.2, 1,
                                                              0,
                                                              simpl.DataArrayPath("StatsGeneratorDataContainer",
                                                                                  "CellEnsembleData", ""),
@@ -187,7 +187,7 @@ def insert_transformation_phase():
                           ("SyntheticVolumeDataContainer", "CellFeatureData", "Volumes2")])
 
     # Generate IPF Colors
-    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                     simpl.DataArrayPath("SyntheticVolumeDataContainer",
                                                                         "CellData", "Phases"),
                                                     simpl.DataArrayPath("SyntheticVolumeDataContainer",

--- a/Wrapping/Python/Examples/TxCopper_Exposed.py
+++ b/Wrapping/Python/Examples/TxCopper_Exposed.py
@@ -28,7 +28,7 @@ def txcopper_exposed():
 
     # Rotate Sample Reference Frame
     err = samplingpy.rotate_sample_ref_frame(dca, simpl.DataArrayPath(data_container_name, "EBSD Scan Data", ""),
-                                             simpl.FloatVec3(0.0, 1.0, 0.0), 180.0, False)
+                                             simpl.FloatVec3Type(0.0, 1.0, 0.0), 180.0, False)
     if err < 0:
         print("RotateSampleRefFrame ErrorCondition: %d" % err)
  
@@ -55,7 +55,7 @@ def txcopper_exposed():
         print("MultiThresholdObjects ErrorCondition: %d" % err)
     
     # Generate IPF Colors
-    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                     simpl.DataArrayPath(data_container_name,
                                                                         "EBSD Scan Data", "Phases"),
                                                     simpl.DataArrayPath(data_container_name,

--- a/Wrapping/Python/Examples/TxCopper_Unexposed.py
+++ b/Wrapping/Python/Examples/TxCopper_Unexposed.py
@@ -28,7 +28,7 @@ def txcopper_unexposed():
 
     # Rotate Sample Reference Framce
     err = samplingpy.rotate_sample_ref_frame(dca, simpl.DataArrayPath(data_container_name, "EBSD Scan Data", ""),
-                                             simpl.FloatVec3(0.0, 1.0, 0.0), 180.0, False)
+                                             simpl.FloatVec3Type(0.0, 1.0, 0.0), 180.0, False)
     if err < 0:
         print("RotateSampleRefFrame ErrorCondition: %d" % err)
  
@@ -55,7 +55,7 @@ def txcopper_unexposed():
         print("MultiThresholdObjects ErrorCondition: %d" % err)
     
     # Generate IPF Colors
-    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3(0, 0, 1),
+    err = orientationanalysispy.generate_ipf_colors(dca, simpl.FloatVec3Type(0, 0, 1),
                                                     simpl.DataArrayPath(data_container_name,
                                                                         "EBSD Scan Data", "Phases"),
                                                     simpl.DataArrayPath(data_container_name,

--- a/Wrapping/Python/SIMPL/simpl_helpers.py
+++ b/Wrapping/Python/SIMPL/simpl_helpers.py
@@ -209,8 +209,8 @@ def CreateDataContainerProxy(dca, data_array_paths):
     return dcap
 
 
-def CreateGeometry(data_container_array, array_handling, geometry_type, data_container_name, treat_warnings_as_errors, dimensions = simpl.IntVec3(0,0,0),
-origin = simpl.FloatVec3(0,0,0), resolution = simpl.FloatVec3(0,0,0), cell_attribute_matrix_name="", x_bounds_array_path = simpl.DataArrayPath("", "", ""),
+def CreateGeometry(data_container_array, array_handling, geometry_type, data_container_name, treat_warnings_as_errors, dimensions = simpl.IntVec3Type(0,0,0),
+origin = simpl.FloatVec3Type(0,0,0), resolution = simpl.FloatVec3Type(0,0,0), cell_attribute_matrix_name="", x_bounds_array_path = simpl.DataArrayPath("", "", ""),
 y_bounds_array_path = simpl.DataArrayPath("", "", ""), z_bounds_array_path = simpl.DataArrayPath("", "", ""), 
 shared_vertex_list_array_path = simpl.DataArrayPath("", "", ""), vertex_attribute_matrix_name = "", shared_edge_list_array_path = simpl.DataArrayPath("", "", ""),
 edge_attribute_matrix_name = "", shared_tri_list_array_path = simpl.DataArrayPath("", "", ""), face_attribute_matrix_name="",

--- a/Wrapping/Python/Testing/PipelineTest.py
+++ b/Wrapping/Python/Testing/PipelineTest.py
@@ -18,9 +18,9 @@ def Pipeline1():
 
   createImageGeom = simpl.CreateImageGeometry.New()
   createImageGeom.SelectedDataContainer = createDataContainer.DataContainerName
-  createImageGeom.Dimensions = simpl.IntVec3(101, 101, 1)
-  createImageGeom.Resolution = simpl.FloatVec3(1.0, 1.0, 1.0)
-  createImageGeom.Origin = simpl.FloatVec3(0.0, 0.0, 0.0)
+  createImageGeom.Dimensions = simpl.IntVec3Type(101, 101, 1)
+  createImageGeom.Resolution = simpl.FloatVec3Type(1.0, 1.0, 1.0)
+  createImageGeom.Origin = simpl.FloatVec3Type(0.0, 0.0, 0.0)
   pipeline.pushBack(createImageGeom)
 
   createAttributeMatrix = simpl.CreateAttributeMatrix.New()


### PR DESCRIPTION
The API is changed to use a FloatVec3Type or SizeVec3Type (both alias for SIMPLArray<T, N>) so that
the API is consistent among the various classes and easy to use within SIMPL/DREAM.3D and its plugins.
The use of the std::tuple<T> based return types is deprecated and removed.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>