### PR TITLE
Topic/2 d image import fix

### DIFF
--- a/Source/SIMPLib/ITK/itkImageReaderHelper.cpp
+++ b/Source/SIMPLib/ITK/itkImageReaderHelper.cpp
@@ -253,12 +253,14 @@ ITK_IMAGE_READER_CLASS_NAME
   // Initialize torigin/tspacing/tDims since arrays are always of size 3 and ITK image may have a different size.
   FloatVec3Type torigin = {0.0f, 0.0f, 0.0f};
   FloatVec3Type tspacing = {1.0f, 1.0f, 1.0f};
-  SizeVec3Type tDims = {1, 1, 1};
+  SizeVec3Type tDims = {0, 0, 0};
+  QVector<size_t> qTdims;
   for(size_t i = 0; i < dimensions; i++)
   {
     torigin[i] = origin[i];
     tspacing[i] = spacing[i];
     tDims[i] = size[i];
+    qTdims.push_back(tDims[i]);
   }
   ImageGeom::Pointer image = ImageGeom::CreateGeometry(SIMPL::Geometry::ImageGeometry);
   image->setDimensions(tDims);
@@ -267,7 +269,6 @@ ITK_IMAGE_READER_CLASS_NAME
   container->setGeometry(image);
 
   QVector<size_t> cDims = ITKDream3DHelper::GetComponentsDimensions<TPixel>();
