### PR TITLE
WIP changes to how numpy arrays are converted to/from DataArrays

### DIFF
--- a/Wrapping/Python/Pybind11/Templates/SIMPLModuleCodeTemplate.in.cpp
+++ b/Wrapping/Python/Pybind11/Templates/SIMPLModuleCodeTemplate.in.cpp
@@ -82,24 +82,89 @@ template <typename T> using PySharedPtrClass = py::class_<T, std::shared_ptr<T>>
         .def(py::init([](T* ptr, size_t numElements, std::vector<size_t> cDims, QString name, bool ownsData) {                                                                                         \
           return DataArrayType::WrapPointer(ptr, numElements, QVector<size_t>::fromStdVector(cDims), name, ownsData);                                                                                  \
         }))                                                                                                                                                                                            \
-        .def(py::init([](py::array_t<T, py::array::c_style> b, std::vector<size_t> cDims, QString name, bool ownsData) {                                                                               \
-          ssize_t numElements = 1;                                                                                                                                                                     \
-          ssize_t nDims = b.ndim();                                                                                                                                                                    \
-          for(ssize_t e = 0; e < nDims; e++)                                                                                                                                                           \
+        .def(py::init([](py::array_t<T, py::array::c_style> b, QString name, bool ownsData) {                                                                                                          \
+          py::buffer_info buf = b.request();                                                                                                                                                           \
+          std::vector<ssize_t> shape = buf.shape;                                                                                                                                                      \
+          ssize_t ndim = buf.ndim;                                                                                                                                                                     \
+          size_t numTuples = 0;                                                                                                                                                                        \
+          QVector<size_t> cDims;                                                                                                                                                                       \
+          if(ndim == 0)                                                                                                                                                                                \
           {                                                                                                                                                                                            \
-            numElements *= b.shape(e);                                                                                                                                                                 \
+            numTuples = 1;                                                                                                                                                                             \
+            cDims.resize(1);                                                                                                                                                                           \
+            cDims[0] = 1;                                                                                                                                                                              \
           }                                                                                                                                                                                            \
-          numElements /= cDims[0];                                                                                                                                                                     \
-          return DataArrayType::WrapPointer(reinterpret_cast<T*>(b.mutable_data(0)), static_cast<size_t>(numElements), QVector<size_t>::fromStdVector(cDims), name, ownsData);                         \
+          else if(ndim == 1)                                                                                                                                                                           \
+          {                                                                                                                                                                                            \
+            numTuples = static_cast<size_t>(shape.front());                                                                                                                                            \
+            cDims.resize(1);                                                                                                                                                                           \
+            cDims[0] = 1;                                                                                                                                                                              \
+          }                                                                                                                                                                                            \
+          else                                                                                                                                                                                         \
+          {                                                                                                                                                                                            \
+            numTuples = static_cast<size_t>(shape.front());                                                                                                                                            \
+            cDims.resize(ndim - 1);                                                                                                                                                                    \
+            for(ssize_t e = 0; e < ndim - 1; e++)                                                                                                                                                      \
+            {                                                                                                                                                                                          \
+              cDims[e] = static_cast<size_t>(shape[e + 1]);                                                                                                                                            \
+            }                                                                                                                                                                                          \
+          }                                                                                                                                                                                            \
+          return DataArrayType::WrapPointer(reinterpret_cast<T*>(b.mutable_data(0)), numTuples, cDims, name, ownsData);                                                                                \
         })) /* Class instance method setValue */                                                                                                                                                       \
         .def("setValue", &DataArrayType::setValue, py::arg("index"), py::arg("value"))                                                                                                                 \
         .def("getValue", &DataArrayType::getValue, py::arg("index"))                                                                                                                                   \
-	      .def_property("Data", &DataArrayType::getArray, &DataArrayType::setArray, py::return_value_policy::reference)                                                                                  \
+        .def_property("Data", &DataArrayType::getArray, &DataArrayType::setArray, py::return_value_policy::reference)                                                                                  \
         .def_property("Name", &DataArrayType::getName, &DataArrayType::setName)                                                                                                                        \
-        .def("Cleanup", []() { return DataArrayType::NullPointer(); });                                                                                                                                \
+        .def("Cleanup", []() { return DataArrayType::NullPointer(); })                                                                                                                                 \
+        .def_buffer([](DataArrayType &m) -> py::buffer_info {                                                                                                                                          \
+          int nComp = m.getNumberOfComponents();                                                                                                                                                       \
+          size_t numTuples = m.getNumberOfTuples();                                                                                                                                                    \
+          ssize_t ndim = 0;                                                                                                                                                                            \
+          std::vector<ssize_t> shape;                                                                                                                                                                  \
+          std::vector<ssize_t> strides;                                                                                                                                                                \
+          if(nComp == 1)                                                                                                                                                                               \
+          {                                                                                                                                                                                            \
+            ndim = 1;                                                                                                                                                                                  \
+            shape.resize(ndim);                                                                                                                                                                        \
+            shape[0] = numTuples;                                                                                                                                                                      \
+            strides.resize(ndim);                                                                                                                                                                      \
+            strides[0] = sizeof(T);                                                                                                                                                                    \
+          }                                                                                                                                                                                            \
+          else                                                                                                                                                                                         \
+          {                                                                                                                                                                                            \
+            QVector<size_t> cDims = m.getComponentDimensions();                                                                                                                                        \
+            ndim = static_cast<ssize_t>(cDims.size()) + 1;                                                                                                                                             \
+            shape.resize(ndim);                                                                                                                                                                        \
+            shape[0] = numTuples;                                                                                                                                                                      \
+            for(ssize_t e = 0; e < ndim - 1; e++)                                                                                                                                                      \
+            {                                                                                                                                                                                          \
+              shape[e + 1] = static_cast<ssize_t>(cDims[e]);                                                                                                                                           \
+            }                                                                                                                                                                                          \
+            ssize_t cur = 1;                                                                                                                                                                           \
+            std::vector<ssize_t> rshape(shape);                                                                                                                                                        \
+            std::reverse(std::begin(rshape), std::end(rshape));                                                                                                                                        \
+            for(auto val : rshape)                                                                                                                                                                     \
+            {                                                                                                                                                                                          \
+              strides.push_back(cur * val * sizeof(T));                                                                                                                                                \
+              cur *= val;                                                                                                                                                                              \
+            }                                                                                                                                                                                          \
+            strides.pop_back();                                                                                                                                                                        \
+            auto front = std::begin(strides);                                                                                                                                                          \
+            strides.insert(front, sizeof(T));                                                                                                                                                          \
+            std::reverse(std::begin(strides), std::end(strides));                                                                                                                                      \
+          }                                                                                                                                                                                            \
+          return py::buffer_info(                                                                                                                                                                      \
+            m.getPointer(0),                                                                                                                                                                           \
+            sizeof(T),                                                                                                                                                                                 \
+            py::format_descriptor<T>::format(),                                                                                                                                                        \
+            ndim,                                                                                                                                                                                      \
+            shape,                                                                                                                                                                                     \
+            strides                                                                                                                                                                                    \
+          );                                                                                                                                                                                           \
+        });                                                                                                                                                                                            \
     ;                                                                                                                                                                                                  \
     return instance;                                                                                                                                                                                   \
-  }
+}
 
 PYB11_DEFINE_DATAARRAY_INIT(int8_t, Int8ArrayType);
 PYB11_DEFINE_DATAARRAY_INIT(uint8_t, UInt8ArrayType);


### PR DESCRIPTION
This PR changes how SIMPL interacts with numpy arrays.  The following changes are included:

- Changed the standard constructor when creating a SIMPL DataArray object that wraps an underlying numpy array.  Now, the constructor only takes as arguments the numpy array, a string name, and a flag for whether the new DataArray will own the data.  The major change here is how the tuples are component dimensions are inferred from the numpy array shape.  The first axis of the numpy array (slowest-moving in C-order) is now considered the number of tuples, while the following axes (faster-moving in C-ordering) determine the component dimensions.  

Consider a numpy array with shape `[10, 3]`, something that could represent 10 rgb values or 10 Euler angles.  The number of tuples in this case is 10 and the component dimensions will be `[3]`.  For another example, consider a numpy array with shape `[1000, 80, 60]`.  Here, the number of tuples would be 1000 while the component dimensions would be `[80, 60]`.  Additionally, scalar (0-dim) numpy arrays are explicitly handled.

- Added a `.def_buffer` lambda that provides buffer access to the underlying DataArray.  This allows direct access of the SIMPL DataArray object as a numpy array.  The convention for inferring numpy array shape is the same as above; for example, a DataArray with 10 tuples and component dimensions `[3]` becomes a numpy array with shape `(10, 3)`.  Note that there is an ambiguity when dealing with scalar DataArrays (i.e., component dimensions of `[1]`).  In this case, both `(num_tuples,)` and `(num_tuples, 1)` are valid numpy array shapes.  The chosen convention is to squeeze the 1-dim axis in the numpy array; i.e., the returned numpy array shape will be `(num_tuples,)`.  To convert a DataArray to a numpy array, the `np.asarray()` function should be used.

The following functions in simpl_helpers.py will need to be updated for the new syntax: `CreateDataArray` and `ConvertToDataArray`.  Also, a helper function that converts a DataArray to a numpy array needs to be added.

Now, some example code showing round-tripping numpy and DataArray objects:

```python
num_array = np.arange(30, dtype=np.float32).reshape([5, 3, 2])
z = np.asarray(num_array)
if not z.flags.contiguous:
    z = np.ascontiguousarray(z)

print("--------------- z ---------------")
print(z.shape)
print(z)

array = simpl.FloatArrayType(z, "test", False)

roundtrip = np.asarray(array)

print("--------------- roundtrip ---------------")
print(roundtrip.shape)
print(roundtrip)
```

Output of the above code:

```
--------------- z ---------------
(5, 3, 2)
[[[ 0.  1.]
  [ 2.  3.]
  [ 4.  5.]]

 [[ 6.  7.]
  [ 8.  9.]
  [10. 11.]]

 [[12. 13.]
  [14. 15.]
  [16. 17.]]

 [[18. 19.]
  [20. 21.]
  [22. 23.]]

 [[24. 25.]
  [26. 27.]
  [28. 29.]]]
--------------- roundtrip ---------------
(5, 3, 2)
[[[ 0.  1.]
  [ 2.  3.]
  [ 4.  5.]]

 [[ 6.  7.]
  [ 8.  9.]
  [10. 11.]]

 [[12. 13.]
  [14. 15.]
  [16. 17.]]

 [[18. 19.]
  [20. 21.]
  [22. 23.]]

 [[24. 25.]
  [26. 27.]
  [28. 29.]]]
```
