### PR TITLE
The DataStructureWidget no longer expands all items on refresh

### DIFF
--- a/Source/SVWidgetsLib/Widgets/DataStructureTreeView.cpp
+++ b/Source/SVWidgetsLib/Widgets/DataStructureTreeView.cpp
@@ -520,3 +520,17 @@ void DataStructureTreeView::search(const QString& name)
   }
   update();
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void DataStructureTreeView::rowsInserted(const QModelIndex& parent, int start, int end)
+{
+  QTreeView::rowsInserted(parent, start, end);
+
+  // Expand if the specified parent did not have children previously
+  if(0 == start && !parent.child(end + 1, 0).isValid())
+  {
+    expand(parent);
+  }
+}

--- a/Source/SVWidgetsLib/Widgets/DataStructureTreeView.h
+++ b/Source/SVWidgetsLib/Widgets/DataStructureTreeView.h
@@ -206,6 +206,14 @@ protected:
   void findExpandedChildren(QAbstractItemModel* model, const QModelIndex& index, QVector<QModelIndex>& expandedVector);
 
   /**
+   * @brief rowsInserted
+   * @param parent
+   * @param start
+   * @param end
+   */
+  void rowsInserted(const QModelIndex& parent, int start, int end) override;
+
+  /**
    * @brief Create custom context menu
    * @param event
    */

--- a/Source/SVWidgetsLib/Widgets/DataStructureWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/DataStructureWidget.cpp
@@ -241,7 +241,6 @@ void DataStructureWidget::refreshData()
       path.push_front(item->text());
       item = item->parent();
     }
-
   }
 
   model = m_Ui->dataBrowserTreeView->getStandardModel();
@@ -263,8 +262,7 @@ void DataStructureWidget::refreshData()
     if(dcItem == nullptr)
     {
       dcItem = new QStandardItem(dc->getName());
-      rootItem->appendRow(dcItem);
-      //      dcItem->setBackground(QBrush(QColor(154, 136, 255)));
+      model->appendRow(dcItem);
       m_Ui->dataBrowserTreeView->expand(dcItem->index());
     }
     dcItem->setData(dc->getInfoString(SIMPL::HtmlFormat), Qt::UserRole + 1);
@@ -319,7 +317,6 @@ void DataStructureWidget::refreshData()
       if(amItem == nullptr)
       {
         amItem = new QStandardItem(am->getName());
-        //          amItem->setBackground(QColor(128, 224, 138));
         dcItem->appendRow(amItem);
         m_Ui->dataBrowserTreeView->expand(amItem->index());
       }
@@ -344,13 +341,8 @@ void DataStructureWidget::refreshData()
         if(aaItem == nullptr)
         {
           aaItem = new QStandardItem(attrArrayName);
-          // aaItem->setBackground(QColor(255, 210, 173));
           amItem->appendRow(aaItem);
         }
-        //        else
-        //        {
-        //          aaItem->setBackground(QColor(255, 255, 255));
-        //        }
         aaItem->setData(attrArray->getInfoString(SIMPL::HtmlFormat), Qt::UserRole + 1);
         aaItem->setToolTip(attrArray->getInfoString(SIMPL::HtmlFormat));
         aaItem->setIcon(QIcon());
@@ -367,7 +359,6 @@ void DataStructureWidget::refreshData()
   }
   removeNonexistingEntries(rootItem, m_Dca->getDataContainerNames(), 0);
 
-  m_Ui->dataBrowserTreeView->expandAll();
   // repaint the DataStructureTreeView
   m_Ui->dataBrowserTreeView->repaint();
 }


### PR DESCRIPTION
* Refreshing the data in DataStructureWidget no longer expands all items.
* Adding child nodes to the DataStructureWidget now expands the parent if the parent did not have any children previously.
* Removed commented out styling for the DataStructure.  This has been handled by the stylesheets for some time and is unlikely to ever return to DataStructureWidget.