-  QVector<size_t> qTdims = {tDims[0], tDims[1], tDims[2]};
   AttributeMatrix::Pointer cellAttrMat = container->createNonPrereqAttributeMatrix(this, dataArrayPath.getAttributeMatrixName(), qTdims, AttributeMatrix::Type::Cell);
   if(getErrorCode() < 0)
   {

--- a/Source/SIMPLib/ITK/itkImageReaderHelper.cpp
+++ b/Source/SIMPLib/ITK/itkImageReaderHelper.cpp
@@ -245,13 +245,13 @@ void ITK_IMAGE_READER_CLASS_NAME ::readImageOutputInformation(const DataArrayPat
   FloatVec3Type torigin = {0.0f, 0.0f, 0.0f};
   FloatVec3Type tspacing = {1.0f, 1.0f, 1.0f};
   SizeVec3Type tDims = {0, 0, 0};
-  QVector<size_t> qTdims;
+  QVector<size_t> qTdims(dimensions);
   for(size_t i = 0; i < dimensions; i++)
   {
     torigin[i] = origin[i];
     tspacing[i] = spacing[i];
     tDims[i] = size[i];
-    qTdims.push_back(tDims[i]);
+    qTdims[i] = tDims[i];
   }
   ImageGeom::Pointer image = ImageGeom::CreateGeometry(SIMPL::Geometry::ImageGeometry);
   image->setDimensions(tDims);

--- a/Source/SIMPLib/ITK/itkImageReaderHelper.cpp
+++ b/Source/SIMPLib/ITK/itkImageReaderHelper.cpp
@@ -48,9 +48,7 @@ protected:
 //
 // -----------------------------------------------------------------------------
 template <typename TComponent>
-void
-ITK_IMAGE_READER_CLASS_NAME
-::readImage(const DataArrayPath& dataArrayPath, const itk::ImageIOBase::Pointer& imageIO, const QString& filename, bool dataCheck)
+void ITK_IMAGE_READER_CLASS_NAME ::readImage(const DataArrayPath& dataArrayPath, const itk::ImageIOBase::Pointer& imageIO, const QString& filename, bool dataCheck)
 {
   const unsigned int dimensions = imageIO->GetNumberOfDimensions();
   switch(dimensions)
@@ -77,9 +75,7 @@ ITK_IMAGE_READER_CLASS_NAME
 //
 // -----------------------------------------------------------------------------
 template <typename TComponent, unsigned int dimensions>
-void
-ITK_IMAGE_READER_CLASS_NAME
-::readImage(const DataArrayPath& dataArrayPath, const itk::ImageIOBase::Pointer& imageIO, const QString& filename, bool dataCheck)
+void ITK_IMAGE_READER_CLASS_NAME ::readImage(const DataArrayPath& dataArrayPath, const itk::ImageIOBase::Pointer& imageIO, const QString& filename, bool dataCheck)
 {
   using PixelTypeType = itk::ImageIOBase::IOPixelType;
   PixelTypeType pixel = imageIO->GetPixelType();
@@ -135,9 +131,7 @@ ITK_IMAGE_READER_CLASS_NAME
 //
 // -----------------------------------------------------------------------------
 template <typename TPixel, unsigned int dimensions>
-void
-ITK_IMAGE_READER_CLASS_NAME
-::readImage(const DataArrayPath& dataArrayPath, const QString& filename, bool dataCheck)
+void ITK_IMAGE_READER_CLASS_NAME ::readImage(const DataArrayPath& dataArrayPath, const QString& filename, bool dataCheck)
 {
   DataContainer::Pointer container = getDataContainerArray()->getDataContainer(dataArrayPath.getDataContainerName());
   if(nullptr == container.get())
@@ -172,9 +166,7 @@ ITK_IMAGE_READER_CLASS_NAME
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void
-ITK_IMAGE_READER_CLASS_NAME
-::readImage(const DataArrayPath& dataArrayPath, bool dataCheck)
+void ITK_IMAGE_READER_CLASS_NAME ::readImage(const DataArrayPath& dataArrayPath, bool dataCheck)
 {
   try
   {
@@ -240,9 +232,8 @@ ITK_IMAGE_READER_CLASS_NAME
 //
 // -----------------------------------------------------------------------------
 template <typename TPixel, unsigned int dimensions>
-void
-ITK_IMAGE_READER_CLASS_NAME
-::readImageOutputInformation(const DataArrayPath& dataArrayPath, typename itk::ImageFileReader<itk::Dream3DImage<TPixel, dimensions>>::Pointer& reader, DataContainer::Pointer& container)
+void ITK_IMAGE_READER_CLASS_NAME ::readImageOutputInformation(const DataArrayPath& dataArrayPath, typename itk::ImageFileReader<itk::Dream3DImage<TPixel, dimensions>>::Pointer& reader,
+                                                              DataContainer::Pointer& container)
 {
   using ImageType = itk::Dream3DImage<TPixel, dimensions>;
   using ValueType = typename itk::NumericTraits<TPixel>::ValueType;

--- a/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.hxx
+++ b/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.hxx
@@ -1,23 +1,21 @@
 #pragma once
 
-#include "itkInPlaceImageToDream3DDataFilter.h"
-#include "itkGetComponentsDimensions.h"
 #include "SIMPLib/Geometry/ImageGeom.h"
+#include "itkGetComponentsDimensions.h"
+#include "itkInPlaceImageToDream3DDataFilter.h"
 #include <QString>
 
 namespace itk
 {
 
-template<typename PixelType, unsigned int VDimension>
-InPlaceImageToDream3DDataFilter<PixelType,VDimension>
-::InPlaceImageToDream3DDataFilter()
+template <typename PixelType, unsigned int VDimension>
+InPlaceImageToDream3DDataFilter<PixelType, VDimension>::InPlaceImageToDream3DDataFilter()
 {
   m_DataArrayName = (SIMPL::Defaults::CellAttributeMatrixName).toStdString();
   m_AttributeMatrixArrayName = (SIMPL::CellData::ImageData).toStdString();
   // Create the output. We use static_cast<> here because we know the default
   // output must be of type DecoratorType
-  typename DecoratorType::Pointer output =
-    static_cast< DecoratorType * >(this->MakeOutput(0).GetPointer());
+  typename DecoratorType::Pointer output = static_cast<DecoratorType*>(this->MakeOutput(0).GetPointer());
   this->ProcessObject::SetNumberOfRequiredOutputs(1);
   this->ProcessObject::SetNthOutput(0, output.GetPointer());
   this->SetNumberOfRequiredInputs(1);
@@ -25,52 +23,37 @@ InPlaceImageToDream3DDataFilter<PixelType,VDimension>
   m_InPlace = true;
 }
 
-
-template< typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter< PixelType, VDimension >
-::SetDataContainer(DataContainer::Pointer dc)
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::SetDataContainer(DataContainer::Pointer dc)
 {
-  DecoratorType *outputPtr = this->GetOutput();
+  DecoratorType* outputPtr = this->GetOutput();
   outputPtr->Set(dc);
 }
 
-
-
-template< typename PixelType, unsigned int VDimension>
-ProcessObject::DataObjectPointer
-InPlaceImageToDream3DDataFilter< PixelType, VDimension >
-::MakeOutput(ProcessObject::DataObjectPointerArraySizeType)
+template <typename PixelType, unsigned int VDimension>
+ProcessObject::DataObjectPointer InPlaceImageToDream3DDataFilter<PixelType, VDimension>::MakeOutput(ProcessObject::DataObjectPointerArraySizeType)
 {
   return DecoratorType::New().GetPointer();
 }
 
-
-template<typename PixelType, unsigned int VDimension>
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::~InPlaceImageToDream3DDataFilter()
+template <typename PixelType, unsigned int VDimension>
+InPlaceImageToDream3DDataFilter<PixelType, VDimension>::~InPlaceImageToDream3DDataFilter()
 {
 }
 
-template< typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter< PixelType, VDimension >
-::SetInput(const ImageType *input)
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::SetInput(const ImageType* input)
 {
   // Process object is not const-correct so the const_cast is required here
-  this->ProcessObject::SetNthInput(0,
-    const_cast< ImageType * >(input));
+  this->ProcessObject::SetNthInput(0, const_cast<ImageType*>(input));
 }
 
-
-template<typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::GenerateOutputInformation()
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::GenerateOutputInformation()
 {
-  DecoratorType *outputPtr = this->GetOutput();
+  DecoratorType* outputPtr = this->GetOutput();
   DataContainer::Pointer dataContainer = outputPtr->Get();
-  //float tol = 0.000001;
+  // float tol = 0.000001;
   QVector<float> torigin(3, 0);
   QVector<float> tspacing(3, 1);
   QVector<size_t> tDims(3, 0);
@@ -82,10 +65,10 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   //// Create image geometry (data container)
   ImageGeom::Pointer imageGeom;
   IGeometry::Pointer geom = dataContainer->getGeometry();
-  if (geom)
+  if(geom)
   {
     imageGeom = std::dynamic_pointer_cast<ImageGeom>(geom);
-    if (!imageGeom)
+    if(!imageGeom)
     {
       itkExceptionMacro("Data container contains a geometry that is not ImageGeometry");
     }
@@ -93,16 +76,16 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   else
   {
     imageGeom = ImageGeom::CreateGeometry(SIMPL::Geometry::ImageGeometry);
-    if (!imageGeom)
+    if(!imageGeom)
     {
       itkExceptionMacro("Could not create image geometry");
     }
   }
-  for (size_t i = 0; i < VDimension; i++)
+  for(size_t i = 0; i < VDimension; i++)
   {
-	  torigin[i] = origin[i];
-	  tspacing[i] = spacing[i];
-	  tDims[i] = size[i];
+    torigin[i] = origin[i];
+    tspacing[i] = spacing[i];
+    tDims[i] = size[i];
   }
   imageGeom->setOrigin(FloatVec3Type(torigin[0], torigin[1], torigin[2]));
   imageGeom->setSpacing(FloatVec3Type(tspacing[0], tspacing[1], tspacing[2]));
@@ -110,12 +93,10 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   dataContainer->setGeometry(imageGeom);
 }
 
-template<typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::GenerateData()
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::GenerateData()
 {
-  DecoratorType *outputPtr = this->GetOutput();
+  DecoratorType* outputPtr = this->GetOutput();
   DataContainer::Pointer dataContainer = outputPtr->Get();
   ImagePointer inputPtr = dynamic_cast<ImageType*>(this->GetInput(0));
   // Create data array
@@ -131,34 +112,34 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   }
 
   AttributeMatrix::Pointer attrMat;
-  if( dataContainer->doesAttributeMatrixExist(m_AttributeMatrixArrayName.c_str()))
+  if(dataContainer->doesAttributeMatrixExist(m_AttributeMatrixArrayName.c_str()))
   {
-	attrMat = dataContainer->getAttributeMatrix(m_AttributeMatrixArrayName.c_str());
-	// Check that attribute matrix type is 'cell'
-	if (attrMat->getType() != AttributeMatrix::Type::Cell)
-	{
-		itkExceptionMacro("Attribute matrix is not of type AttributeMatrix::Type::Cell.");
-	}
-	// Check that if size does not match, there are no other data array than the one we expect.
-	// That makes it possible to modify the attribute matrix without having to worry.
-	QVector<size_t> matDims = attrMat->getTupleDimensions();
-	if (matDims != tDims)
-	{
-    if (! ((attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()) && attrMat->getNumAttributeArrays() == 1)
-      || ! (attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()) && attrMat->getNumAttributeArrays() == 0)) )
-		{
-			itkExceptionMacro("Tuples dimension of existing matrix array do not match image size and other attribute arrays are contained in this attribute matrix.");
-		}
-		dataContainer->removeAttributeMatrix(m_AttributeMatrixArrayName.c_str());
-    attrMat = dataContainer->createAndAddAttributeMatrix(attrMatDims, m_AttributeMatrixArrayName.c_str(), AttributeMatrix::Type::Cell);
-	}
+    attrMat = dataContainer->getAttributeMatrix(m_AttributeMatrixArrayName.c_str());
+    // Check that attribute matrix type is 'cell'
+    if(attrMat->getType() != AttributeMatrix::Type::Cell)
+    {
+      itkExceptionMacro("Attribute matrix is not of type AttributeMatrix::Type::Cell.");
+    }
+    // Check that if size does not match, there are no other data array than the one we expect.
+    // That makes it possible to modify the attribute matrix without having to worry.
+    QVector<size_t> matDims = attrMat->getTupleDimensions();
+    if(matDims != tDims)
+    {
+      if(!((attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()) && attrMat->getNumAttributeArrays() == 1) ||
+           !(attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()) && attrMat->getNumAttributeArrays() == 0)))
+      {
+        itkExceptionMacro("Tuples dimension of existing matrix array do not match image size and other attribute arrays are contained in this attribute matrix.");
+      }
+      dataContainer->removeAttributeMatrix(m_AttributeMatrixArrayName.c_str());
+      attrMat = dataContainer->createAndAddAttributeMatrix(attrMatDims, m_AttributeMatrixArrayName.c_str(), AttributeMatrix::Type::Cell);
+    }
   }
   else
   {
     attrMat = dataContainer->createAndAddAttributeMatrix(attrMatDims, m_AttributeMatrixArrayName.c_str(), AttributeMatrix::Type::Cell);
   }
   // Checks if doesAttributeArray exists and remove it if it is the case
-  if (attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()))
+  if(attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()))
   {
     IDataArray::Pointer attrArray = attrMat->getAttributeArray(m_DataArrayName.c_str());
     if(attrArray->getNumberOfTuples() != attrMat->getNumberOfTuples())
@@ -167,8 +148,8 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
     }
   }
   typename DataArrayPixelType::Pointer data;
-  inputPtr->SetBufferedRegion( inputPtr->GetLargestPossibleRegion() );
-  if( m_InPlace )
+  inputPtr->SetBufferedRegion(inputPtr->GetLargestPossibleRegion());
+  if(m_InPlace)
   {
     inputPtr->GetPixelContainer()->SetContainerManageMemory(false);
     data = DataArrayPixelType::WrapPointer(reinterpret_cast<ValueType*>(inputPtr->GetBufferPointer()), attrMat->getNumberOfTuples(), cDims, this->GetDataArrayName().c_str(), true);
@@ -176,7 +157,7 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   else
   {
     data = DataArrayPixelType::CreateArray(attrMat->getNumberOfTuples(), cDims, m_DataArrayName.c_str(), true);
-    if (nullptr != data.get())
+    if(nullptr != data.get())
     {
       ::memcpy(data->getPointer(0), reinterpret_cast<ValueType*>(inputPtr->GetBufferPointer()), attrMat->getNumberOfTuples() * sizeof(ValueType));
     }
@@ -186,38 +167,33 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
 }
 
 // Check that names has been initialized correctly
-template<typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::CheckValidArrayPathComponentName(std::string var) const
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::CheckValidArrayPathComponentName(std::string var) const
 {
-  if (var.find('/') != std::string::npos)
+  if(var.find('/') != std::string::npos)
   {
     itkExceptionMacro("Name contains a '/'");
   }
-  if (var.empty())
+  if(var.empty())
   {
     itkExceptionMacro("Name is empty");
   }
 }
 
-
 // Check that the inputs have been initialized correctly
-template<typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::VerifyPreconditions() ITKv5_CONST
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::VerifyPreconditions() ITKv5_CONST
 {
-  //Test only works if image if of dimension 2 or 3
-  if (VDimension != 2 && VDimension != 3)
+  // Test only works if image if of dimension 2 or 3
+  if(VDimension != 2 && VDimension != 3)
   {
     itkExceptionMacro("Dimension must be 2 or 3.");
   }
   CheckValidArrayPathComponentName(m_AttributeMatrixArrayName);
   CheckValidArrayPathComponentName(m_DataArrayName);
   // Verify data container
-  const DecoratorType *outputPtr = this->GetOutput();
-  if (!outputPtr->Get())
+  const DecoratorType* outputPtr = this->GetOutput();
+  if(!outputPtr->Get())
   {
     itkExceptionMacro("Data container not set");
   }
@@ -226,23 +202,18 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
 }
 
 /**
-*
-*/
-template<typename PixelType, unsigned int VDimension>
-typename InPlaceImageToDream3DDataFilter<PixelType, VDimension>::DecoratorType*
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::GetOutput()
+ *
+ */
+template <typename PixelType, unsigned int VDimension>
+typename InPlaceImageToDream3DDataFilter<PixelType, VDimension>::DecoratorType* InPlaceImageToDream3DDataFilter<PixelType, VDimension>::GetOutput()
 {
-  return itkDynamicCastInDebugMode< DecoratorType * >(this->GetPrimaryOutput());
+  return itkDynamicCastInDebugMode<DecoratorType*>(this->GetPrimaryOutput());
 }
 
-template<typename PixelType, unsigned int VDimension>
-const typename InPlaceImageToDream3DDataFilter<PixelType, VDimension>::DecoratorType*
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::GetOutput() const
+template <typename PixelType, unsigned int VDimension>
+const typename InPlaceImageToDream3DDataFilter<PixelType, VDimension>::DecoratorType* InPlaceImageToDream3DDataFilter<PixelType, VDimension>::GetOutput() const
 {
-  return itkDynamicCastInDebugMode< const DecoratorType * >(this->GetPrimaryOutput());
+  return itkDynamicCastInDebugMode<const DecoratorType*>(this->GetPrimaryOutput());
 }
 
-} // end of itk namespace
-
+} // namespace itk


### PR DESCRIPTION
Updating ITKImageReader and itkInPlaceImageToDream3DDataFilter classes so that they import 2D datasets with the 3rd dimension in the data container's geometry set to 0.  This is needed to be able to tell the difference between a true, flat 2D dataset and a really thin image geometry.