### PR TITLE
WIP: Changing the IDataArray and DataArray API to use STL containers.

### DIFF
--- a/Source/Experimental/FilterCallback/FilterParameter.cpp
+++ b/Source/Experimental/FilterCallback/FilterParameter.cpp
@@ -61,7 +61,7 @@ void Int32Parameter::writeJson(QJsonObject& json) const
   json[QString::fromStdString(getPropertyName())] = m_GetterCallback();
 }
 
-Int32Parameter::Int32Parameter(const std::string& humanLabel, const std::string& propertyName, int defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+Int32Parameter::Int32Parameter(const std::string& humanLabel, const std::string& propertyName, int defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
   : IFilterParameter(humanLabel, propertyName, category, groupIndex)
   , m_DefaultValue(defaultValue)
   , m_SetterCallback(setterCallback)
@@ -110,7 +110,7 @@ void DoubleParameter::writeJson(QJsonObject& json) const
 }
 
 
-DoubleParameter::DoubleParameter(const std::string& humanLabel, const std::string& propertyName, double defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+DoubleParameter::DoubleParameter(const std::string& humanLabel, const std::string& propertyName, double defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
   : IFilterParameter(humanLabel, propertyName, category, groupIndex)
   , m_DefaultValue(defaultValue)
   , m_SetterCallback(setterCallback)
@@ -169,7 +169,7 @@ void DataArrayPathParameter::writeJson(QJsonObject& json) const
   }
 }
 
-DataArrayPathParameter::DataArrayPathParameter(const std::string& humanLabel, const std::string& propertyName, const DataArrayPath &defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+DataArrayPathParameter::DataArrayPathParameter(const std::string& humanLabel, const std::string& propertyName, const DataArrayPath &defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
   : IFilterParameter(humanLabel, propertyName, category, groupIndex)
   , m_DefaultValue(defaultValue)
   , m_SetterCallback(setterCallback)

--- a/Source/Experimental/FilterCallback/FilterParameter.h
+++ b/Source/Experimental/FilterCallback/FilterParameter.h
@@ -160,8 +160,7 @@ class Int32Parameter : public IFilterParameter
                        const std::string& propertyName,
                        const int& defaultValue,
                        Category category,
-                       SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback,
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                        int groupIndex = -1);
     virtual ~Int32Parameter();
     
@@ -175,7 +174,7 @@ class Int32Parameter : public IFilterParameter
     void writeJson(QJsonObject& json) const override;
     
   protected:
-    Int32Parameter(const std::string& humanLabel, const std::string& propertyName, int defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex);
+    Int32Parameter(const std::string& humanLabel, const std::string& propertyName, int defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex);
     
   private:
     Int32Parameter(const Int32Parameter&) = delete; // Copy Constructor Not Implemented
@@ -200,8 +199,7 @@ class DoubleParameter : public IFilterParameter
                        const std::string& propertyName,
                        const double& defaultValue,
                        Category category,
-                       SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback,
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                        int groupIndex = -1);
     virtual ~DoubleParameter();
     
@@ -216,7 +214,7 @@ class DoubleParameter : public IFilterParameter
     void writeJson(QJsonObject& json) const override;
     
   protected:
-    DoubleParameter(const std::string& humanLabel, const std::string& propertyName, double defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex);
+    DoubleParameter(const std::string& humanLabel, const std::string& propertyName, double defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex);
     
   private:
     DoubleParameter(const DoubleParameter&) = delete; // Copy Constructor Not Implemented
@@ -241,8 +239,7 @@ class DataArrayPathParameter : public IFilterParameter
                        const std::string& propertyName,
                        const DataArrayPath& defaultValue,
                        Category category,
-                       SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback,
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                        int groupIndex = -1);
     
     virtual ~DataArrayPathParameter();
@@ -258,7 +255,7 @@ class DataArrayPathParameter : public IFilterParameter
     void writeJson(QJsonObject& json) const override;
     
   protected:
-    DataArrayPathParameter(const std::string& humanLabel, const std::string& propertyName, const DataArrayPath &defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex);
+    DataArrayPathParameter(const std::string& humanLabel, const std::string& propertyName, const DataArrayPath &defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex);
     
   private:
     DataArrayPathParameter(const DataArrayPathParameter&) = delete; // Copy Constructor Not Implemented

--- a/Source/H5Support/QH5Lite.h
+++ b/Source/H5Support/QH5Lite.h
@@ -547,10 +547,7 @@ namespace H5Support_NAMESPACE
        * @return Standard HDF Error condition
        */
       template <typename T>
-      static herr_t readVectorAttribute(hid_t loc_id,
-                                        const QString& objName,
-                                        const QString& attrName,
-                                        QVector<T>& data)
+      static herr_t readVectorAttribute(hid_t loc_id, const QString& objName, const QString& attrName, std::vector<T>& data)
       {
 
         std::string objNameStr = objName.toStdString();
@@ -560,78 +557,6 @@ namespace H5Support_NAMESPACE
         data.resize(dataV.size());
         std::copy(dataV.begin(), dataV.end(), data.begin());
         return err;
-#if 0
-        /* identifiers */
-        hid_t      obj_id;
-        H5O_info_t statbuf;
-        herr_t err = 0;
-        herr_t retErr = 0;
-        hid_t attr_id;
-        hid_t tid;
-        T test = 0x00;
-        hid_t dataType = QH5Lite::HDFTypeForPrimitive(test);
-        if (dataType == -1)
-        {
-          return -1;
-        }
-        //qDebug() << "   Reading Vector Attribute at Path '" << objName << "' with Key: '" << attrName << "'";
-        /* Get the type of object */
-        err = H5Oget_info_by_name(loc_id, objName.toLatin1().data(),  &statbuf, H5P_DEFAULT);
-        if (err < 0)
-        { return err; }
-        /* Open the object */
-        obj_id = QH5Lite::openId( loc_id, objName, statbuf.type);
-        if ( obj_id >= 0)
-        {
-          attr_id = H5Aopen_by_name( loc_id, objName.toLatin1().data(), attrName.toLatin1().data(), H5P_DEFAULT, H5P_DEFAULT );
-          if ( attr_id >= 0 )
-          {
-            //Need to allocate the array size
-            H5T_class_t type_class;
-            size_t type_size;
-            QVector<hsize_t> dims;
-            err = QH5Lite::getAttributeInfo(loc_id, objName, attrName, dims, type_class, type_size, tid);
-            hsize_t numElements = 1;
-            for (QVector<hsize_t>::iterator iter = dims.begin(); iter < dims.end(); ++iter )
-            {
-              numElements *= *(iter);
-            }
-            //qDebug() << "    Vector Attribute has " << numElements << " elements.";
-            if (numElements > static_cast<hsize_t>(std::numeric_limits<qint32>::max() ) )
-            {
-              qDebug() << "Number of Elements in Array is larger than QVector can handle. Suggest using a std::vector<> instead";
-              err = -1000;
-            }
-            else
-            {
-              data.resize( static_cast<signed int>(numElements) );
-              err = H5Aread( attr_id, dataType, &(data.front()) );
-            }
-            if ( err < 0 )
-            {
-              qDebug() << "Error Reading Attribute." << err;
-              retErr = err;
-            }
-            err = H5Aclose( attr_id );
-            if ( err < 0 )
-            {
-              qDebug() << "Error Closing Attribute";
-              retErr = err;
-            }
-          }
-          else
-          {
-            retErr = attr_id;
-          }
-          err = QH5Lite::closeId( obj_id, statbuf.type );
-          if ( err < 0 )
-          {
-            qDebug() << "Error Closing Object";
-            retErr = err;
-          }
-        }
-        return retErr;
-#endif
       }
 
       /**
@@ -652,57 +577,6 @@ namespace H5Support_NAMESPACE
         std::string attrNameStr = attrName.toStdString();
         herr_t  err = H5Lite::readScalarAttribute(loc_id, objNameStr, attrNameStr, data);
         return err;
-#if 0
-        /* identifiers */
-        hid_t      obj_id;
-        H5O_info_t statbuf;
-        herr_t err = 0;
-        herr_t retErr = 0;
-        hid_t attr_id;
-        T test = static_cast<T>(0x00);
-        hid_t dataType = QH5Lite::HDFTypeForPrimitive(test);
-        if (dataType == -1)
-        {
-          return -1;
-        }
-        //qDebug() << "Reading Scalar style Attribute at Path '" << objName << "' with Key: '" << attrName << "'";
-        /* Get the type of object */
-        err = H5Oget_info_by_name(loc_id, objName.toLatin1().data(),  &statbuf, H5P_DEFAULT);
-        if (err < 0)
-        { return err; }
-        /* Open the object */
-        obj_id = QH5Lite::openId( loc_id, objName, statbuf.type);
-        if ( obj_id >= 0)
-        {
-          attr_id = H5Aopen_by_name( loc_id, objName.toLatin1().data(), attrName.toLatin1().data(), H5P_DEFAULT, H5P_DEFAULT );
-          if ( attr_id >= 0 )
-          {
-            err = H5Aread( attr_id, dataType, &data );
-            if ( err < 0 )
-            {
-              qDebug() << "Error Reading Attribute.";
-              retErr = err;
-            }
-            err = H5Aclose( attr_id );
-            if ( err < 0 )
-            {
-              qDebug() << "Error Closing Attribute";
-              retErr = err;
-            }
-          }
-          else
-          {
-            retErr = attr_id;
-          }
-          err = QH5Lite::closeId( obj_id, statbuf.type );
-          if ( err < 0 )
-          {
-            qDebug() << "Error Closing Object";
-            retErr = err;
-          }
-        }
-        return retErr;
-#endif
       }
 
       /**
@@ -723,57 +597,6 @@ namespace H5Support_NAMESPACE
         std::string attrNameStr = attrName.toStdString();
         herr_t  err = H5Lite::readPointerAttribute(loc_id, objNameStr, attrNameStr, data);
         return err;
-#if 0
-        /* identifiers */
-        hid_t      obj_id;
-        H5O_info_t statbuf;
-        herr_t err = 0;
-        herr_t retErr = 0;
-        hid_t attr_id;
-        T test = 0x00;
-        hid_t dataType = QH5Lite::HDFTypeForPrimitive(test);
-        if (dataType == -1)
-        {
-          return -1;
-        }
-        //qDebug() << "   Reading Vector Attribute at Path '" << objName << "' with Key: '" << attrName << "'";
-        /* Get the type of object */
-        err = H5Oget_info_by_name(loc_id, objName.toLatin1().data(),  &statbuf, H5P_DEFAULT);
-        if (err < 0)
-        { return err; }
-        /* Open the object */
-        obj_id = QH5Lite::openId( loc_id, objName, statbuf.type);
-        if ( obj_id >= 0)
-        {
-          attr_id = H5Aopen_by_name( loc_id, objName.toLatin1().data(), attrName.toLatin1().data(), H5P_DEFAULT, H5P_DEFAULT );
-          if ( attr_id >= 0 )
-          {
-            err = H5Aread( attr_id, dataType, data);
-            if ( err < 0 )
-            {
-              qDebug() << "Error Reading Attribute." << err;
-              retErr = err;
-            }
-            err = H5Aclose( attr_id );
-            if ( err < 0 )
-            {
-              qDebug() << "Error Closing Attribute";
-              retErr = err;
-            }
-          }
-          else
-          {
-            //retErr = attr_id;
-          }
-          err = QH5Lite::closeId( obj_id, statbuf.type );
-          if ( err < 0 )
-          {
-            qDebug() << "Error Closing Object";
-            retErr = err;
-          }
-        }
-        return retErr;
-#endif
       }
 
       /**

--- a/Source/H5Support/Test/H5LiteTest.cpp
+++ b/Source/H5Support/Test/H5LiteTest.cpp
@@ -364,14 +364,14 @@ public:
     attributeKey = "VectorAttribute<" + attributeKey + ">";
 
     int32_t numElements = DIM0;
-    QVector<hsize_t> dims(1, DIM0);
+    std::vector<hsize_t> dims(1, DIM0);
 
-    QVector<T> data(DIM0, 0);
+    std::vector<T> data(DIM0, 0);
     for(int i = 0; i < numElements; ++i)
     {
       data[i] = (T)(i);
     }
-    QVector<T> rData(numElements, 0); // allocate and zero out the memory
+    std::vector<T> rData(numElements, 0); // allocate and zero out the memory
     err = QH5Lite::readVectorAttribute(file_id, dsetName, attributeKey, rData);
     DREAM3D_REQUIRE(err >= 0);
     DREAM3D_REQUIRE(data == rData);

--- a/Source/SIMPLib/Common/EnsembleInfo.cpp
+++ b/Source/SIMPLib/Common/EnsembleInfo.cpp
@@ -200,7 +200,7 @@ void EnsembleInfo::setPhaseName(size_t index, QString phaseName)
 // -----------------------------------------------------------------------------
 void EnsembleInfo::remove(size_t index)
 {
-  QVector<size_t> indexVec;
+  std::vector<size_t> indexVec;
   indexVec.push_back(index);
   m_CrystalStructures.erase(m_CrystalStructures.begin() + index);
   m_PhaseTypes.erase(m_PhaseTypes.begin() + index);

--- a/Source/SIMPLib/Common/SIMPLibSetGetMacros.h
+++ b/Source/SIMPLib/Common/SIMPLibSetGetMacros.h
@@ -220,9 +220,11 @@ public:     \
     return superclass::IsTypeOf(type); \
   }
 
-#define SIMPL_CLASS_VERSION(vers)\
-  virtual int getClassVersion() { return vers; }
-
+#define SIMPL_CLASS_VERSION(vers)                                                                                                                                                                      \
+  int getClassVersion() override                                                                                                                                                                       \
+  {                                                                                                                                                                                                    \
+    return vers;                                                                                                                                                                                       \
+  }
 
 //------------------------------------------------------------------------------
 // Macros for Properties

--- a/Source/SIMPLib/Common/TemplateHelpers.cpp
+++ b/Source/SIMPLib/Common/TemplateHelpers.cpp
@@ -37,7 +37,8 @@
 using namespace TemplateHelpers;
 
 // -----------------------------------------------------------------------------
-IDataArrayWkPtr CreateNonPrereqArrayFromArrayType::operator()(AbstractFilter* f, const DataArrayPath& arrayPath, const QVector<size_t>& compDims, const IDataArrayShPtr& sourceArrayType, RenameDataPath::DataID_t id)
+IDataArrayWkPtr CreateNonPrereqArrayFromArrayType::operator()(AbstractFilter* f, const DataArrayPath& arrayPath, const std::vector<size_t>& compDims, const IDataArrayShPtr& sourceArrayType,
+                                                              RenameDataPath::DataID_t id)
 {
 
   IDataArrayShPtr ptr = IDataArray::NullPointer();
@@ -99,7 +100,8 @@ IDataArrayWkPtr CreateNonPrereqArrayFromArrayType::operator()(AbstractFilter* f,
 }
 
 // -----------------------------------------------------------------------------
-IDataArrayWkPtr CreateNonPrereqArrayFromTypeEnum::operator()(AbstractFilter* f, const DataArrayPath& arrayPath, const QVector<size_t>& compDims, int arrayType, double initValue, RenameDataPath::DataID_t id)
+IDataArrayWkPtr CreateNonPrereqArrayFromTypeEnum::operator()(AbstractFilter* f, const DataArrayPath& arrayPath, const std::vector<size_t>& compDims, int arrayType, double initValue,
+                                                             RenameDataPath::DataID_t id)
 {
   IDataArrayShPtr ptr = IDataArray::NullPointer();
 
@@ -150,16 +152,16 @@ IDataArrayWkPtr CreateNonPrereqArrayFromTypeEnum::operator()(AbstractFilter* f, 
 }
 
 // -----------------------------------------------------------------------------
-IDataArrayShPtr CreateArrayFromArrayType::operator()(AbstractFilter* f, const size_t& numTuples, const QVector<size_t>& compDims, const QString& arrayName, bool allocate,
+IDataArrayShPtr CreateArrayFromArrayType::operator()(AbstractFilter* f, const size_t& numTuples, const std::vector<size_t>& compDims, const QString& arrayName, bool allocate,
                                                      const IDataArrayShPtr& sourceArrayType)
 {
   CreateArrayFromArrayType classInstance;
-  QVector<size_t> tupleDims(1, numTuples);
+  std::vector<size_t> tupleDims = {numTuples};
   return classInstance(f, tupleDims, compDims, arrayName, allocate, sourceArrayType);
 }
 
 // -----------------------------------------------------------------------------
-IDataArrayShPtr CreateArrayFromArrayType::operator()(AbstractFilter* f, const QVector<size_t>& tupleDims, const QVector<size_t>& compDims, const QString& arrayName, bool allocate,
+IDataArrayShPtr CreateArrayFromArrayType::operator()(AbstractFilter* f, const std::vector<size_t>& tupleDims, const std::vector<size_t>& compDims, const QString& arrayName, bool allocate,
                                                      const IDataArrayShPtr& sourceArrayType)
 {
   IDataArrayShPtr ptr = IDataArray::NullPointer();
@@ -221,15 +223,16 @@ IDataArrayShPtr CreateArrayFromArrayType::operator()(AbstractFilter* f, const QV
 }
 
 // -----------------------------------------------------------------------------
-IDataArrayShPtr CreateArrayFromType::operator()(AbstractFilter* f, const size_t& numTuples, const QVector<size_t>& compDims, const QString& arrayName, bool allocate, const QString& type)
+IDataArrayShPtr CreateArrayFromType::operator()(AbstractFilter* f, const size_t& numTuples, const std::vector<size_t>& compDims, const QString& arrayName, bool allocate, const QString& type)
 {
   CreateArrayFromType classInstance;
-  QVector<size_t> tupleDims(1, numTuples);
+  std::vector<size_t> tupleDims(1, numTuples);
   return classInstance(f, tupleDims, compDims, arrayName, allocate, type);
 }
 
 // -----------------------------------------------------------------------------
-IDataArrayShPtr CreateArrayFromType::operator()(AbstractFilter* f, const QVector<size_t>& tupleDims, const QVector<size_t>& compDims, const QString& arrayName, bool allocate, const QString& type)
+IDataArrayShPtr CreateArrayFromType::operator()(AbstractFilter* f, const std::vector<size_t>& tupleDims, const std::vector<size_t>& compDims, const QString& arrayName, bool allocate,
+                                                const QString& type)
 {
   IDataArrayShPtr ptr = IDataArray::NullPointer();
 
@@ -287,7 +290,7 @@ IDataArrayShPtr CreateArrayFromType::operator()(AbstractFilter* f, const QVector
 }
 
 // -----------------------------------------------------------------------------
-IDataArrayWkPtr GetPrereqArrayFromPath::operator()(AbstractFilter* f, const DataArrayPath& arrayPath, QVector<size_t>& compDims)
+IDataArrayWkPtr GetPrereqArrayFromPath::operator()(AbstractFilter* f, const DataArrayPath& arrayPath, std::vector<size_t>& compDims)
 {
   IDataArrayShPtr retPtr = IDataArray::NullPointer();
   DataContainer::Pointer volDataCntr = f->getDataContainerArray()->getPrereqDataContainer(f, arrayPath.getDataContainerName(), false);
@@ -311,7 +314,7 @@ IDataArrayWkPtr GetPrereqArrayFromPath::operator()(AbstractFilter* f, const Data
     f->setErrorCondition(Errors::MissingArray, ss);
     return retPtr;
   }
-  if(compDims.isEmpty())
+  if(compDims.empty())
   {
     compDims = templ_ptr->getComponentDimensions();
   }

--- a/Source/SIMPLib/Common/TemplateHelpers.h
+++ b/Source/SIMPLib/Common/TemplateHelpers.h
@@ -36,6 +36,7 @@
 
 //-- C++11 Includes
 #include <memory>
+#include <vector>
 
 #include <QtCore/QString>
 
@@ -230,7 +231,8 @@ public:
    * @param sourceArrayType
    * @return
    */
-  IDataArrayWkPtr operator()(AbstractFilter* f, const DataArrayPath& arrayPath, const QVector<size_t>& compDims, const IDataArrayShPtr& sourceArrayType, RenameDataPath::DataID_t = RenameDataPath::k_Invalid_ID);
+  IDataArrayWkPtr operator()(AbstractFilter* f, const DataArrayPath& arrayPath, const std::vector<size_t>& compDims, const IDataArrayShPtr& sourceArrayType,
+                             RenameDataPath::DataID_t = RenameDataPath::k_Invalid_ID);
 };
 
 /**
@@ -256,7 +258,8 @@ public:
    * @param initValue
    * @return
    */
-  IDataArrayWkPtr operator()(AbstractFilter* f, const DataArrayPath& arrayPath, const QVector<size_t>& compDims, int arrayType, double initValue, RenameDataPath::DataID_t id = RenameDataPath::k_Invalid_ID);
+  IDataArrayWkPtr operator()(AbstractFilter* f, const DataArrayPath& arrayPath, const std::vector<size_t>& compDims, int arrayType, double initValue,
+                             RenameDataPath::DataID_t id = RenameDataPath::k_Invalid_ID);
 };
 
 /**
@@ -273,7 +276,7 @@ public:
   CreateArrayFromArrayType& operator=(const CreateArrayFromArrayType&) = delete; // Copy Assignment Not Implemented
   CreateArrayFromArrayType& operator=(CreateArrayFromArrayType&&) = delete;      // Move Assignment Not Implemented
 
-  IDataArrayShPtr operator()(AbstractFilter* f, const size_t& numTuples, const QVector<size_t>& compDims, const QString& arrayName, bool allocate, const IDataArrayShPtr& sourceArrayType);
+  IDataArrayShPtr operator()(AbstractFilter* f, const size_t& numTuples, const std::vector<size_t>& compDims, const QString& arrayName, bool allocate, const IDataArrayShPtr& sourceArrayType);
 
   /**
    * @brief operator ()
@@ -285,7 +288,8 @@ public:
    * @param sourceArrayType
    * @return
    */
-  IDataArrayShPtr operator()(AbstractFilter* f, const QVector<size_t>& tupleDims, const QVector<size_t>& compDims, const QString& arrayName, bool allocate, const IDataArrayShPtr& sourceArrayType);
+  IDataArrayShPtr operator()(AbstractFilter* f, const std::vector<size_t>& tupleDims, const std::vector<size_t>& compDims, const QString& arrayName, bool allocate,
+                             const IDataArrayShPtr& sourceArrayType);
 };
 
 /**
@@ -312,7 +316,7 @@ public:
    * @param type
    * @return
    */
-  IDataArrayShPtr operator()(AbstractFilter* f, const size_t& numTuples, const QVector<size_t>& compDims, const QString& arrayName, bool allocate, const QString& type);
+  IDataArrayShPtr operator()(AbstractFilter* f, const size_t& numTuples, const std::vector<size_t>& compDims, const QString& arrayName, bool allocate, const QString& type);
 
   /**
    * @brief operator ()
@@ -324,7 +328,7 @@ public:
    * @param type
    * @return
    */
-  IDataArrayShPtr operator()(AbstractFilter* f, const QVector<size_t>& tupleDims, const QVector<size_t>& compDims, const QString& arrayName, bool allocate, const QString& type);
+  IDataArrayShPtr operator()(AbstractFilter* f, const std::vector<size_t>& tupleDims, const std::vector<size_t>& compDims, const QString& arrayName, bool allocate, const QString& type);
 };
 
 /**
@@ -347,7 +351,7 @@ public:
    * @param compDims
    * @return
    */
-  IDataArrayWkPtr operator()(AbstractFilter* f, const DataArrayPath& arrayPath, QVector<size_t>& compDims);
+  IDataArrayWkPtr operator()(AbstractFilter* f, const DataArrayPath& arrayPath, std::vector<size_t>& compDims);
   // Move assignment Not Implemented
 };
 

--- a/Source/SIMPLib/CoreFilters/ArrayCalculator.cpp
+++ b/Source/SIMPLib/CoreFilters/ArrayCalculator.cpp
@@ -265,7 +265,7 @@ void ArrayCalculator::dataCheck()
 
   AttributeMatrix::Pointer selectedAM = getDataContainerArray()->getAttributeMatrix(m_SelectedAttributeMatrix);
 
-  QVector<size_t> cDims;
+  std::vector<size_t> cDims;
   ICalculatorArray::ValueType resultType = ICalculatorArray::ValueType::Unknown;
 
   for(const auto& item1 : parsedInfix)
@@ -277,7 +277,7 @@ void ArrayCalculator::dataCheck()
       ICalculatorArray::Pointer array1 = std::dynamic_pointer_cast<ICalculatorArray>(item1);
       if (item1->isArray())
       {
-        if(!cDims.isEmpty() && resultType == ICalculatorArray::ValueType::Array && cDims != array1->getArray()->getComponentDimensions())
+        if(!cDims.empty() && resultType == ICalculatorArray::ValueType::Array && cDims != array1->getArray()->getComponentDimensions())
         {
           QString ss = QObject::tr("Attribute Array symbols in the infix expression have mismatching component dimensions");
           setErrorCondition(static_cast<int>(CalculatorItem::ErrorCode::INCONSISTENT_COMP_DIMS), ss);
@@ -804,7 +804,7 @@ void ArrayCalculator::parseMinusSign(QString token, QVector<CalculatorItem::Poin
 void ArrayCalculator::parseNumericValue(QString token, QVector<CalculatorItem::Pointer>& parsedInfix, double number)
 {
   // This is a number, so create an array with numOfTuples equal to 1 and set the value into it
-  DoubleArrayType::Pointer ptr = DoubleArrayType::CreateArray(1, QVector<size_t>(1, 1), "INTERNAL_USE_ONLY_NumberArray");
+  DoubleArrayType::Pointer ptr = DoubleArrayType::CreateArray(1, std::vector<size_t>(1, 1), "INTERNAL_USE_ONLY_NumberArray");
   ptr->setValue(0, number);
   CalculatorItem::Pointer itemPtr = CalculatorArray<double>::New(ptr, ICalculatorArray::Number, !getInPreflight());
   parsedInfix.push_back(itemPtr);

--- a/Source/SIMPLib/CoreFilters/ArrayCalculator.h
+++ b/Source/SIMPLib/CoreFilters/ArrayCalculator.h
@@ -54,7 +54,7 @@ class SIMPLib_EXPORT ArrayCalculator : public AbstractFilter
     PYB11_PROPERTY(DataArrayPath SelectedAttributeMatrix READ getSelectedAttributeMatrix WRITE setSelectedAttributeMatrix)
     PYB11_PROPERTY(QString InfixEquation READ getInfixEquation WRITE setInfixEquation)
     PYB11_PROPERTY(DataArrayPath CalculatedArray READ getCalculatedArray WRITE setCalculatedArray)
-    PYB11_PROPERTY(AngleUnits Units READ getUnits WRITE setUnits)
+    PYB11_PROPERTY(ArrayCalculator::AngleUnits Units READ getUnits WRITE setUnits)
     PYB11_PROPERTY(SIMPL::ScalarTypes::Type ScalarType READ getScalarType WRITE setScalarType)
 
   public:

--- a/Source/SIMPLib/CoreFilters/CombineAttributeArrays.cpp
+++ b/Source/SIMPLib/CoreFilters/CombineAttributeArrays.cpp
@@ -285,7 +285,7 @@ void CombineAttributeArrays::dataCheck()
     return;
   }
 
-  QVector<size_t> cDims(1, totalComps);
+  std::vector<size_t> cDims(1, totalComps);
 
   DataArrayPath tempPath(getSelectedDataArrayPaths()[0].getDataContainerName(), getSelectedDataArrayPaths()[0].getAttributeMatrixName(), getStackedDataArrayName());
   m_StackedDataPtr = TemplateHelpers::CreateNonPrereqArrayFromArrayType()(this, tempPath, cDims, m_SelectedWeakPtrVector[0].lock(), CombinedArrayID);

--- a/Source/SIMPLib/CoreFilters/CombineAttributeMatrices.cpp
+++ b/Source/SIMPLib/CoreFilters/CombineAttributeMatrices.cpp
@@ -107,7 +107,7 @@ void CombineAttributeMatrices::setupFilterParameters()
     amTypes.push_back(AttributeMatrix::Type::VertexFeature);
     QVector<QString> daTypes;
     daTypes.push_back(SIMPL::TypeNames::Int32);
-    QVector<QVector<size_t>> compDims;
+    std::vector<std::vector<size_t>> compDims;
     compDims.resize(1);
     compDims[0].resize(1);
     compDims[0][0] = 1;
@@ -197,7 +197,7 @@ void CombineAttributeMatrices::dataCheck()
   // Note that the minus 1 in the totalTuples calculation is to account for the fact that the zeroth tuple in the two attribute matrices should only be counted once, not twice.
   // All Feature or Ensemble AMs should start from 1 and the zeroth tuple can be combined in the two AMs
   size_t totalTuples = firstAttrMat->getNumberOfTuples() + secondAttrMat->getNumberOfTuples() - 1;
-  QVector<size_t> tDims(1, totalTuples);
+  std::vector<size_t> tDims(1, totalTuples);
   m->createNonPrereqAttributeMatrix(this, getCombinedAttributeMatrixName(), tDims, firstAttrMat->getType(), CombinedMatrixID);
   if(getErrorCode() < 0)
   {
@@ -205,7 +205,7 @@ void CombineAttributeMatrices::dataCheck()
   }
   AttributeMatrix::Pointer combinedAttrMat = m->getAttributeMatrix(getCombinedAttributeMatrixName());
 
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   m_FirstIndexPtr = getDataContainerArray()->getPrereqArrayFromPath<DataArray<int32_t>, AbstractFilter>(this, getFirstIndexArrayPath(),
                                                                                                         cDims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */
   if(nullptr != m_FirstIndexPtr.lock())                                                                         /* Validate the Weak Pointer wraps a non-nullptr pointer to a DataArray<T> object */
@@ -236,7 +236,7 @@ void CombineAttributeMatrices::dataCheck()
     IDataArray::Pointer tmpDataArray = firstAttrMat->getPrereqIDataArray<IDataArray, AbstractFilter>(this, *iter, -90001);
     if(getErrorCode() >= 0)
     {
-      QVector<size_t> cDims = tmpDataArray->getComponentDimensions();
+      std::vector<size_t> cDims = tmpDataArray->getComponentDimensions();
       TemplateHelpers::CreateNonPrereqArrayFromArrayType()(this, tempPath, cDims, tmpDataArray);
     }
   }
@@ -249,7 +249,7 @@ void CombineAttributeMatrices::dataCheck()
     {
       if(!fArrayNames.contains(*iter))
       {
-        QVector<size_t> cDims = tmpDataArray->getComponentDimensions();
+        std::vector<size_t> cDims = tmpDataArray->getComponentDimensions();
         TemplateHelpers::CreateNonPrereqArrayFromArrayType()(this, tempPath, cDims, tmpDataArray);
       }
     }

--- a/Source/SIMPLib/CoreFilters/ConditionalSetValue.cpp
+++ b/Source/SIMPLib/CoreFilters/ConditionalSetValue.cpp
@@ -176,7 +176,7 @@ void ConditionalSetValue::dataCheck()
     return;
   }
 
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   m_ConditionalArrayPtr = getDataContainerArray()->getPrereqArrayFromPath<DataArray<bool>, AbstractFilter>(this, getConditionalArrayPath(),
                                                                                                            cDims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */
   if(nullptr != m_ConditionalArrayPtr.lock())                                                                      /* Validate the Weak Pointer wraps a non-nullptr pointer to a DataArray<T> object */

--- a/Source/SIMPLib/CoreFilters/ConvertColorToGrayScale.cpp
+++ b/Source/SIMPLib/CoreFilters/ConvertColorToGrayScale.cpp
@@ -285,7 +285,7 @@ void ConvertColorToGrayScale::dataCheck()
   AttributeMatrix::Pointer outAM;
   if(m_CreateNewAttributeMatrix)
   {
-    QVector<size_t> tDims = inAM->getTupleDimensions();
+    std::vector<size_t> tDims = inAM->getTupleDimensions();
 
     outAM = dc->createNonPrereqAttributeMatrix(this, getOutputAttributeMatrixName(), tDims, AttributeMatrix::Type::Cell);
     if(getErrorCode() < 0 || nullptr == outAM.get())
@@ -308,7 +308,7 @@ void ConvertColorToGrayScale::dataCheck()
     {
       return;
     }
-    QVector<size_t> outCDims(1, 1);
+    std::vector<size_t> outCDims(1, 1);
     if(outAM.get() == nullptr)
     {
       outAM = dc->getPrereqAttributeMatrix(this, inputAMPath.getAttributeMatrixName(), -62105);

--- a/Source/SIMPLib/CoreFilters/ConvertData.cpp
+++ b/Source/SIMPLib/CoreFilters/ConvertData.cpp
@@ -51,7 +51,7 @@
     Type::Pointer Type##Ptr = std::dynamic_pointer_cast<Type>(Array);                                                                                                                                  \
     if(nullptr != Type##Ptr)                                                                                                                                                                           \
     {                                                                                                                                                                                                  \
-      QVector<size_t> dims = Array->getComponentDimensions();                                                                                                                                          \
+      std::vector<size_t> dims = Array->getComponentDimensions();                                                                                                                                      \
       Detail::ConvertData<Type>(this, Type##Ptr.get(), dims, DataContainer, ScalarType, AttributeMatrixName, OutputName);                                                                              \
       completed = true;                                                                                                                                                                                \
     }                                                                                                                                                                                                  \
@@ -69,7 +69,8 @@ template <typename T>
  * @param attributeMatrixName Name of target AttributeMatrix
  * @param name Name of converted array
  */
-void ConvertData(AbstractFilter* filter, T* ptr, QVector<size_t> dims, DataContainer::Pointer m, SIMPL::NumericTypes::Type scalarType, const QString attributeMatrixName, const QString& name)
+void ConvertData(AbstractFilter* filter, T* ptr, const std::vector<size_t>& dims, DataContainer::Pointer m, SIMPL::NumericTypes::Type scalarType, const QString attributeMatrixName,
+                 const QString& name)
 {
   size_t voxels = ptr->getNumberOfTuples();
   size_t size = ptr->getSize();
@@ -267,7 +268,7 @@ void ConvertData::dataCheck()
       return;
     }
 
-    QVector<size_t> dims = p->getComponentDimensions();
+    std::vector<size_t> dims = p->getComponentDimensions();
     size_t voxels = cellAttrMat->getNumberOfTuples();
     if(m_ScalarType == SIMPL::NumericTypes::Type::Int8)
     {

--- a/Source/SIMPLib/CoreFilters/CopyFeatureArrayToElementArray.cpp
+++ b/Source/SIMPLib/CoreFilters/CopyFeatureArrayToElementArray.cpp
@@ -121,7 +121,7 @@ void CopyFeatureArrayToElementArray::dataCheck()
     return;
   }
 
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   m_FeatureIdsPtr = getDataContainerArray()->getPrereqArrayFromPath<DataArray<int32_t>, AbstractFilter>(this, getFeatureIdsArrayPath(),
                                                                                                         cDims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */
   if(nullptr != m_FeatureIdsPtr.lock())                                                                         /* Validate the Weak Pointer wraps a non-nullptr pointer to a DataArray<T> object */
@@ -170,7 +170,7 @@ template <typename T> IDataArray::Pointer copyData(IDataArray::Pointer inputData
     return IDataArray::NullPointer();
   }
 
-  QVector<size_t> cDims = inputData->getComponentDimensions();
+  std::vector<size_t> cDims = inputData->getComponentDimensions();
   typename DataArray<T>::Pointer cell = DataArray<T>::CreateArray(totalPoints, cDims, cellArrayName);
 
   T* fPtr = feature->getPointer(0);

--- a/Source/SIMPLib/CoreFilters/CreateAttributeMatrix.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateAttributeMatrix.cpp
@@ -140,7 +140,7 @@ void CreateAttributeMatrix::dataCheck()
   }
 
   std::vector<double> cols = rows[0]; // Get the first (and only) row of data
-  QVector<size_t> tDims(cols.size(), 0);
+  std::vector<size_t> tDims(cols.size(), 0);
   for(int i = 0; i < cols.size(); i++)
   {
     tDims[i] = static_cast<size_t>(cols[i]);

--- a/Source/SIMPLib/CoreFilters/CreateDataArray.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateDataArray.cpp
@@ -352,7 +352,7 @@ void CreateDataArray::dataCheck()
     QString ss = QObject::tr("The Created DataArrayPath is invalid. Please select the Data Container, Attribute Matrix and set an output DataArray name.");
     setErrorCondition(-8051, ss);
   }
-  QVector<size_t> cDims(1, getNumberOfComponents());
+  std::vector<size_t> cDims(1, getNumberOfComponents());
   if(getErrorCode() < 0)
   {
     return;

--- a/Source/SIMPLib/CoreFilters/CreateFeatureArrayFromElementArray.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateFeatureArrayFromElementArray.cpp
@@ -124,7 +124,7 @@ void CreateFeatureArrayFromElementArray::dataCheck()
     return;
   }
 
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   m_FeatureIdsPtr = getDataContainerArray()->getPrereqArrayFromPath<DataArray<int32_t>, AbstractFilter>(this, getFeatureIdsArrayPath(),
                                                                                                         cDims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */
   if(nullptr != m_FeatureIdsPtr.lock())                                                                         /* Validate the Weak Pointer wraps a non-nullptr pointer to a DataArray<T> object */
@@ -171,7 +171,7 @@ template <typename T> IDataArray::Pointer copyCellData(AbstractFilter* filter, I
     return IDataArray::NullPointer();
   }
 
-  QVector<size_t> dims = inputData->getComponentDimensions();
+  std::vector<size_t> dims = inputData->getComponentDimensions();
   typename DataArray<T>::Pointer feature = DataArray<T>::CreateArray(features, dims, createdArrayName);
 
   T* fPtr = feature->getPointer(0);

--- a/Source/SIMPLib/CoreFilters/CreateGeometry.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateGeometry.cpp
@@ -289,7 +289,7 @@ void CreateGeometry::dataCheck()
     image->setSpacing(getSpacing());
     dc->setGeometry(image);
 
-    QVector<size_t> tDims = {image->getXPoints(), image->getYPoints(), image->getZPoints()};
+    std::vector<size_t> tDims = {image->getXPoints(), image->getYPoints(), image->getZPoints()};
     DataArrayPath path = getDataContainerName();
     path.setAttributeMatrixName(getImageCellAttributeMatrixName());
     dc->createNonPrereqAttributeMatrix(this, path, tDims, AttributeMatrix::Type::Cell);
@@ -297,7 +297,7 @@ void CreateGeometry::dataCheck()
   }
   case 1: // RectGridGeom
   {
-    QVector<size_t> cDims(1, 1);
+    std::vector<size_t> cDims(1, 1);
 
     m_XBoundsPtr = getDataContainerArray()->getPrereqArrayFromPath<DataArray<float>, AbstractFilter>(this, getXBoundsArrayPath(), cDims);
     if(m_XBoundsPtr.lock())
@@ -353,7 +353,7 @@ void CreateGeometry::dataCheck()
     rectgrid->setDimensions(SizeVec3Type(m_XBoundsPtr.lock()->getNumberOfTuples() - 1, m_YBoundsPtr.lock()->getNumberOfTuples() - 1, m_ZBoundsPtr.lock()->getNumberOfTuples() - 1));
     dc->setGeometry(rectgrid);
 
-    QVector<size_t> tDims = {rectgrid->getXPoints(), rectgrid->getYPoints(), rectgrid->getZPoints()};
+    std::vector<size_t> tDims = {rectgrid->getXPoints(), rectgrid->getYPoints(), rectgrid->getZPoints()};
     DataArrayPath path = getDataContainerName();
     path.setAttributeMatrixName(getRectGridCellAttributeMatrixName());
     dc->createNonPrereqAttributeMatrix(this, path, tDims, AttributeMatrix::Type::Cell);
@@ -361,7 +361,7 @@ void CreateGeometry::dataCheck()
   }
   case 2: // VertexGeom
   {
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     FloatArrayType::Pointer verts = getDataContainerArray()->getPrereqArrayFromPath<DataArray<float>, AbstractFilter>(this, getSharedVertexListArrayPath0(), cDims);
 
@@ -382,7 +382,7 @@ void CreateGeometry::dataCheck()
     }
     dc->setGeometry(vertex);
 
-    QVector<size_t> tDims(1, vertex->getNumberOfVertices());
+    std::vector<size_t> tDims(1, vertex->getNumberOfVertices());
     DataArrayPath path = getDataContainerName();
     path.setAttributeMatrixName(getVertexAttributeMatrixName0());
     dc->createNonPrereqAttributeMatrix(this, path, tDims, AttributeMatrix::Type::Vertex);
@@ -390,7 +390,7 @@ void CreateGeometry::dataCheck()
   }
   case 3: // EdgeGeom
   {
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     FloatArrayType::Pointer verts = getDataContainerArray()->getPrereqArrayFromPath<DataArray<float>, AbstractFilter>(this, getSharedVertexListArrayPath1(), cDims);
     cDims[0] = 2;
@@ -420,7 +420,7 @@ void CreateGeometry::dataCheck()
     dc->setGeometry(edge);
 
     m_NumVerts = edge->getNumberOfVertices();
-    QVector<size_t> tDims(1, edge->getNumberOfVertices());
+    std::vector<size_t> tDims(1, edge->getNumberOfVertices());
     DataArrayPath path = getDataContainerName();
     path.setAttributeMatrixName(getVertexAttributeMatrixName1());
     dc->createNonPrereqAttributeMatrix(this, path, tDims, AttributeMatrix::Type::Vertex);
@@ -431,7 +431,7 @@ void CreateGeometry::dataCheck()
   }
   case 4: // TriangleGeom
   {
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     FloatArrayType::Pointer verts = getDataContainerArray()->getPrereqArrayFromPath<DataArray<float>, AbstractFilter>(this, getSharedVertexListArrayPath2(), cDims);
     m_TrisPtr = getDataContainerArray()->getPrereqArrayFromPath<SharedTriList, AbstractFilter>(this, getSharedTriListArrayPath(), cDims);
@@ -460,7 +460,7 @@ void CreateGeometry::dataCheck()
     dc->setGeometry(triangle);
 
     m_NumVerts = triangle->getNumberOfVertices();
-    QVector<size_t> tDims(1, triangle->getNumberOfVertices());
+    std::vector<size_t> tDims(1, triangle->getNumberOfVertices());
     DataArrayPath path = getDataContainerName();
     path.setAttributeMatrixName(getVertexAttributeMatrixName2());
     dc->createNonPrereqAttributeMatrix(this, path, tDims, AttributeMatrix::Type::Vertex);
@@ -471,7 +471,7 @@ void CreateGeometry::dataCheck()
   }
   case 5: // QuadGeom
   {
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     FloatArrayType::Pointer verts = getDataContainerArray()->getPrereqArrayFromPath<DataArray<float>, AbstractFilter>(this, getSharedVertexListArrayPath3(), cDims);
     cDims[0] = 4;
@@ -501,7 +501,7 @@ void CreateGeometry::dataCheck()
     dc->setGeometry(quadrilateral);
 
     m_NumVerts = quadrilateral->getNumberOfVertices();
-    QVector<size_t> tDims(1, quadrilateral->getNumberOfVertices());
+    std::vector<size_t> tDims(1, quadrilateral->getNumberOfVertices());
     DataArrayPath path = getDataContainerName();
     path.setAttributeMatrixName(getVertexAttributeMatrixName3());
     dc->createNonPrereqAttributeMatrix(this, path, tDims, AttributeMatrix::Type::Vertex);
@@ -512,7 +512,7 @@ void CreateGeometry::dataCheck()
   }
   case 6: // TetrahedralGeom
   {
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     FloatArrayType::Pointer verts = getDataContainerArray()->getPrereqArrayFromPath<DataArray<float>, AbstractFilter>(this, getSharedVertexListArrayPath4(), cDims);
     cDims[0] = 4;
@@ -543,7 +543,7 @@ void CreateGeometry::dataCheck()
     dc->setGeometry(tetrahedral);
 
     m_NumVerts = tetrahedral->getNumberOfVertices();
-    QVector<size_t> tDims(1, tetrahedral->getNumberOfVertices());
+    std::vector<size_t> tDims(1, tetrahedral->getNumberOfVertices());
     DataArrayPath path = getDataContainerName();
     path.setAttributeMatrixName(getVertexAttributeMatrixName4());
     dc->createNonPrereqAttributeMatrix(this, path, tDims, AttributeMatrix::Type::Vertex);
@@ -554,7 +554,7 @@ void CreateGeometry::dataCheck()
   }
   case 7: // HexahedralGeom
   {
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     FloatArrayType::Pointer verts = getDataContainerArray()->getPrereqArrayFromPath<DataArray<float>, AbstractFilter>(this, getSharedVertexListArrayPath5(), cDims);
     cDims[0] = 8;
@@ -586,7 +586,7 @@ void CreateGeometry::dataCheck()
     dc->setGeometry(hexahedral);
 
     m_NumVerts = hexahedral->getNumberOfVertices();
-    QVector<size_t> tDims(1, hexahedral->getNumberOfVertices());
+    std::vector<size_t> tDims(1, hexahedral->getNumberOfVertices());
     DataArrayPath path = getDataContainerName();
     path.setAttributeMatrixName(getVertexAttributeMatrixName5());
     dc->createNonPrereqAttributeMatrix(this, path, tDims, AttributeMatrix::Type::Vertex);

--- a/Source/SIMPLib/CoreFilters/CreateStringArray.cpp
+++ b/Source/SIMPLib/CoreFilters/CreateStringArray.cpp
@@ -152,7 +152,7 @@ void CreateStringArray::dataCheck()
     QString ss = "Empty initialization value.";
     setErrorCondition(-5759, ss);
   }
-  QVector<size_t> cDims(1, getNumberOfComponents());
+  std::vector<size_t> cDims(1, getNumberOfComponents());
   if(getErrorCode() < 0)
   {
     return;

--- a/Source/SIMPLib/CoreFilters/CropVertexGeometry.cpp
+++ b/Source/SIMPLib/CoreFilters/CropVertexGeometry.cpp
@@ -158,7 +158,7 @@ void CropVertexGeometry::dataCheck()
 
   DataContainer::Pointer m = getDataContainerArray()->getDataContainer(getDataContainerName());
   m_AttrMatList = m->getAttributeMatrixNames();
-  QVector<size_t> tDims(1, 0);
+  std::vector<size_t> tDims(1, 0);
   QList<QString> tempDataArrayList;
   DataArrayPath tempPath;
   AttributeMatrix::Type tempAttrMatType = AttributeMatrix::Type::Vertex;
@@ -189,7 +189,7 @@ void CropVertexGeometry::dataCheck()
           IDataArray::Pointer tmpDataArray = tmpAttrMat->getPrereqIDataArray<IDataArray, AbstractFilter>(this, data_array, -90002);
           if(getErrorCode() >= 0)
           {
-            QVector<size_t> cDims = tmpDataArray->getComponentDimensions();
+            std::vector<size_t> cDims = tmpDataArray->getComponentDimensions();
             TemplateHelpers::CreateNonPrereqArrayFromArrayType()(this, tempPath, cDims, tmpDataArray);
           }
         }
@@ -287,7 +287,7 @@ void CropVertexGeometry::execute()
     crop->setCoords(i, coords);
   }
 
-  QVector<size_t> tDims(1, croppedPoints.size());
+  std::vector<size_t> tDims(1, croppedPoints.size());
 
   for(auto&& attr_mat : m_AttrMatList)
   {

--- a/Source/SIMPLib/CoreFilters/ExtractAttributeArraysFromGeometry.cpp
+++ b/Source/SIMPLib/CoreFilters/ExtractAttributeArraysFromGeometry.cpp
@@ -246,7 +246,7 @@ void ExtractAttributeArraysFromGeometry::dataCheck()
     yarrays.push_back(rectgrid->getYBounds());
     zarrays.push_back(rectgrid->getZBounds());
 
-    QVector<size_t> cDims(1, 1);
+    std::vector<size_t> cDims(1, 1);
 
     m_XBoundsPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<float>, AbstractFilter, float>(this, getXBoundsArrayPath(), 0, cDims, "", RectGrid_XBoundsID);
     if(m_XBoundsPtr.lock())
@@ -291,7 +291,7 @@ void ExtractAttributeArraysFromGeometry::dataCheck()
     QVector<IDataArray::Pointer> arrays;
     arrays.push_back(vertex->getVertices());
 
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     m_VertsPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<float>, AbstractFilter, float>(this, getSharedVertexListArrayPath0(), 0, cDims, "", Vert_SharedVertexID);
     if(m_VertsPtr.lock())
@@ -316,7 +316,7 @@ void ExtractAttributeArraysFromGeometry::dataCheck()
     varrays.push_back(edge->getVertices());
     earrays.push_back(edge->getEdges());
 
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     m_VertsPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<float>, AbstractFilter, float>(this, getSharedVertexListArrayPath1(), 0, cDims, "", Edge_SharedVertexID);
     if(m_VertsPtr.lock())
@@ -354,7 +354,7 @@ void ExtractAttributeArraysFromGeometry::dataCheck()
     varrays.push_back(triangle->getVertices());
     earrays.push_back(triangle->getTriangles());
 
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     m_VertsPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<float>, AbstractFilter, float>(this, getSharedVertexListArrayPath2(), 0, cDims, "", Tri_SharedVertexID);
     if(m_VertsPtr.lock())
@@ -390,7 +390,7 @@ void ExtractAttributeArraysFromGeometry::dataCheck()
     varrays.push_back(quad->getVertices());
     earrays.push_back(quad->getQuads());
 
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     m_VertsPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<float>, AbstractFilter, float>(this, getSharedVertexListArrayPath3(), 0, cDims, "", Quad_SharedVertexID);
     if(m_VertsPtr.lock())
@@ -428,7 +428,7 @@ void ExtractAttributeArraysFromGeometry::dataCheck()
     varrays.push_back(tet->getVertices());
     earrays.push_back(tet->getTetrahedra());
 
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     m_VertsPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<float>, AbstractFilter, float>(this, getSharedVertexListArrayPath4(), 0, cDims, "", Tet_SharedVertexID);
     if(m_VertsPtr.lock())
@@ -466,7 +466,7 @@ void ExtractAttributeArraysFromGeometry::dataCheck()
     varrays.push_back(hex->getVertices());
     earrays.push_back(hex->getHexahedra());
 
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     m_VertsPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<float>, AbstractFilter, float>(this, getSharedVertexListArrayPath5(), 0, cDims, "", Hex_SharedVertexID);
     if(m_VertsPtr.lock())

--- a/Source/SIMPLib/CoreFilters/ExtractComponentAsArray.cpp
+++ b/Source/SIMPLib/CoreFilters/ExtractComponentAsArray.cpp
@@ -150,7 +150,7 @@ void ExtractComponentAsArray::dataCheck()
     return;
   }
 
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   DataArrayPath tempPath(getSelectedArrayPath().getDataContainerName(), getSelectedArrayPath().getAttributeMatrixName(), getNewArrayArrayName());
   m_NewArrayPtr = TemplateHelpers::CreateNonPrereqArrayFromArrayType()(this, tempPath, cDims, m_InArrayPtr.lock(), DataArrayID);
 }

--- a/Source/SIMPLib/CoreFilters/FeatureCountDecision.cpp
+++ b/Source/SIMPLib/CoreFilters/FeatureCountDecision.cpp
@@ -103,7 +103,7 @@ void FeatureCountDecision::dataCheck()
 
   getDataContainerArray()->getPrereqGeometryFromDataContainer<ImageGeom, AbstractFilter>(this, getFeatureIdsArrayPath().getDataContainerName());
 
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
 
   m_FeatureIdsPtr = getDataContainerArray()->getPrereqArrayFromPath<DataArray<int32_t>, AbstractFilter>(this, getFeatureIdsArrayPath(),
                                                                                                         cDims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */

--- a/Source/SIMPLib/CoreFilters/FindDerivatives.cpp
+++ b/Source/SIMPLib/CoreFilters/FindDerivatives.cpp
@@ -366,7 +366,7 @@ void FindDerivatives::dataCheck()
 
   int cDims = m_InArrayPtr.lock()->getNumberOfComponents();
   cDims *= 3;
-  QVector<size_t> dims(1, cDims);
+  std::vector<size_t> dims(1, cDims);
 
   m_DerivativesArrayPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<double>, AbstractFilter, double>(
       this, getDerivativesArrayPath(), 0, dims, "", DerivativesArrayID);    /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */

--- a/Source/SIMPLib/CoreFilters/GenerateColorTable.cpp
+++ b/Source/SIMPLib/CoreFilters/GenerateColorTable.cpp
@@ -21,7 +21,7 @@ enum createdPathID : RenameDataPath::DataID_t {
 //
 // -----------------------------------------------------------------------------
 template <typename T>
-int findRightBinIndex(T nValue, QVector<float> binPoints)
+int findRightBinIndex(T nValue, std::vector<float> binPoints)
 {
   /* This is a brute-force way of finding the proper bins.
      We will need to change this method to a binary search. */
@@ -37,7 +37,7 @@ int findRightBinIndex(T nValue, QVector<float> binPoints)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-int findRightBinIndex_Binary(float nValue, QVector<float> binPoints)
+int findRightBinIndex_Binary(float nValue, std::vector<float> binPoints)
 {
   int min = 0, max = binPoints.size() - 1;
   while (min < max)
@@ -63,13 +63,13 @@ template <typename T>
 class GenerateColorTableImpl
 {
 public:
-  GenerateColorTableImpl(typename DataArray<T>::Pointer arrayPtr, QVector<float> binPoints,
-                         std::vector<std::vector<double> > controlPoints, int numControlColors, UInt8ArrayType::Pointer colorArray) :
-    m_ArrayPtr(arrayPtr),
-    m_BinPoints(binPoints),
-    m_NumControlColors(numControlColors),
-    m_ControlPoints(controlPoints),
-    m_ColorArray(colorArray)
+  GenerateColorTableImpl(typename DataArray<T>::Pointer arrayPtr, std::vector<float>& binPoints, std::vector<std::vector<double>>& controlPoints, int numControlColors,
+                         const UInt8ArrayType::Pointer& colorArray)
+  : m_ArrayPtr(arrayPtr)
+  , m_BinPoints(binPoints)
+  , m_NumControlColors(numControlColors)
+  , m_ControlPoints(controlPoints)
+  , m_ColorArray(colorArray)
   {
     m_ArrayMin = arrayPtr->getValue(0);
     m_ArrayMax = arrayPtr->getValue(0);
@@ -132,7 +132,7 @@ public:
   }
 private:
   typename DataArray<T>::Pointer                        m_ArrayPtr;
-  QVector<float>                                        m_BinPoints;
+  std::vector<float> m_BinPoints;
   T                                                     m_ArrayMin;
   T                                                     m_ArrayMax;
   int                                                   m_NumControlColors;
@@ -158,7 +158,7 @@ void generateColorArray(typename DataArray<T>::Pointer arrayPtr, QJsonArray pres
   std::vector<std::vector<double> > controlPoints(numControlColors, std::vector<double>(numComponents));
 
   // Migrate colorControlPoints values from QJsonArray to 2D array.  Store A-values in binPoints vector.
-  QVector<float> binPoints;
+  std::vector<float> binPoints;
   for (int i=0; i<numControlColors; i++)
   {
     for (int j=0; j<numComponents; j++)
@@ -182,7 +182,7 @@ void generateColorArray(typename DataArray<T>::Pointer arrayPtr, QJsonArray pres
   DataArrayPath tmpPath = selectedDAP;
   tmpPath.setDataArrayName(rgbArrayName);
 
-  UInt8ArrayType::Pointer colorArray = dca->getPrereqArrayFromPath<UInt8ArrayType, AbstractFilter>(nullptr, tmpPath, QVector<size_t>(1, 3));
+  UInt8ArrayType::Pointer colorArray = dca->getPrereqArrayFromPath<UInt8ArrayType, AbstractFilter>(nullptr, tmpPath, std::vector<size_t>(1, 3));
   if (colorArray.get() == nullptr) { return; }
 
   ParallelDataAlgorithm dataAlg;
@@ -256,7 +256,7 @@ void GenerateColorTable::dataCheck()
   DataArrayPath tmpPath = getSelectedDataArrayPath();
   tmpPath.setDataArrayName(getRgbArrayName());
 
-  getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<uint8_t>, AbstractFilter, uint8_t>(this, tmpPath, 0, QVector<size_t>(1, 3), "", ColorArrayID);
+  getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<uint8_t>, AbstractFilter, uint8_t>(this, tmpPath, 0, std::vector<size_t>(1, 3), "", ColorArrayID);
 }
 
 // -----------------------------------------------------------------------------
@@ -285,59 +285,59 @@ void GenerateColorTable::execute()
     return;
   }
 
-  if (getDataContainerArray()->getPrereqArrayFromPath<Int8ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), QVector<size_t>(1, 1)).get() != nullptr)
+  if(getDataContainerArray()->getPrereqArrayFromPath<Int8ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), {static_cast<size_t>(1)}).get() != nullptr)
   {
-    Int8ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<Int8ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), QVector<size_t>(1, 1));
+    Int8ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<Int8ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), {static_cast<size_t>(1)});
     generateColorArray<int8_t>(ptr, getSelectedPresetControlPoints(), getSelectedDataArrayPath(), getRgbArrayName(), getDataContainerArray());
   }
-  else if (getDataContainerArray()->getPrereqArrayFromPath<UInt8ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), QVector<size_t>(1, 1)).get() != nullptr)
+  else if(getDataContainerArray()->getPrereqArrayFromPath<UInt8ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), {static_cast<size_t>(1)}).get() != nullptr)
   {
-    UInt8ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<UInt8ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), QVector<size_t>(1, 1));
+    UInt8ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<UInt8ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), {static_cast<size_t>(1)});
     generateColorArray<uint8_t>(ptr, getSelectedPresetControlPoints(), getSelectedDataArrayPath(), getRgbArrayName(), getDataContainerArray());
   }
-  else if (getDataContainerArray()->getPrereqArrayFromPath<Int16ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), QVector<size_t>(1, 1)).get() != nullptr)
+  else if(getDataContainerArray()->getPrereqArrayFromPath<Int16ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), {static_cast<size_t>(1)}).get() != nullptr)
   {
-    Int16ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<Int16ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), QVector<size_t>(1, 1));
+    Int16ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<Int16ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), {static_cast<size_t>(1)});
     generateColorArray<int16_t>(ptr, getSelectedPresetControlPoints(), getSelectedDataArrayPath(), getRgbArrayName(), getDataContainerArray());
   }
-  else if (getDataContainerArray()->getPrereqArrayFromPath<UInt16ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), QVector<size_t>(1, 1)).get() != nullptr)
+  else if(getDataContainerArray()->getPrereqArrayFromPath<UInt16ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), {static_cast<size_t>(1)}).get() != nullptr)
   {
-    UInt16ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<UInt16ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), QVector<size_t>(1, 1));
+    UInt16ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<UInt16ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), {static_cast<size_t>(1)});
     generateColorArray<uint16_t>(ptr, getSelectedPresetControlPoints(), getSelectedDataArrayPath(), getRgbArrayName(), getDataContainerArray());
   }
-  else if (getDataContainerArray()->getPrereqArrayFromPath<Int32ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), QVector<size_t>(1, 1)).get() != nullptr)
+  else if(getDataContainerArray()->getPrereqArrayFromPath<Int32ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), {static_cast<size_t>(1)}).get() != nullptr)
   {
-    Int32ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<Int32ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), QVector<size_t>(1, 1));
+    Int32ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<Int32ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), {static_cast<size_t>(1)});
     generateColorArray<int32_t>(ptr, getSelectedPresetControlPoints(), getSelectedDataArrayPath(), getRgbArrayName(), getDataContainerArray());
   }
-  else if (getDataContainerArray()->getPrereqArrayFromPath<UInt32ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), QVector<size_t>(1, 1)).get() != nullptr)
+  else if(getDataContainerArray()->getPrereqArrayFromPath<UInt32ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), {static_cast<size_t>(1)}).get() != nullptr)
   {
-    UInt32ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<UInt32ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), QVector<size_t>(1, 1));
+    UInt32ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<UInt32ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), {static_cast<size_t>(1)});
     generateColorArray<uint32_t>(ptr, getSelectedPresetControlPoints(), getSelectedDataArrayPath(), getRgbArrayName(), getDataContainerArray());
   }
-  else if (getDataContainerArray()->getPrereqArrayFromPath<Int64ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), QVector<size_t>(1, 1)).get() != nullptr)
+  else if(getDataContainerArray()->getPrereqArrayFromPath<Int64ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), {static_cast<size_t>(1)}).get() != nullptr)
   {
-    Int64ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<Int64ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), QVector<size_t>(1, 1));
+    Int64ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<Int64ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), {static_cast<size_t>(1)});
     generateColorArray<int64_t>(ptr, getSelectedPresetControlPoints(), getSelectedDataArrayPath(), getRgbArrayName(), getDataContainerArray());
   }
-  else if (getDataContainerArray()->getPrereqArrayFromPath<UInt64ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), QVector<size_t>(1, 1)).get() != nullptr)
+  else if(getDataContainerArray()->getPrereqArrayFromPath<UInt64ArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), {static_cast<size_t>(1)}).get() != nullptr)
   {
-    UInt64ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<UInt64ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), QVector<size_t>(1, 1));
+    UInt64ArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<UInt64ArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), {static_cast<size_t>(1)});
     generateColorArray<uint64_t>(ptr, getSelectedPresetControlPoints(), getSelectedDataArrayPath(), getRgbArrayName(), getDataContainerArray());
   }
-  else if (getDataContainerArray()->getPrereqArrayFromPath<DoubleArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), QVector<size_t>(1, 1)).get() != nullptr)
+  else if(getDataContainerArray()->getPrereqArrayFromPath<DoubleArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), {static_cast<size_t>(1)}).get() != nullptr)
   {
-    DoubleArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<DoubleArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), QVector<size_t>(1, 1));
+    DoubleArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<DoubleArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), {static_cast<size_t>(1)});
     generateColorArray<double>(ptr, getSelectedPresetControlPoints(), getSelectedDataArrayPath(), getRgbArrayName(), getDataContainerArray());
   }
-  else if (getDataContainerArray()->getPrereqArrayFromPath<FloatArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), QVector<size_t>(1, 1)).get() != nullptr)
+  else if(getDataContainerArray()->getPrereqArrayFromPath<FloatArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), {static_cast<size_t>(1)}).get() != nullptr)
   {
-    FloatArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<FloatArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), QVector<size_t>(1, 1));
+    FloatArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<FloatArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), {static_cast<size_t>(1)});
     generateColorArray<float>(ptr, getSelectedPresetControlPoints(), getSelectedDataArrayPath(), getRgbArrayName(), getDataContainerArray());
   }
-  else if (getDataContainerArray()->getPrereqArrayFromPath<BoolArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), QVector<size_t>(1, 1)).get() != nullptr)
+  else if(getDataContainerArray()->getPrereqArrayFromPath<BoolArrayType, AbstractFilter>(nullptr, getSelectedDataArrayPath(), {static_cast<size_t>(1)}).get() != nullptr)
   {
-    BoolArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<BoolArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), QVector<size_t>(1, 1));
+    BoolArrayType::Pointer ptr = getDataContainerArray()->getPrereqArrayFromPath<BoolArrayType, AbstractFilter>(this, getSelectedDataArrayPath(), {static_cast<size_t>(1)});
     generateColorArray<bool>(ptr, getSelectedPresetControlPoints(), getSelectedDataArrayPath(), getRgbArrayName(), getDataContainerArray());
   }
   else

--- a/Source/SIMPLib/CoreFilters/GenerateColorTable.cpp
+++ b/Source/SIMPLib/CoreFilters/GenerateColorTable.cpp
@@ -63,13 +63,13 @@ template <typename T>
 class GenerateColorTableImpl
 {
 public:
-  GenerateColorTableImpl(typename DataArray<T>::Pointer arrayPtr, std::vector<float>& binPoints, std::vector<std::vector<double>>& controlPoints, int numControlColors,
-                         const UInt8ArrayType::Pointer& colorArray)
+  GenerateColorTableImpl(typename DataArray<T>::Pointer arrayPtr, std::vector<float> binPoints, std::vector<std::vector<double>> controlPoints, int numControlColors,
+                         UInt8ArrayType::Pointer colorArray)
   : m_ArrayPtr(arrayPtr)
-  , m_BinPoints(binPoints)
+  , m_BinPoints(std::move(binPoints))
   , m_NumControlColors(numControlColors)
-  , m_ControlPoints(controlPoints)
-  , m_ColorArray(colorArray)
+  , m_ControlPoints(std::move(controlPoints))
+  , m_ColorArray(std::move(colorArray))
   {
     m_ArrayMin = arrayPtr->getValue(0);
     m_ArrayMax = arrayPtr->getValue(0);

--- a/Source/SIMPLib/CoreFilters/ImportAsciDataArray.cpp
+++ b/Source/SIMPLib/CoreFilters/ImportAsciDataArray.cpp
@@ -428,14 +428,14 @@ void ImportAsciDataArray::dataCheck()
     return;
   }
 
-  QVector<size_t> tDims = attrMat->getTupleDimensions();
+  std::vector<size_t> tDims = attrMat->getTupleDimensions();
   size_t totalDim = 1;
   for(int i = 0; i < tDims.size(); i++)
   {
     totalDim = totalDim * tDims[i];
   }
 
-  QVector<size_t> cDims(1, m_NumberOfComponents);
+  std::vector<size_t> cDims(1, m_NumberOfComponents);
   if(m_ScalarType == SIMPL::NumericTypes::Type::Int8)
   {
     getDataContainerArray()->createNonPrereqArrayFromPath<Int8ArrayType, AbstractFilter, int8_t>(this, getCreatedAttributeArrayPath(), 0, cDims, "CreatedAttributeArrayPath", AsciiArrayID);
@@ -517,7 +517,7 @@ void ImportAsciDataArray::execute()
 
   char delimiter = converSelectedDelimiter();
 
-  QVector<size_t> cDims(1, m_NumberOfComponents);
+  std::vector<size_t> cDims(1, m_NumberOfComponents);
   int32_t err = 0;
   if(m_ScalarType == SIMPL::NumericTypes::Type::Int8)
   {

--- a/Source/SIMPLib/CoreFilters/ImportAsciDataArray.cpp
+++ b/Source/SIMPLib/CoreFilters/ImportAsciDataArray.cpp
@@ -430,7 +430,7 @@ void ImportAsciDataArray::dataCheck()
 
   std::vector<size_t> tDims = attrMat->getTupleDimensions();
   size_t totalDim = 1;
-  for(int i = 0; i < tDims.size(); i++)
+  for(size_t i = 0; i < tDims.size(); i++)
   {
     totalDim = totalDim * tDims[i];
   }

--- a/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.cpp
+++ b/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.cpp
@@ -49,7 +49,8 @@ namespace Detail
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-template <typename T> IDataArray::Pointer readH5Dataset(hid_t locId, const QString& datasetPath, const size_t& numOfTuples, const QVector<size_t>& cDims)
+template <typename T>
+IDataArray::Pointer readH5Dataset(hid_t locId, const QString& datasetPath, const size_t& numOfTuples, const std::vector<size_t>& cDims)
 {
   herr_t err = -1;
   IDataArray::Pointer ptr;
@@ -215,8 +216,8 @@ void ImportHDF5Dataset::dataCheck()
       return;
     }
 
-    QVector<size_t> cDims = createComponentDimensions(cDimsStr);
-    if(cDims.isEmpty())
+    std::vector<size_t> cDims = createComponentDimensions(cDimsStr);
+    if(cDims.empty())
     {
       QString ss = tr("Component Dimensions are not in the right format for dataset with path '%1'. Use comma-separated values (ex: 4x2 would be '4, 2').").arg(datasetPath);
       setErrorCondition(-20007, ss);
@@ -256,8 +257,8 @@ void ImportHDF5Dataset::dataCheck()
     stream << tr("Attribute Matrix Path: %1\n").arg(m_SelectedAttributeMatrix.serialize("/"));
 
     size_t userEnteredTotalElements = 1;
-    QVector<size_t> amTupleDims = am->getTupleDimensions();
-    stream << tr("No. of Attribute Matrix Dimension(s): ") << locale.toString(amTupleDims.size()) << "\n";
+    std::vector<size_t> amTupleDims = am->getTupleDimensions();
+    stream << tr("No. of Attribute Matrix Dimension(s): ") << locale.toString(static_cast<quint64>(amTupleDims.size())) << "\n";
     stream << "Attribute Matrix Dimension(s): ";
     for(int i = 0; i < amTupleDims.size(); i++)
     {
@@ -274,7 +275,7 @@ void ImportHDF5Dataset::dataCheck()
     int numOfAMTuples = am->getNumberOfTuples();
     stream << tr("Total Attribute Matrix Tuple Count: %1\n").arg(locale.toString(numOfAMTuples));
 
-    stream << tr("No. of Component Dimension(s): ") << locale.toString(cDims.size()) << "\n";
+    stream << tr("No. of Component Dimension(s): ") << locale.toString(static_cast<quint64>(cDims.size())) << "\n";
     stream << "Component Dimension(s): ";
 
     int totalComponents = 1;
@@ -375,9 +376,9 @@ void ImportHDF5Dataset::execute()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<size_t> ImportHDF5Dataset::createComponentDimensions(const QString& cDimsStr)
+std::vector<size_t> ImportHDF5Dataset::createComponentDimensions(const QString& cDimsStr)
 {
-  QVector<size_t> cDims;
+  std::vector<size_t> cDims;
   QStringList dimsStrVec = cDimsStr.split(',', QString::SkipEmptyParts);
   for(int i = 0; i < dimsStrVec.size(); i++)
   {
@@ -388,7 +389,7 @@ QVector<size_t> ImportHDF5Dataset::createComponentDimensions(const QString& cDim
     int val = dimsStr.toInt(&ok);
     if(!ok)
     {
-      return QVector<size_t>();
+      return std::vector<size_t>();
     }
 
     cDims.push_back(val);
@@ -400,7 +401,7 @@ QVector<size_t> ImportHDF5Dataset::createComponentDimensions(const QString& cDim
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IDataArray::Pointer ImportHDF5Dataset::readIDataArray(hid_t gid, const QString& name, size_t numOfTuples, QVector<size_t> cDims, bool metaDataOnly)
+IDataArray::Pointer ImportHDF5Dataset::readIDataArray(hid_t gid, const QString& name, size_t numOfTuples, std::vector<size_t> cDims, bool metaDataOnly)
 {
   herr_t err = -1;
   // herr_t retErr = 1;

--- a/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.h
+++ b/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.h
@@ -188,13 +188,13 @@ protected:
 private:
   QString m_HDF5Dimensions = "";
 
-  IDataArray::Pointer readIDataArray(hid_t gid, const QString& name, size_t numOfTuples, QVector<size_t> cDims, bool metaDataOnly);
+  IDataArray::Pointer readIDataArray(hid_t gid, const QString& name, size_t numOfTuples, std::vector<size_t> cDims, bool metaDataOnly);
 
   /**
    * @brief createComponentDimensions
    * @return
    */
-  QVector<size_t> createComponentDimensions(const QString& cDimsStr);
+  std::vector<size_t> createComponentDimensions(const QString& cDimsStr);
 
 public:
   ImportHDF5Dataset(const ImportHDF5Dataset&) = delete;            // Copy Constructor Not Implemented

--- a/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.h
+++ b/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.h
@@ -47,7 +47,7 @@ class SIMPLib_EXPORT ImportHDF5Dataset : public AbstractFilter
   PYB11_CREATE_BINDINGS(ImportHDF5Dataset SUPERCLASS AbstractFilter)
   PYB11_PROPERTY(QString HDF5FilePath READ getHDF5FilePath WRITE setHDF5FilePath)
   PYB11_PROPERTY(QString HDF5Dimensions READ getHDF5Dimensions)
-  PYB11_PROPERTY(QList<DatasetImportInfo> DatasetImportInfoList READ getDatasetImportInfoList WRITE setDatasetImportInfoList)
+  PYB11_PROPERTY(QList<ImportHDF5Dataset::DatasetImportInfo> DatasetImportInfoList READ getDatasetImportInfoList WRITE setDatasetImportInfoList)
   PYB11_PROPERTY(DataArrayPath SelectedAttributeMatrix READ getSelectedAttributeMatrix WRITE setSelectedAttributeMatrix)
 
 public:

--- a/Source/SIMPLib/CoreFilters/LinkFeatureMapToElementArray.cpp
+++ b/Source/SIMPLib/CoreFilters/LinkFeatureMapToElementArray.cpp
@@ -130,10 +130,10 @@ void LinkFeatureMapToElementArray::dataCheck()
     return;
   }
 
-  QVector<size_t> tDims(1, 0);
+  std::vector<size_t> tDims(1, 0);
   m->createNonPrereqAttributeMatrix(this, getCellFeatureAttributeMatrixName(), tDims, AttributeMatrix::Type::CellFeature, AttributeMatrixID);
 
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   m_SelectedCellDataPtr = getDataContainerArray()->getPrereqArrayFromPath<DataArray<int32_t>, AbstractFilter>(this, getSelectedCellArrayPath(),
                                                                                                               cDims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */
   if(nullptr != m_SelectedCellDataPtr.lock()) /* Validate the Weak Pointer wraps a non-nullptr pointer to a DataArray<T> object */
@@ -196,7 +196,7 @@ void LinkFeatureMapToElementArray::execute()
     }
   }
 
-  QVector<size_t> tDims(1, maxIndex);
+  std::vector<size_t> tDims(1, maxIndex);
   m->getAttributeMatrix(getCellFeatureAttributeMatrixName())->resizeAttributeArrays(tDims);
   updateFeatureInstancePointers();
 

--- a/Source/SIMPLib/CoreFilters/MaskCountDecision.cpp
+++ b/Source/SIMPLib/CoreFilters/MaskCountDecision.cpp
@@ -96,7 +96,7 @@ void MaskCountDecision::dataCheck()
   clearErrorCode();
   clearWarningCode();
 
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
 
   m_MaskPtr =
       getDataContainerArray()->getPrereqArrayFromPath<DataArray<bool>, AbstractFilter>(this, getMaskArrayPath(), cDims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */

--- a/Source/SIMPLib/CoreFilters/MultiThresholdObjects.cpp
+++ b/Source/SIMPLib/CoreFilters/MultiThresholdObjects.cpp
@@ -138,7 +138,7 @@ void MultiThresholdObjects::dataCheck()
     }
 
     ComparisonInput_t comp = m_SelectedThresholds[0];
-    QVector<size_t> cDims(1, 1);
+    std::vector<size_t> cDims(1, 1);
     DataArrayPath tempPath(comp.dataContainerName, comp.attributeMatrixName, getDestinationArrayName());
     m_DestinationPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<bool>, AbstractFilter, bool>(this, tempPath, true, cDims, "", ThresholdArrayID);
     if(nullptr != m_DestinationPtr.lock()) /* Validate the Weak Pointer wraps a non-nullptr pointer to a DataArray<T> object */

--- a/Source/SIMPLib/CoreFilters/MultiThresholdObjects2.cpp
+++ b/Source/SIMPLib/CoreFilters/MultiThresholdObjects2.cpp
@@ -133,7 +133,7 @@ void MultiThresholdObjects2::dataCheck()
     }
 
     //AbstractComparison::Pointer comp = m_SelectedThresholds[0];
-    QVector<size_t> cDims(1, 1);
+    std::vector<size_t> cDims(1, 1);
     DataArrayPath tempPath(dcName, amName, getDestinationArrayName());
     m_DestinationPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<bool>, AbstractFilter, bool>(this, tempPath, true, cDims, "", ThresholdArrayID);
     if(nullptr != m_DestinationPtr.lock()) /* Validate the Weak Pointer wraps a non-nullptr pointer to a DataArray<T> object */

--- a/Source/SIMPLib/CoreFilters/RawBinaryReader.cpp
+++ b/Source/SIMPLib/CoreFilters/RawBinaryReader.cpp
@@ -272,11 +272,11 @@ void RawBinaryReader::dataCheck()
     return;
   }
 
-  QVector<size_t> tDims = attrMat->getTupleDimensions();
+  std::vector<size_t> tDims = attrMat->getTupleDimensions();
   size_t totalDim = std::accumulate(tDims.begin(), tDims.end(), 1, std::multiplies<size_t>());
 
   size_t allocatedBytes = 0;
-  QVector<size_t> cDims(1, m_NumberOfComponents);
+  std::vector<size_t> cDims(1, m_NumberOfComponents);
   if(m_ScalarType == SIMPL::NumericTypes::Type::Int8)
   {
     getDataContainerArray()->createNonPrereqArrayFromPath<Int8ArrayType, AbstractFilter, int8_t>(this, getCreatedAttributeArrayPath(), 0, cDims, "CreatedAttributeArrayPath");

--- a/Source/SIMPLib/CoreFilters/ReadASCIIData.cpp
+++ b/Source/SIMPLib/CoreFilters/ReadASCIIData.cpp
@@ -74,7 +74,7 @@ void ReadASCIIData::readFilterParameters(AbstractFilterParametersReader* reader,
   data.automaticAM = reader->readValue(prefix + "AutomaticAM", false);
 
   QVector<uint64_t> tmpVec;
-  QVector<size_t> tDims;
+  std::vector<size_t> tDims;
   tmpVec = reader->readArray(prefix + "TupleDims", QVector<uint64_t>());
   for(uint64_t i : tmpVec)
   {
@@ -143,7 +143,7 @@ void ReadASCIIData::readFilterParameters(QJsonObject& obj)
 
   {
     QJsonArray jsonArray = obj[prefix + "TupleDims"].toArray();
-    QVector<size_t> tupleDims;
+    std::vector<size_t> tupleDims;
     for(int i = 0, total = jsonArray.size(); i < total; ++i)
     {
       tupleDims.push_back(static_cast<size_t>(jsonArray[i].toInt()));
@@ -257,8 +257,8 @@ void ReadASCIIData::dataCheck()
   QStringList dataTypes = wizardData.dataTypes;
   bool automaticAM = wizardData.automaticAM;
   DataArrayPath selectedPath = wizardData.selectedPath;
-  QVector<size_t> tDims = wizardData.tupleDims;
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> tDims = wizardData.tupleDims;
+  std::vector<size_t> cDims(1, 1);
 
   QFileInfo fi(inputFilePath);
   if(inputFilePath.isEmpty())

--- a/Source/SIMPLib/CoreFilters/RemoveComponentFromArray.cpp
+++ b/Source/SIMPLib/CoreFilters/RemoveComponentFromArray.cpp
@@ -162,7 +162,7 @@ void RemoveComponentFromArray::dataCheck()
     return;
   }
 
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   if(m_SaveRemovedComponent)
   {
     DataArrayPath tempPath(getSelectedArrayPath().getDataContainerName(), getSelectedArrayPath().getAttributeMatrixName(), getNewArrayArrayName());

--- a/Source/SIMPLib/CoreFilters/SplitAttributeArray.cpp
+++ b/Source/SIMPLib/CoreFilters/SplitAttributeArray.cpp
@@ -119,7 +119,7 @@ void SplitAttributeArray::dataCheck()
       return;
     }
 
-    QVector<size_t> cDims(1, 1);
+    std::vector<size_t> cDims(1, 1);
 
     for(int32_t i = 0; i < numComps; i++)
     {

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ArrayCalculatorTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ArrayCalculatorTest.cpp
@@ -87,8 +87,8 @@ public:
   {
     DataContainerArray::Pointer dca = DataContainerArray::New();
     DataContainer::Pointer dc = DataContainer::New("DataContainer");
-    AttributeMatrix::Pointer am1 = AttributeMatrix::New(QVector<size_t>(1, 10), "AttributeMatrix", AttributeMatrix::Type::Cell);
-    AttributeMatrix::Pointer am2 = AttributeMatrix::New(QVector<size_t>(1, 1), "NumericMatrix", AttributeMatrix::Type::Cell);
+    AttributeMatrix::Pointer am1 = AttributeMatrix::New(std::vector<size_t>(1, 10), "AttributeMatrix", AttributeMatrix::Type::Cell);
+    AttributeMatrix::Pointer am2 = AttributeMatrix::New(std::vector<size_t>(1, 1), "NumericMatrix", AttributeMatrix::Type::Cell);
     FloatArrayType::Pointer array1 = FloatArrayType::CreateArray(10, "InputArray1");
     array1->initializeWithValue(-12);
     UInt32ArrayType::Pointer array2 = UInt32ArrayType::CreateArray(10, "InputArray2");
@@ -96,7 +96,7 @@ public:
     UInt32ArrayType::Pointer sArray = UInt32ArrayType::CreateArray(10, "Spaced Array");
     sArray->initializeWithValue(2);
 
-    UInt32ArrayType::Pointer mcArray1 = UInt32ArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 3), "MultiComponent Array1");
+    UInt32ArrayType::Pointer mcArray1 = UInt32ArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 3), "MultiComponent Array1");
     int num = 0;
     for(int i = 0; i < mcArray1->getNumberOfTuples() * mcArray1->getNumberOfComponents(); i++)
     {
@@ -104,7 +104,7 @@ public:
       num++;
     }
 
-    UInt32ArrayType::Pointer mcArray2 = UInt32ArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 3), "MultiComponent Array2");
+    UInt32ArrayType::Pointer mcArray2 = UInt32ArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 3), "MultiComponent Array2");
     num = 0;
     for(int i = 0; i < mcArray2->getNumberOfTuples() * mcArray2->getNumberOfComponents(); i++)
     {

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CombineAttributeArraysTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CombineAttributeArraysTest.cpp
@@ -117,13 +117,13 @@ public:
 
     DataContainer::Pointer m = DataContainer::New("CombineAttributeArraysTest");
 
-    QVector<size_t> tDims(1, 100);
+    std::vector<size_t> tDims(1, 100);
     AttributeMatrix::Pointer attrMat = AttributeMatrix::New(tDims, "CombineAttributeArraysTest", AttributeMatrix::Type::Cell);
     m->addOrReplaceAttributeMatrix(attrMat);
     dca->addOrReplaceDataContainer(m);
 
-    QVector<size_t> cDimsVec(1, 3);
-    QVector<size_t> cDimsScalar(1, 1);
+    std::vector<size_t> cDimsVec(1, 3);
+    std::vector<size_t> cDimsScalar(1, 1);
 
     CREATE_DATA_ARRAY(uint8_t, attrMat, tDims, cDimsVec, cDimsScalar, uint8_tVectorArray, uint8_tScalarArray, err);
     CREATE_DATA_ARRAY(int8_t, attrMat, tDims, cDimsVec, cDimsScalar, int8_tVectorArray, int8_tScalarArray, err);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CombineAttributeMatricesTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CombineAttributeMatricesTest.cpp
@@ -219,11 +219,11 @@ public:
     DataContainer::Pointer m2 = DataContainer::New("CombineAttributeMatricesTest2");
 
     // Create Attribute Matrices with different tDims to test validation of tuple compatibility
-    QVector<size_t> tDims(3, 0);
+    std::vector<size_t> tDims(3, 0);
     tDims[0] = 2;
     tDims[1] = 2;
     tDims[2] = 1;
-    QVector<size_t> cDims(1, 1);
+    std::vector<size_t> cDims(1, 1);
     int32_t initVal = 10;
 
     // Make Cell AM

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ConditionalSetValueTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ConditionalSetValueTest.cpp
@@ -151,14 +151,14 @@ public:
     DataContainer::Pointer m = DataContainer::New("ConditionalSetValueTest");
 
     // Create Attribute Matrices with different tDims to test validation of tuple compatibility
-    QVector<size_t> tDims(1, 10);
+    std::vector<size_t> tDims(1, 10);
     AttributeMatrix::Pointer attrMat = AttributeMatrix::New(tDims, "ConditionalSetValueAttrMat", AttributeMatrix::Type::Cell);
 
     m->addOrReplaceAttributeMatrix(attrMat);
 
     dca->addOrReplaceDataContainer(m);
 
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
     int32_t initVal = 10;
 
     CREATE_DATA_ARRAY(uint8_t, attrMat, tDims, cDims, initVal, 3, err);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ConvertColorToGrayScaleTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ConvertColorToGrayScaleTest.cpp
@@ -295,7 +295,7 @@ class ConvertColorToGrayScaleTest
     }
   }
 
-  static DataContainer::Pointer createVertexGeometryDataContainer(const DataArray<uint8_t>::Pointer& aa, const QVector<size_t>& tDims)
+  static DataContainer::Pointer createVertexGeometryDataContainer(const DataArray<uint8_t>::Pointer& aa, const std::vector<size_t>& tDims)
   {
     AttributeMatrix::Pointer am = AttributeMatrix::New(tDims, SIMPL::Defaults::VertexAttributeMatrixName, AttributeMatrix::Type::Vertex);
     am->insertOrAssign(aa);
@@ -477,8 +477,8 @@ public:
     int err = 0;
 
     const QString aaName = SIMPL::VertexData::SurfaceMeshNodes;
-    const QVector<size_t> tDims{16};
-    const QVector<size_t> cDims{3, 1, 1};
+    const std::vector<size_t> tDims{16};
+    const std::vector<size_t> cDims{3, 1, 1};
 
     DataArray<uint8_t>::Pointer testAA{DataArray<uint8_t>::CreateArray(tDims, cDims, aaName)};
     SetDataArrayTestValues(testAA);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ConvertDataTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ConvertDataTest.cpp
@@ -1,41 +1,41 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-
-#include <assert.h>
-#include <stdint.h>
+#include <cassert>
+#include <cstdint>
+#include <vector>
 
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
 #include "SIMPLib/CoreFilters/ConvertData.h"
@@ -67,12 +67,12 @@ public:
     DataContainer::Pointer dc = DataContainer::New("DataContainer");
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims;
+    std::vector<size_t> dims;
     dims.push_back(2);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);
 
-    QVector<size_t> cdims;
+    std::vector<size_t> cdims;
     cdims.push_back(2);
     IDataArray::Pointer da;
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CopyFeatureArrayToElementArrayTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CopyFeatureArrayToElementArrayTest.cpp
@@ -81,7 +81,8 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<std::vector<T>>& data, const QVector<size_t>& tupleDims, const QVector<size_t>& cDims)
+  template <typename T>
+  std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<std::vector<T>>& data, const std::vector<size_t>& tupleDims, const std::vector<size_t>& cDims)
   {
     typename DataArray<T>::Pointer da = DataArray<T>::CreateArray(tupleDims, cDims, daName);
     for(int i = 0; i < da->getNumberOfTuples(); i++)
@@ -116,7 +117,7 @@ public:
     dca->addOrReplaceDataContainer(dc);
 
     // Create AttributeMatrices
-    QVector<size_t> tDims = {{10, 3}};
+    std::vector<size_t> tDims = {{10, 3}};
     AttributeMatrix::Pointer cellAM = AttributeMatrix::New(tDims, k_Cell_AMName, AttributeMatrix::Type::Cell);
     dc->addOrReplaceAttributeMatrix(cellAM);
 
@@ -234,7 +235,7 @@ public:
 
 private:
   QString m_FilterName = QString("CopyFeatureArrayToElementArray");
-  QVector<size_t> m_Dims1 = {1};
-  QVector<size_t> m_Dims3 = {3};
-  QVector<size_t> m_Dims10 = {10};
+  std::vector<size_t> m_Dims1 = {1};
+  std::vector<size_t> m_Dims3 = {3};
+  std::vector<size_t> m_Dims10 = {10};
 };

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CopyObjectTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CopyObjectTest.cpp
@@ -92,7 +92,8 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<std::vector<T>>& data, const QVector<size_t>& tupleDims, const QVector<size_t>& cDims)
+  template <typename T>
+  std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<std::vector<T>>& data, const std::vector<size_t>& tupleDims, const std::vector<size_t>& cDims)
   {
     typename DataArray<T>::Pointer da = DataArray<T>::CreateArray(tupleDims, cDims, daName);
     for(size_t i = 0; i < da->getNumberOfTuples(); i++)
@@ -105,7 +106,8 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const QVector<size_t>& tupleDims, const QVector<size_t>& cDims)
+  template <typename T>
+  std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<size_t>& tupleDims, const std::vector<size_t>& cDims)
   {
     typename DataArray<T>::Pointer da = DataArray<T>::CreateArray(tupleDims, cDims, daName);
     for(size_t i = 0; i < da->getSize(); i++)
@@ -948,9 +950,9 @@ public:
 
 private:
   QString m_FilterName = QString("CopyObject");
-  QVector<size_t> m_Dims1 = {1};
-  QVector<size_t> m_Dims2 = {2};
-  QVector<size_t> m_Dims3 = {3};
-  QVector<size_t> m_Dims4 = {4};
-  QVector<size_t> m_Dims8 = {8};
+  std::vector<size_t> m_Dims1 = {1};
+  std::vector<size_t> m_Dims2 = {2};
+  std::vector<size_t> m_Dims3 = {3};
+  std::vector<size_t> m_Dims4 = {4};
+  std::vector<size_t> m_Dims8 = {8};
 };

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateAttributeMatrixTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateAttributeMatrixTest.cpp
@@ -359,7 +359,7 @@ public:
   // -----------------------------------------------------------------------------
   void TestOperators()
   {
-    QVector<size_t> tDims = {10, 10};
+    std::vector<size_t> tDims = {10, 10};
     AttributeMatrix::Pointer am = AttributeMatrix::New(tDims, "Test", AttributeMatrix::Type::Cell);
 
     FloatArrayType::Pointer floatArray = FloatArrayType::CreateArray(100, "Float");

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateDataArrayTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateDataArrayTest.cpp
@@ -169,7 +169,7 @@ public:
     DataContainerArray::Pointer dca = DataContainerArray::New();
     DataContainer::Pointer m = DataContainer::New(SIMPL::Defaults::DataContainerName);
     dca->addOrReplaceDataContainer(m);
-    AttributeMatrix::Pointer attrMatrix = AttributeMatrix::New(QVector<size_t>(1, 1), SIMPL::Defaults::AttributeMatrixName, AttributeMatrix::Type::Generic);
+    AttributeMatrix::Pointer attrMatrix = AttributeMatrix::New(std::vector<size_t>(1, 1), SIMPL::Defaults::AttributeMatrixName, AttributeMatrix::Type::Generic);
     m->addOrReplaceAttributeMatrix(attrMatrix);
     return dca;
   }

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateFeatureArrayFromElementArrayTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateFeatureArrayFromElementArrayTest.cpp
@@ -93,8 +93,8 @@ public:
 
         DataContainer::Pointer dc = DataContainer::New("DataContainer");
 
-        AttributeMatrix::Pointer cellAttr = AttributeMatrix::New(QVector<size_t>(1, 16), "Cell Attribute Matrix", AttributeMatrix::Type::Cell);
-        AttributeMatrix::Pointer featureAttr = AttributeMatrix::New(QVector<size_t>(1, 5), "Feature Attribute Matrix", AttributeMatrix::Type::Cell);
+        AttributeMatrix::Pointer cellAttr = AttributeMatrix::New(std::vector<size_t>(1, 16), "Cell Attribute Matrix", AttributeMatrix::Type::Cell);
+        AttributeMatrix::Pointer featureAttr = AttributeMatrix::New(std::vector<size_t>(1, 5), "Feature Attribute Matrix", AttributeMatrix::Type::Cell);
 
         DataArray<int32_t>::Pointer featureIds = DataArray<int32_t>::CreateArray(16, "FeatureIds");
         size_t numTuples = featureIds->getNumberOfTuples();
@@ -183,8 +183,8 @@ public:
 
         DataContainer::Pointer dc = DataContainer::New("DataContainer");
 
-        AttributeMatrix::Pointer cellAttr = AttributeMatrix::New(QVector<size_t>(1, 16), "Cell Attribute Matrix", AttributeMatrix::Type::Cell);
-        AttributeMatrix::Pointer featureAttr = AttributeMatrix::New(QVector<size_t>(1, 5), "Feature Attribute Matrix", AttributeMatrix::Type::Cell);
+        AttributeMatrix::Pointer cellAttr = AttributeMatrix::New(std::vector<size_t>(1, 16), "Cell Attribute Matrix", AttributeMatrix::Type::Cell);
+        AttributeMatrix::Pointer featureAttr = AttributeMatrix::New(std::vector<size_t>(1, 5), "Feature Attribute Matrix", AttributeMatrix::Type::Cell);
 
         DataArray<int32_t>::Pointer featureIds = DataArray<int32_t>::CreateArray(16, "FeatureIds");
         size_t numTuples = featureIds->getNumberOfTuples();
@@ -213,7 +213,7 @@ public:
         featureIds->initializeTuple(14, &value);
         featureIds->initializeTuple(15, &value);
 
-        QVector<size_t> cDims = QVector<size_t>(1, 3);
+        std::vector<size_t> cDims = std::vector<size_t>(1, 3);
         DataArray<float>::Pointer cellDataArray = DataArray<float>::CreateArray(16, cDims, "CellData");
         numTuples = cellDataArray->getNumberOfTuples();
         for(size_t i = 0; i < numTuples; i++)
@@ -274,8 +274,8 @@ public:
 
         DataContainer::Pointer dc = DataContainer::New("DataContainer");
 
-        AttributeMatrix::Pointer cellAttr = AttributeMatrix::New(QVector<size_t>(1, 16), "Cell Attribute Matrix", AttributeMatrix::Type::Cell);
-        AttributeMatrix::Pointer featureAttr = AttributeMatrix::New(QVector<size_t>(1, 5), "Feature Attribute Matrix", AttributeMatrix::Type::Cell);
+        AttributeMatrix::Pointer cellAttr = AttributeMatrix::New(std::vector<size_t>(1, 16), "Cell Attribute Matrix", AttributeMatrix::Type::Cell);
+        AttributeMatrix::Pointer featureAttr = AttributeMatrix::New(std::vector<size_t>(1, 5), "Feature Attribute Matrix", AttributeMatrix::Type::Cell);
 
         DataArray<int32_t>::Pointer featureIds = DataArray<int32_t>::CreateArray(16, "FeatureIds");
         int32_t value = 1;

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateGeometryTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateGeometryTest.cpp
@@ -95,7 +95,8 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<std::vector<T>>& data, const QVector<size_t>& tupleDims, const QVector<size_t>& cDims)
+  template <typename T>
+  std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<std::vector<T>>& data, const std::vector<size_t>& tupleDims, const std::vector<size_t>& cDims)
   {
     typename DataArray<T>::Pointer da = DataArray<T>::CreateArray(tupleDims, cDims, daName);
     for(int i = 0; i < da->getNumberOfTuples(); i++)
@@ -1328,9 +1329,9 @@ public:
 
 private:
   QString m_FilterName = QString("CreateGeometry");
-  QVector<size_t> m_Dims1 = {1};
-  QVector<size_t> m_Dims2 = {2};
-  QVector<size_t> m_Dims3 = {3};
-  QVector<size_t> m_Dims4 = {4};
-  QVector<size_t> m_Dims8 = {8};
+  std::vector<size_t> m_Dims1 = {1};
+  std::vector<size_t> m_Dims2 = {2};
+  std::vector<size_t> m_Dims3 = {3};
+  std::vector<size_t> m_Dims4 = {4};
+  std::vector<size_t> m_Dims8 = {8};
 };

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateImageGeometryTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateImageGeometryTest.cpp
@@ -60,7 +60,7 @@ public:
   {
     CreateImageGeometry::Pointer imageGeometry = CreateImageGeometry::New();
 
-    QVector<size_t> attributeMatrixSize = QVector<size_t>();
+    std::vector<size_t> attributeMatrixSize = std::vector<size_t>();
     attributeMatrixSize.push_back(3);
     attributeMatrixSize.push_back(3);
     attributeMatrixSize.push_back(3);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateStringArrayTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CreateStringArrayTest.cpp
@@ -93,7 +93,7 @@ public:
     static const QString k_StringInitialValue("Test String");
     static const QString k_EmptyQString("");
 
-    QVector<size_t> tupleDims(1, 5);
+    std::vector<size_t> tupleDims(1, 5);
 
     // Create DataContainerArray
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/CropVertexGeometryTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/CropVertexGeometryTest.cpp
@@ -85,7 +85,8 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<std::vector<T>>& data, const QVector<size_t>& tupleDims, const QVector<size_t>& cDims)
+  template <typename T>
+  std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<std::vector<T>>& data, const std::vector<size_t>& tupleDims, const std::vector<size_t>& cDims)
   {
     typename DataArray<T>::Pointer da = DataArray<T>::CreateArray(tupleDims, cDims, daName);
     for(int i = 0; i < da->getNumberOfTuples(); i++)
@@ -131,7 +132,7 @@ public:
 
     // Create AttributeMatrix
 
-    QVector<size_t> dims(1, vertices.size());
+    std::vector<size_t> dims(1, vertices.size());
 
     AttributeMatrix::Pointer vertexAM = AttributeMatrix::New(dims, k_VertexAttributeMatrixName, AttributeMatrix::Type::Vertex);
     dc->addOrReplaceAttributeMatrix(vertexAM);
@@ -146,7 +147,7 @@ public:
 
     // Manually create cropped DataArray for comparison
 
-    QVector<size_t> croppedDims(1, postCropVertices.size());
+    std::vector<size_t> croppedDims(1, postCropVertices.size());
 
     FloatArrayType::Pointer daCroppedVert = createDataArray<float>(k_CroppedVertexCoordinatesDAName, postCropVertices, croppedDims, m_Dims3);
 
@@ -302,9 +303,9 @@ public:
 
 private:
   QString m_FilterName = QString("CropVertexGeometry");
-  QVector<size_t> m_Dims1 = {1};
-  QVector<size_t> m_Dims2 = {2};
-  QVector<size_t> m_Dims3 = {3};
-  QVector<size_t> m_Dims4 = {4};
-  QVector<size_t> m_Dims8 = {8};
+  std::vector<size_t> m_Dims1 = {1};
+  std::vector<size_t> m_Dims2 = {2};
+  std::vector<size_t> m_Dims3 = {3};
+  std::vector<size_t> m_Dims4 = {4};
+  std::vector<size_t> m_Dims8 = {8};
 };

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/DataContainerTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/DataContainerTest.cpp
@@ -181,7 +181,8 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> void CreateDataArray(AttributeMatrix::Pointer attrMat, QVector<size_t> compDims)
+  template <typename T>
+  void CreateDataArray(AttributeMatrix::Pointer attrMat, std::vector<size_t> compDims)
   {
     QString name("[");
     for(int i = 0; i < compDims.size(); i++)
@@ -205,7 +206,7 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  void CreateStringArray(AttributeMatrix::Pointer attrMat, QVector<size_t> compDims)
+  void CreateStringArray(AttributeMatrix::Pointer attrMat, std::vector<size_t> compDims)
   {
     QString name("ExampleStringDataArray");
     StringDataArray::Pointer data = StringDataArray::CreateArray(attrMat->getNumberOfTuples(), name);
@@ -220,7 +221,7 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  void FillAttributeMatrix(const AttributeMatrix::Pointer& attrMat, const QVector<size_t>& compDims)
+  void FillAttributeMatrix(const AttributeMatrix::Pointer& attrMat, const std::vector<size_t>& compDims)
   {
     CreateDataArray<int8_t>(attrMat, compDims);
     CreateDataArray<uint8_t>(attrMat, compDims);
@@ -238,11 +239,11 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  void PopulateVolumeDataContainer(const DataContainer::Pointer& dc, QVector<size_t> tupleDims, const QString& name)
+  void PopulateVolumeDataContainer(const DataContainer::Pointer& dc, std::vector<size_t> tupleDims, const QString& name)
   {
     // Create the attribute matrix with the dimensions and name
     AttributeMatrix::Pointer attrMat = AttributeMatrix::New(tupleDims, name, AttributeMatrix::Type::Cell);
-    QVector<size_t> compDims(1, 1); // Create a Single Scalar Component (numComp = 1) Data Array
+    std::vector<size_t> compDims(1, 1); // Create a Single Scalar Component (numComp = 1) Data Array
     FillAttributeMatrix(attrMat, compDims);
 
     // Add Data Arrays that have a [1x3] component dimensions
@@ -280,7 +281,7 @@ public:
   // -----------------------------------------------------------------------------
   void TestDataContainerWriter()
   {
-    QVector<size_t> tupleDims;
+    std::vector<size_t> tupleDims;
     DataContainerArray::Pointer dca = DataContainerArray::New();
     size_t nx = DataContainerIOTest::XSize;
     size_t ny = DataContainerIOTest::YSize;
@@ -335,7 +336,7 @@ public:
     }
     attrMatrix->insertOrAssign(boolArray);
 
-    QVector<size_t> dims(1, 3);
+    std::vector<size_t> dims(1, 3);
     FloatArrayType::Pointer avgEuler = FloatArrayType::CreateArray(size, dims, SIMPL::FeatureData::AxisEulerAngles);
     for(int32_t i = 0; i < size; ++i)
     {
@@ -480,7 +481,7 @@ public:
     DREAM3D_REQUIRE_NULL_POINTER(attrMatrix.get())
 
     // Now add an AttributeMatrix to the DataContainer
-    QVector<size_t> tDims(1, 0);
+    std::vector<size_t> tDims(1, 0);
     AttributeMatrix::Pointer attrMat = m->createAndAddAttributeMatrix(tDims, getCellAttributeMatrixName(), AttributeMatrix::Type::Cell);
     DREAM3D_REQUIRE_VALID_POINTER(attrMat.get())
 
@@ -500,7 +501,7 @@ public:
     IDataArray::Pointer ida = attrMat->getAttributeArray("Test");
     DREAM3D_REQUIRE_VALID_POINTER(ida.get());
 
-    QVector<size_t> dims(1, 1);
+    std::vector<size_t> dims(1, 1);
     t = attrMat->getPrereqArray<T, AbstractFilter>(nullptr, "Test", -723, dims);
     DREAM3D_REQUIRE_VALID_POINTER(ida.get());
 
@@ -1004,7 +1005,7 @@ public:
 
     const QString k_DC0("DCO");
     const QString k_DC1("DC1");
-    QVector<size_t> tDims = {10, 10};
+    std::vector<size_t> tDims = {10, 10};
     AttributeMatrix::Pointer am0 = AttributeMatrix::New(tDims, k_DC0, AttributeMatrix::Type::Generic);
     AttributeMatrix::Pointer am1 = AttributeMatrix::New(tDims, k_DC1, AttributeMatrix::Type::Generic);
 
@@ -1082,7 +1083,7 @@ public:
   void TestAttributeMatrix()
   {
     bool result = false;
-    QVector<size_t> tDims = {10, 10};
+    std::vector<size_t> tDims = {10, 10};
     AttributeMatrix::Pointer am = AttributeMatrix::New(tDims, "AttributeMatrix", AttributeMatrix::Type::Generic);
     // addDataContainer
     // insertOrAssign

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ExtractAttributeArraysFromGeometryTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ExtractAttributeArraysFromGeometryTest.cpp
@@ -91,7 +91,8 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<std::vector<T>>& data, const QVector<size_t>& tupleDims, const QVector<size_t>& cDims)
+  template <typename T>
+  std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<std::vector<T>>& data, const std::vector<size_t>& tupleDims, const std::vector<size_t>& cDims)
   {
     typename DataArray<T>::Pointer da = DataArray<T>::CreateArray(tupleDims, cDims, daName);
     for(int i = 0; i < da->getNumberOfTuples(); i++)
@@ -759,9 +760,9 @@ public:
 
 private:
   QString m_FilterName = QString("ExtractAttributeArraysFromGeometry");
-  QVector<size_t> m_Dims1 = {1};
-  QVector<size_t> m_Dims2 = {2};
-  QVector<size_t> m_Dims3 = {3};
-  QVector<size_t> m_Dims4 = {4};
-  QVector<size_t> m_Dims8 = {8};
+  std::vector<size_t> m_Dims1 = {1};
+  std::vector<size_t> m_Dims2 = {2};
+  std::vector<size_t> m_Dims3 = {3};
+  std::vector<size_t> m_Dims4 = {4};
+  std::vector<size_t> m_Dims8 = {8};
 };

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ExtractComponentAsArrayTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ExtractComponentAsArrayTest.cpp
@@ -66,12 +66,12 @@ public:
 
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims;
+    std::vector<size_t> dims;
     dims.push_back(2);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);
 
-    QVector<size_t> cdims;
+    std::vector<size_t> cdims;
     cdims.push_back(2);
     DataArray<int>::Pointer da = DataArray<int>::CreateArray(2, cdims, "DataArray");
     da->setComponent(0, 0, 1);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ExtractVertexGeometryTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ExtractVertexGeometryTest.cpp
@@ -89,7 +89,7 @@ public:
     imageGeomDC->setGeometry(imageGeom);
 
     // Create the Cell AttributeMatrix
-    AttributeMatrix::Pointer cellAttrMat = AttributeMatrix::Create(dims, k_CellAttrMatName, AttributeMatrix::Type::Cell);
+    AttributeMatrix::Pointer cellAttrMat = AttributeMatrix::New(dims, k_CellAttrMatName, AttributeMatrix::Type::Cell);
     imageGeomDC->addOrReplaceAttributeMatrix(cellAttrMat);
 
     // Create a cell attribute array
@@ -101,7 +101,7 @@ public:
     dims[0] = 1;
     dims[1] = 2;
     dims[2] = 3;
-    AttributeMatrix::Pointer featureAttrMat = AttributeMatrix::Create(dims, k_FeatureAttrMatName, AttributeMatrix::Type::CellFeature);
+    AttributeMatrix::Pointer featureAttrMat = AttributeMatrix::New(dims, k_FeatureAttrMatName, AttributeMatrix::Type::CellFeature);
     imageGeomDC->addOrReplaceAttributeMatrix(featureAttrMat);
 
     // Create a feature attribute array

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/FeatureDataCSVWriterTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/FeatureDataCSVWriterTest.cpp
@@ -378,10 +378,10 @@ public:
     static const size_t yDim(2);
     static const size_t zDim(3);
 
-    QVector<size_t> tupleDims = {xDim, yDim, zDim};
-    QVector<size_t> cDims = {2};
-    QVector<size_t> cDimsFloat = {3};
-    QVector<size_t> cDimsNeighbor = {1};
+    std::vector<size_t> tupleDims = {xDim, yDim, zDim};
+    std::vector<size_t> cDims = {2};
+    std::vector<size_t> cDimsFloat = {3};
+    std::vector<size_t> cDimsNeighbor = {1};
 
     // Create DataContainerArray
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/FindDerivativesFilterTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/FindDerivativesFilterTest.cpp
@@ -118,7 +118,7 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  void initializeDataArrays(DataContainer::Pointer m, QVector<size_t> cDims)
+  void initializeDataArrays(DataContainer::Pointer m, std::vector<size_t> cDims)
   {
     for(auto& am : m->getChildren())
     {
@@ -161,7 +161,7 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  void initializeAttributeMatrices(DataContainer::Pointer m, QVector<size_t> tDimsVert, QVector<size_t> tDimsCell)
+  void initializeAttributeMatrices(DataContainer::Pointer m, std::vector<size_t> tDimsVert, std::vector<size_t> tDimsCell)
   {
     AttributeMatrix::Pointer attrMat;
     QString ss = QObject::tr("AttrMatType%1").arg(0);
@@ -282,8 +282,8 @@ public:
     FDTEST_CREATE_DATA_CONTAINER(QuadDC, quads, dca);
     FDTEST_CREATE_DATA_CONTAINER(TetDC, tets, dca);
 
-    QVector<size_t> tDims(1, 100);
-    QVector<size_t> tDims2(1, 1);
+    std::vector<size_t> tDims(1, 100);
+    std::vector<size_t> tDims2(1, 1);
     initializeAttributeMatrices(_nullGeomContainer, tDims, tDims);
     tDims[0] = 1000;
     initializeAttributeMatrices(_imageContainer, tDims, tDims);
@@ -298,7 +298,7 @@ public:
     initializeAttributeMatrices(_quadsContainer, tDims, tDims2);
     initializeAttributeMatrices(_tetsContainer, tDims, tDims2);
 
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
 
     initializeDataArrays(_nullGeomContainer, cDims);
     initializeDataArrays(_imageContainer, cDims);
@@ -349,8 +349,8 @@ public:
     QVariant var;
     bool propWasSet;
     int err = 0;
-    QVector<size_t> checkDims;
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> checkDims;
+    std::vector<size_t> cDims(1, 3);
     QString derivativeName = "Derivatives";
     DataArrayPath derivs;
     IDataArray::Pointer data;

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/GenerateColorTableTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/GenerateColorTableTest.cpp
@@ -165,7 +165,7 @@ public:
     // Validate Results
     {
       DataArrayPath daPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, "CI_RGB");
-      UInt8ArrayType::Pointer da = dca->getPrereqArrayFromPath<UInt8ArrayType, AbstractFilter>(nullptr, daPath, QVector<size_t>(1, 3));
+      UInt8ArrayType::Pointer da = dca->getPrereqArrayFromPath<UInt8ArrayType, AbstractFilter>(nullptr, daPath, std::vector<size_t>(1, 3));
       if(da.get() != nullptr)
       {
         QFile file(presetFilePath);
@@ -205,7 +205,7 @@ public:
 
     DataContainerArray::Pointer dca = DataContainerArray::New();
     DataContainer::Pointer dc = DataContainer::New(SIMPL::Defaults::ImageDataContainerName);
-    AttributeMatrix::Pointer am = AttributeMatrix::New(QVector<size_t>(1, 37989), SIMPL::Defaults::CellAttributeMatrixName, AttributeMatrix::Type::Generic);
+    AttributeMatrix::Pointer am = AttributeMatrix::New(std::vector<size_t>(1, 37989), SIMPL::Defaults::CellAttributeMatrixName, AttributeMatrix::Type::Generic);
     dc->addOrReplaceAttributeMatrix(am);
     dca->addOrReplaceDataContainer(dc);
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ImportAsciDataArrayTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ImportAsciDataArrayTest.cpp
@@ -66,7 +66,7 @@ public:
     dc->setGeometry(imageGeom);
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> tDims = {m_XDim, m_YDim, m_ZDim};
+    std::vector<size_t> tDims = {m_XDim, m_YDim, m_ZDim};
     AttributeMatrix::Pointer attrMat = AttributeMatrix::New(tDims, "AttributeMatrix", AttributeMatrix::Type::Generic);
 
     dc->addOrReplaceAttributeMatrix(attrMat);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ImportHDF5DatasetTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ImportHDF5DatasetTest.cpp
@@ -253,7 +253,7 @@ public:
     ImportHDF5Dataset::Pointer filter = ImportHDF5Dataset::New();
 
     // Set a dummy data container array for error testing purposes
-    DataContainerArray::Pointer dca = createDataContainerArray(QVector<size_t>(1, 1));
+    DataContainerArray::Pointer dca = createDataContainerArray(std::vector<size_t>(1, 1));
     filter->setDataContainerArray(dca);
     filter->setSelectedAttributeMatrix(DataArrayPath("DataContainer", "AttributeMatrix", ""));
 
@@ -324,7 +324,7 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  DataContainerArray::Pointer createDataContainerArray(QVector<size_t> tDims)
+  DataContainerArray::Pointer createDataContainerArray(std::vector<size_t> tDims)
   {
     DataContainerArray::Pointer dca = DataContainerArray::New();
 
@@ -341,7 +341,7 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  QString createVectorString(QVector<size_t> vec)
+  QString createVectorString(std::vector<size_t> vec)
   {
     QString str = "(";
     for(int i = 0; i < vec.size(); i++)
@@ -360,7 +360,7 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> void DatasetTest(ImportHDF5Dataset::Pointer filter, QList<ImportHDF5Dataset::DatasetImportInfo> importInfoList, QVector<size_t> amDims, int errCode)
+  template <typename T> void DatasetTest(ImportHDF5Dataset::Pointer filter, QList<ImportHDF5Dataset::DatasetImportInfo> importInfoList, std::vector<size_t> amDims, int errCode)
   {
     if(importInfoList.empty())
     {
@@ -427,7 +427,7 @@ public:
 
         QString cDimsStr = dsetInfoList[i].componentDimensions;
         QStringList tokens = cDimsStr.split(", ");
-        QVector<size_t> cDims;
+        std::vector<size_t> cDims;
         for(int i = 0; i < tokens.size(); i++)
         {
           cDims.push_back(tokens[i].toInt());
@@ -472,7 +472,8 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> QString joinVector(QVector<T> vector, const QString& separator)
+  template <typename T>
+  QString joinVector(std::vector<T> vector, const QString& separator)
   {
     QString cDimsStr = "";
     for(int i = 0; i < vector.size(); i++)
@@ -497,8 +498,8 @@ public:
     //  // ******************* Test Reading Data *************************************
 
     // Create tuple and component dimensions for all tests
-    QVector<QVector<size_t>> tDimsVector;
-    QVector<QVector<size_t>> cDimsVector;
+    QVector<std::vector<size_t>> tDimsVector;
+    QVector<std::vector<size_t>> cDimsVector;
 
     // Add 1D, 2D, 3D, and 4D tuple and component dimensions that test all 4 possibilities:
     // 1. Tuple dimensions and component dimensions are both valid
@@ -506,37 +507,37 @@ public:
     // 3. Tuple dimensions are invalid, but component dimensions are valid
     // 4. Neither tuple dimensions or component dimensions are valid
 
-    tDimsVector.push_back(QVector<size_t>(1) = {TUPLEDIMPROD});
-    cDimsVector.push_back(QVector<size_t>(1) = {COMPDIMPROD});
+    tDimsVector.push_back(std::vector<size_t>(1) = {TUPLEDIMPROD});
+    cDimsVector.push_back(std::vector<size_t>(1) = {COMPDIMPROD});
 
-    tDimsVector.push_back(QVector<size_t>(2) = {10, 4});
-    cDimsVector.push_back(QVector<size_t>(2) = {12, 6});
+    tDimsVector.push_back(std::vector<size_t>(2) = {10, 4});
+    cDimsVector.push_back(std::vector<size_t>(2) = {12, 6});
 
-    tDimsVector.push_back(QVector<size_t>(3) = {2, 2, 10});
-    cDimsVector.push_back(QVector<size_t>(3) = {4, 3, 6});
+    tDimsVector.push_back(std::vector<size_t>(3) = {2, 2, 10});
+    cDimsVector.push_back(std::vector<size_t>(3) = {4, 3, 6});
 
-    tDimsVector.push_back(QVector<size_t>(4) = {2, 2, 5, 2});
-    cDimsVector.push_back(QVector<size_t>(4) = {4, 3, 3, 2});
+    tDimsVector.push_back(std::vector<size_t>(4) = {2, 2, 5, 2});
+    cDimsVector.push_back(std::vector<size_t>(4) = {4, 3, 3, 2});
 
-    tDimsVector.push_back(QVector<size_t>(1) = {TUPLEDIMPROD - 1});
-    cDimsVector.push_back(QVector<size_t>(1) = {COMPDIMPROD - 1});
+    tDimsVector.push_back(std::vector<size_t>(1) = {TUPLEDIMPROD - 1});
+    cDimsVector.push_back(std::vector<size_t>(1) = {COMPDIMPROD - 1});
 
-    tDimsVector.push_back(QVector<size_t>(2) = {TUPLEDIMPROD - 1, 34});
-    cDimsVector.push_back(QVector<size_t>(2) = {COMPDIMPROD - 1, 56});
+    tDimsVector.push_back(std::vector<size_t>(2) = {TUPLEDIMPROD - 1, 34});
+    cDimsVector.push_back(std::vector<size_t>(2) = {COMPDIMPROD - 1, 56});
 
-    tDimsVector.push_back(QVector<size_t>(3) = {TUPLEDIMPROD - 1, 23, 654});
-    cDimsVector.push_back(QVector<size_t>(3) = {COMPDIMPROD - 1, 56, 12});
+    tDimsVector.push_back(std::vector<size_t>(3) = {TUPLEDIMPROD - 1, 23, 654});
+    cDimsVector.push_back(std::vector<size_t>(3) = {COMPDIMPROD - 1, 56, 12});
 
-    tDimsVector.push_back(QVector<size_t>(4) = {TUPLEDIMPROD - 1, 98, 12, 45});
-    cDimsVector.push_back(QVector<size_t>(4) = {COMPDIMPROD - 1, 43, 12, 53});
+    tDimsVector.push_back(std::vector<size_t>(4) = {TUPLEDIMPROD - 1, 98, 12, 45});
+    cDimsVector.push_back(std::vector<size_t>(4) = {COMPDIMPROD - 1, 43, 12, 53});
 
     // Execute all combinations of tests
     for(int i = 0; i < tDimsVector.size(); i++)
     {
       for(int j = 0; j < cDimsVector.size(); j++)
       {
-        QVector<size_t> tDims = tDimsVector[i];
-        QVector<size_t> cDims = cDimsVector[j];
+        std::vector<size_t> tDims = tDimsVector[i];
+        std::vector<size_t> cDims = cDimsVector[j];
 
         size_t amTupleCount = 1;
         for(int t = 0; t < tDims.size(); t++)

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/MoveDataTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/MoveDataTest.cpp
@@ -83,7 +83,8 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const QVector<size_t>& tupleDims, const QVector<size_t>& cDims)
+  template <typename T>
+  std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<size_t>& tupleDims, const std::vector<size_t>& cDims)
   {
     typename DataArray<T>::Pointer da = DataArray<T>::CreateArray(tupleDims, cDims, daName);
     for(size_t i = 0; i < da->getNumberOfTuples(); i++)
@@ -374,9 +375,9 @@ public:
     static const QString k_AttributeMatrixBadDstName("AttributeMatrixBadDst");
     static const QString k_DataArraySrcName("DataArraySrc");
 
-    QVector<size_t> tupleDims = {12};
-    QVector<size_t> badTupleDims = {14};
-    QVector<size_t> cDims = {3};
+    std::vector<size_t> tupleDims = {12};
+    std::vector<size_t> badTupleDims = {14};
+    std::vector<size_t> cDims = {3};
 
     // Create DataContainerArray
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/MoveMultiDataTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/MoveMultiDataTest.cpp
@@ -83,7 +83,8 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const QVector<size_t>& tupleDims, const QVector<size_t>& cDims)
+  template <typename T>
+  std::shared_ptr<DataArray<T>> createDataArray(const QString& daName, const std::vector<size_t>& tupleDims, const std::vector<size_t>& cDims)
   {
     typename DataArray<T>::Pointer da = DataArray<T>::CreateArray(tupleDims, cDims, daName);
     for(size_t i = 0; i < da->getNumberOfTuples(); i++)
@@ -398,9 +399,9 @@ public:
     static const QString k_floatArrayName("floatDataArray");
     static const QString k_doubleArrayName("doubleDataArray");
 
-    QVector<size_t> tupleDims = {12};
-    QVector<size_t> badTupleDims = {14};
-    QVector<size_t> cDims = {3};
+    std::vector<size_t> tupleDims = {12};
+    std::vector<size_t> badTupleDims = {14};
+    std::vector<size_t> cDims = {3};
 
     // Create DataContainerArray
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/MultiThresholdObjects2Test.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/MultiThresholdObjects2Test.cpp
@@ -89,9 +89,9 @@ public:
     size_t dims[1] = {20};
     image->setDimensions(dims);
 
-    QVector<size_t> tDims(1, 0);
+    std::vector<size_t> tDims(1, 0);
     tDims[0] = 20;
-    QVector<size_t> cDims(1);
+    std::vector<size_t> cDims(1);
     cDims[0] = 1;
     float fnum = 0.0f;
     int inum = 0;

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/MultiThresholdObjectsTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/MultiThresholdObjectsTest.cpp
@@ -87,9 +87,9 @@ public:
     size_t dims[1] = {20};
     image->setDimensions(dims);
 
-    QVector<size_t> tDims(1, 0);
+    std::vector<size_t> tDims(1, 0);
     tDims[0] = 20;
-    QVector<size_t> cDims(1);
+    std::vector<size_t> cDims(1);
     cDims[0] = 1;
     float fnum = 0.0f;
     int inum = 0;

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RawBinaryReaderTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RawBinaryReaderTest.cpp
@@ -244,7 +244,7 @@ public:
     DREAM3D_REQUIRED(result, ==, true)
 
     // Create the attribute matrix
-    QVector<size_t> dims(1, k_ArraySize);
+    std::vector<size_t> dims(1, k_ArraySize);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
 
     // Create the data container
@@ -349,7 +349,7 @@ public:
     DREAM3D_REQUIRED(result, ==, true)
 
     // Create the attribute matrix
-    QVector<size_t> dims(1, k_ArraySize);
+    std::vector<size_t> dims(1, k_ArraySize);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
 
     // Create the data container
@@ -449,7 +449,7 @@ public:
     DREAM3D_REQUIRED(result, ==, true)
 
     // Create the attribute matrix
-    QVector<size_t> dims(1, k_ArraySize);
+    std::vector<size_t> dims(1, k_ArraySize);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
 
     // Create the data container
@@ -559,7 +559,7 @@ public:
     DREAM3D_REQUIRED(result, ==, true)
 
     // Create the attribute matrix
-    QVector<size_t> dims(1, k_ArraySize);
+    std::vector<size_t> dims(1, k_ArraySize);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
 
     // Create the data container
@@ -697,7 +697,7 @@ public:
     DREAM3D_REQUIRED(result, ==, true)
 
     // Create the attribute matrix
-    QVector<size_t> dims(1, k_ArraySize);
+    std::vector<size_t> dims(1, k_ArraySize);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
 
     // Create the data container
@@ -807,7 +807,7 @@ public:
     DREAM3D_REQUIRED(result, ==, true)
 
     // Create the attribute matrix
-    QVector<size_t> dims(1, k_ArraySize);
+    std::vector<size_t> dims(1, k_ArraySize);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
 
     // Create the data container

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ReadASCIIDataTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ReadASCIIDataTest.cpp
@@ -133,7 +133,7 @@ public:
   {
     DataContainerArray::Pointer dca = DataContainerArray::New();
     DataContainer::Pointer dc = DataContainer::New(DataContainerName);
-    AttributeMatrix::Pointer am = AttributeMatrix::New(QVector<size_t>(1, data.numberOfLines), AttributeMatrixName, AttributeMatrix::Type::Cell);
+    AttributeMatrix::Pointer am = AttributeMatrix::New(std::vector<size_t>(1, data.numberOfLines), AttributeMatrixName, AttributeMatrix::Type::Cell);
     dc->addOrReplaceAttributeMatrix(am);
     dca->addOrReplaceDataContainer(dc);
 
@@ -188,7 +188,7 @@ public:
     data.inputFilePath = UnitTest::ReadASCIIDataTest::TestFile1;
     data.numberOfLines = 10;
     data.selectedPath = DataArrayPath(DataContainerName, AttributeMatrixName, "");
-    data.tupleDims = QVector<size_t>(1, 10);
+    data.tupleDims = std::vector<size_t>(1, 10);
 
     // Test Using Expected Input - Double/Float
     {
@@ -335,7 +335,7 @@ public:
       CreateFile(UnitTest::ReadASCIIDataTest::TestFile1, inputOctVector, delimiter);
 
       data.numberOfLines = 7;
-      data.tupleDims = QVector<size_t>(1, 7);
+      data.tupleDims = std::vector<size_t>(1, 7);
       AbstractFilter::Pointer importASCIIData = PrepFilter(data);
       DREAM3D_REQUIRE_VALID_POINTER(importASCIIData.get())
 
@@ -363,7 +363,7 @@ public:
       CreateFile(UnitTest::ReadASCIIDataTest::TestFile1, inputMaxVector, delimiter);
 
       data.numberOfLines = 1;
-      data.tupleDims = QVector<size_t>(1, 1);
+      data.tupleDims = std::vector<size_t>(1, 1);
       AbstractFilter::Pointer importASCIIData = PrepFilter(data);
       DREAM3D_REQUIRE_VALID_POINTER(importASCIIData.get())
 
@@ -399,7 +399,7 @@ public:
       CreateFile(UnitTest::ReadASCIIDataTest::TestFile1, inputMinVector, delimiter);
 
       data.numberOfLines = 1;
-      data.tupleDims = QVector<size_t>(1, 1);
+      data.tupleDims = std::vector<size_t>(1, 1);
       AbstractFilter::Pointer importASCIIData = PrepFilter(data);
       DREAM3D_REQUIRE_VALID_POINTER(importASCIIData.get())
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RemoveArraysTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RemoveArraysTest.cpp
@@ -62,13 +62,13 @@ public:
   // -----------------------------------------------------------------------------
   AbstractFilter::Pointer createFilter()
   {
-    QVector<size_t> vec;
+    std::vector<size_t> vec;
     vec.push_back(1);
 
     const QString arrayName = "DataArray";
     DataArray<uint>::Pointer da = DataArray<uint>::CreateArray(1, vec, arrayName);
 
-    QVector<size_t> sizeList;
+    std::vector<size_t> sizeList;
     sizeList.push_back(1);
     sizeList.push_back(1);
     sizeList.push_back(1);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RemoveComponentFromArrayTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RemoveComponentFromArrayTest.cpp
@@ -170,7 +170,7 @@ public:
     DataContainerArray::Pointer dca = DataContainerArray::New();
     DataContainer::Pointer m = DataContainer::New(SIMPL::Defaults::DataContainerName);
     dca->addOrReplaceDataContainer(m);
-    AttributeMatrix::Pointer attrMatrix = AttributeMatrix::New(QVector<size_t>(1, numTuples), SIMPL::Defaults::AttributeMatrixName, AttributeMatrix::Type::Generic);
+    AttributeMatrix::Pointer attrMatrix = AttributeMatrix::New(std::vector<size_t>(1, numTuples), SIMPL::Defaults::AttributeMatrixName, AttributeMatrix::Type::Generic);
     m->addOrReplaceAttributeMatrix(attrMatrix);
     return dca;
   }

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RenameAttributeArrayTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RenameAttributeArrayTest.cpp
@@ -91,7 +91,7 @@ public:
 
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims = QVector<size_t>();
+    std::vector<size_t> dims = std::vector<size_t>();
     dims.push_back(1);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);
@@ -126,7 +126,7 @@ public:
 
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims = QVector<size_t>();
+    std::vector<size_t> dims = std::vector<size_t>();
     dims.push_back(1);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);
@@ -164,7 +164,7 @@ public:
 
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims = QVector<size_t>();
+    std::vector<size_t> dims = std::vector<size_t>();
     dims.push_back(1);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);
@@ -204,7 +204,7 @@ public:
 
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims = QVector<size_t>();
+    std::vector<size_t> dims = std::vector<size_t>();
     dims.push_back(1);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);
@@ -242,7 +242,7 @@ public:
 
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims = QVector<size_t>();
+    std::vector<size_t> dims = std::vector<size_t>();
     dims.push_back(1);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);
@@ -279,7 +279,7 @@ public:
 
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims = QVector<size_t>();
+    std::vector<size_t> dims = std::vector<size_t>();
     dims.push_back(1);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RenameAttributeMatrixTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RenameAttributeMatrixTest.cpp
@@ -121,7 +121,7 @@ public:
 
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims = QVector<size_t>();
+    std::vector<size_t> dims = std::vector<size_t>();
     dims.push_back(1);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);
@@ -156,7 +156,7 @@ public:
 
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims = QVector<size_t>();
+    std::vector<size_t> dims = std::vector<size_t>();
     dims.push_back(1);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);
@@ -193,7 +193,7 @@ public:
 
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims = QVector<size_t>();
+    std::vector<size_t> dims = std::vector<size_t>();
     dims.push_back(1);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);
@@ -228,7 +228,7 @@ public:
 
     dca->addOrReplaceDataContainer(dc);
 
-    QVector<size_t> dims = QVector<size_t>();
+    std::vector<size_t> dims = std::vector<size_t>();
     dims.push_back(1);
     AttributeMatrix::Pointer am = AttributeMatrix::New(dims, "AttributeMatrix", AttributeMatrix::Type::Any);
     dc->addOrReplaceAttributeMatrix(am);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ReplaceValueTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ReplaceValueTest.cpp
@@ -149,14 +149,14 @@ public:
     DataContainer::Pointer m = DataContainer::New("ReplaceValueTest");
 
     // Create Attribute Matrices with different tDims to test validation of tuple compatibility
-    QVector<size_t> tDims(1, 100);
+    std::vector<size_t> tDims(1, 100);
     AttributeMatrix::Pointer attrMat = AttributeMatrix::New(tDims, "ReplaceValueAttrMat", AttributeMatrix::Type::Cell);
 
     m->addOrReplaceAttributeMatrix(attrMat);
 
     dca->addOrReplaceDataContainer(m);
 
-    QVector<size_t> cDims(1, 3);
+    std::vector<size_t> cDims(1, 3);
     int32_t initVal = 10;
     tDims[0] = 100;
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RequiredZThicknessTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RequiredZThicknessTest.cpp
@@ -77,7 +77,7 @@ public:
     // incorrect geometry
     TriangleGeom::Pointer triGeom = TriangleGeom::New();
 
-    QVector<size_t> dims;
+    std::vector<size_t> dims;
     dims.push_back(3);
     DataArray<float>::Pointer verts = DataArray<float>::CreateArray(3, dims, "Vertices");
     verts->setComponent(0, 0, -1);
@@ -92,7 +92,7 @@ public:
     verts->setComponent(2, 1, 1);
     verts->setComponent(2, 2, 0);
 
-    QVector<size_t> dims2;
+    std::vector<size_t> dims2;
     dims2.push_back(3);
     SharedTriList::Pointer tris = SharedTriList::CreateArray(1, dims2, "Triangles");
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/ScaleVolumeTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/ScaleVolumeTest.cpp
@@ -87,7 +87,7 @@ public:
 
     TriangleGeom::Pointer triGeom = TriangleGeom::New();
 
-    QVector<size_t> dims;
+    std::vector<size_t> dims;
     dims.push_back(3);
     DataArray<float>::Pointer verts = DataArray<float>::CreateArray(3, dims, "Vertices");
     verts->setComponent(0, 0, -1);
@@ -102,7 +102,7 @@ public:
     verts->setComponent(2, 1, 1);
     verts->setComponent(2, 2, 0);
 
-    QVector<size_t> dims2;
+    std::vector<size_t> dims2;
     dims2.push_back(3);
     SharedTriList::Pointer tris = SharedTriList::CreateArray(1, dims2, "Triangles");
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/SetOriginResolutionImageGeomTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/SetOriginResolutionImageGeomTest.cpp
@@ -86,7 +86,7 @@ public:
     // incorrect geometry
     TriangleGeom::Pointer triGeom = TriangleGeom::New();
 
-    QVector<size_t> dims;
+    std::vector<size_t> dims;
     dims.push_back(3);
     DataArray<float>::Pointer verts = DataArray<float>::CreateArray(3, dims, "Vertices");
     verts->setComponent(0, 0, -1);
@@ -101,7 +101,7 @@ public:
     verts->setComponent(2, 1, 1);
     verts->setComponent(2, 2, 0);
 
-    QVector<size_t> dims2;
+    std::vector<size_t> dims2;
     dims2.push_back(3);
     SharedTriList::Pointer tris = SharedTriList::CreateArray(1, dims2, "Triangles");
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/SplitAttributeArrayTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/SplitAttributeArrayTest.cpp
@@ -65,45 +65,45 @@ public:
   {
     DataContainerArray::Pointer dca = DataContainerArray::New();
     DataContainer::Pointer dc = DataContainer::New("DataContainer");
-    AttributeMatrix::Pointer am1 = AttributeMatrix::New(QVector<size_t>(1, 10), "AttributeMatrix", AttributeMatrix::Type::Any);
+    AttributeMatrix::Pointer am1 = AttributeMatrix::New(std::vector<size_t>(1, 10), "AttributeMatrix", AttributeMatrix::Type::Any);
 
-    UInt32ArrayType::Pointer mcArray1 = UInt32ArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array uint32_t");
+    UInt32ArrayType::Pointer mcArray1 = UInt32ArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array uint32_t");
     fillDataArray<uint32_t>(mcArray1);
 
-    BoolArrayType::Pointer mcArray2 = BoolArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array bool");
+    BoolArrayType::Pointer mcArray2 = BoolArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array bool");
     fillDataArray(mcArray2);
 
-    UCharArrayType::Pointer mcArray3 = UCharArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array unsigned char");
+    UCharArrayType::Pointer mcArray3 = UCharArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array unsigned char");
     fillDataArray<unsigned char>(mcArray3);
 
-    Int8ArrayType::Pointer mcArray4 = Int8ArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array int8_t");
+    Int8ArrayType::Pointer mcArray4 = Int8ArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array int8_t");
     fillDataArray<int8_t>(mcArray4);
 
-    UInt8ArrayType::Pointer mcArray5 = UInt8ArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array uint8_t");
+    UInt8ArrayType::Pointer mcArray5 = UInt8ArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array uint8_t");
     fillDataArray<uint8_t>(mcArray5);
 
-    Int16ArrayType::Pointer mcArray6 = Int16ArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array int16_t");
+    Int16ArrayType::Pointer mcArray6 = Int16ArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array int16_t");
     fillDataArray<int16_t>(mcArray6);
 
-    UInt16ArrayType::Pointer mcArray7 = UInt16ArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array uint16_t");
+    UInt16ArrayType::Pointer mcArray7 = UInt16ArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array uint16_t");
     fillDataArray<uint16_t>(mcArray7);
 
-    Int32ArrayType::Pointer mcArray8 = Int32ArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array int32_t");
+    Int32ArrayType::Pointer mcArray8 = Int32ArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array int32_t");
     fillDataArray<int32_t>(mcArray8);
 
-    Int64ArrayType::Pointer mcArray9 = Int64ArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array int64_t");
+    Int64ArrayType::Pointer mcArray9 = Int64ArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array int64_t");
     fillDataArray<int64_t>(mcArray9);
 
-    UInt64ArrayType::Pointer mcArray10 = UInt64ArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array uint64_t");
+    UInt64ArrayType::Pointer mcArray10 = UInt64ArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array uint64_t");
     fillDataArray<uint64_t>(mcArray10);
 
-    FloatArrayType::Pointer mcArray11 = FloatArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array float");
+    FloatArrayType::Pointer mcArray11 = FloatArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array float");
     fillDataArray<float>(mcArray11);
 
-    DoubleArrayType::Pointer mcArray12 = DoubleArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array double");
+    DoubleArrayType::Pointer mcArray12 = DoubleArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array double");
     fillDataArray<double>(mcArray12);
 
-    SizeTArrayType::Pointer mcArray13 = SizeTArrayType::CreateArray(QVector<size_t>(1, 10), QVector<size_t>(1, 5), "MultiComponent Array size_t");
+    SizeTArrayType::Pointer mcArray13 = SizeTArrayType::CreateArray(std::vector<size_t>(1, 10), std::vector<size_t>(1, 5), "MultiComponent Array size_t");
     fillDataArray<size_t>(mcArray13);
 
     am1->insertOrAssign(mcArray1);

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/WriteASCIIDataTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/WriteASCIIDataTest.cpp
@@ -89,7 +89,7 @@ public:
 
     DataContainerArray::Pointer dca = DataContainerArray::New();
     DataContainer::Pointer dc = DataContainer::New("DataContainer");
-    AttributeMatrix::Pointer am = AttributeMatrix::New(QVector<size_t>(1, k_ArraySize), "TestAttributeMatrix", AttributeMatrix::Type::Any);
+    AttributeMatrix::Pointer am = AttributeMatrix::New(std::vector<size_t>(1, k_ArraySize), "TestAttributeMatrix", AttributeMatrix::Type::Any);
 
     StringDataArray::Pointer strArray = StringDataArray::CreateArray(k_ArraySize, k_ArrayName, true);
     strArray->setValue(0, QString("Foo"));

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/WriteTriangleGeometryTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/WriteTriangleGeometryTest.cpp
@@ -105,9 +105,9 @@ public:
     static const QString k_TriVertexListDAName("TriVertexList");
     static const QString k_TriListDAName("TriangleList");
 
-    QVector<size_t> k_Dims3(1, 3);
-    QVector<size_t> k_NumNodes(1, 99);
-    QVector<size_t> k_NumTriangles(1, 33);
+    std::vector<size_t> k_Dims3(1, 3);
+    std::vector<size_t> k_NumNodes(1, 99);
+    std::vector<size_t> k_NumTriangles(1, 33);
 
     // Create DataContainerArray
 

--- a/Source/SIMPLib/CoreFilters/util/ASCIIWizardData.hpp
+++ b/Source/SIMPLib/CoreFilters/util/ASCIIWizardData.hpp
@@ -1,38 +1,37 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #pragma once
 
@@ -58,21 +57,15 @@ class ASCIIWizardData
   // clang-format on
 
 public:
-  ASCIIWizardData() :
-    inputFilePath(""),
-    beginIndex(-1),
-    numberOfLines(-1)
-  {
+  ASCIIWizardData() = default;
 
-  }
-
-  QString inputFilePath;
+  QString inputFilePath = "";
   QStringList dataHeaders;
   int beginIndex = -1;
   int numberOfLines = -1;
   QStringList dataTypes;
   QList<char> delimiters;
-  QVector<size_t> tupleDims;
+  std::vector<size_t> tupleDims;
   int attrMatType = 999;
   DataArrayPath selectedPath;
 
@@ -109,7 +102,7 @@ public:
 
   bool isEmpty()
   {
-    if (inputFilePath.isEmpty() && dataHeaders.isEmpty() && dataTypes.isEmpty() && tupleDims.isEmpty() && beginIndex < 0 && numberOfLines < 0 && selectedPath.isEmpty())
+    if(inputFilePath.isEmpty() && dataHeaders.isEmpty() && dataTypes.isEmpty() && tupleDims.empty() && beginIndex < 0 && numberOfLines < 0 && selectedPath.isEmpty())
     {
       return true;
     }

--- a/Source/SIMPLib/CoreFilters/util/CalculatorArray.hpp
+++ b/Source/SIMPLib/CoreFilters/util/CalculatorArray.hpp
@@ -68,15 +68,12 @@ class SIMPLib_EXPORT CalculatorArray : public ICalculatorArray
       {
         return static_cast<double>(m_Array->getValue(i));
       }
-      else if (m_Array->getNumberOfTuples() == 1)
+      if(m_Array->getNumberOfTuples() == 1)
       {
         return static_cast<double>(m_Array->getValue(0));
       }
-      else
-      {
-        // ERROR: The array is empty!
-        return 0.0;
-      }
+      // ERROR: The array is empty!
+      return 0.0;
     }
 
     ICalculatorArray::ValueType getType() override
@@ -90,7 +87,7 @@ class SIMPLib_EXPORT CalculatorArray : public ICalculatorArray
       {
         if(m_Array->getNumberOfComponents() > 1)
         {
-          DoubleArrayType::Pointer newArray = DoubleArrayType::CreateArray(m_Array->getNumberOfTuples(), QVector<size_t>(1, 1), m_Array->getName(), allocate);
+          DoubleArrayType::Pointer newArray = DoubleArrayType::CreateArray(m_Array->getNumberOfTuples(), {1}, m_Array->getName(), allocate);
           if(allocate)
           {
             for(int i = 0; i < m_Array->getNumberOfTuples(); i++)
@@ -122,7 +119,7 @@ class SIMPLib_EXPORT CalculatorArray : public ICalculatorArray
       m_Type(type)
     {
       m_Array = DoubleArrayType::CreateArray(dataArray->getNumberOfTuples(), dataArray->getComponentDimensions(), dataArray->getName(), allocate);
-      if (allocate == true)
+      if(allocate)
       {
         for (int i = 0; i < dataArray->getSize(); i++)
         {
@@ -135,7 +132,10 @@ class SIMPLib_EXPORT CalculatorArray : public ICalculatorArray
     DoubleArrayType::Pointer                                  m_Array;
     ValueType                                                 m_Type;
 
-    CalculatorArray(const CalculatorArray&); // Copy Constructor Not Implemented
-    void operator=(const CalculatorArray&);  // Move assignment Not Implemented
+  public:
+    CalculatorArray(const CalculatorArray&) = delete;            // Copy Constructor Not Implemented
+    CalculatorArray(CalculatorArray&&) = delete;                 // Move Constructor Not Implemented
+    CalculatorArray& operator=(const CalculatorArray&) = delete; // Copy Assignment Not Implemented
+    CalculatorArray& operator=(CalculatorArray&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLib/DataArrays/DataArray.hpp
+++ b/Source/SIMPLib/DataArrays/DataArray.hpp
@@ -55,23 +55,9 @@
   ptr[s] = ptr[d];                                                                                                                                                                                     \
   ptr[d] = t[0];
 
-/** @brief Resizes the DataArray Shared m_Array and assigns its internal data pointer
- *
- */
-#define RESIZE_ARRAY(sharedArray, pointer, size) pointer = sharedArray->WritePointer(0, size);
-
-#define DECLARE_WRAPPED_ARRAY(pubVar, priVar, Type)                                                                                                                                                    \
-  DataArray<Type>::Pointer priVar;                                                                                                                                                                     \
-  Type* pubVar;
-
-#define INIT_DataArray(var, Type) var = DataArray<Type>::CreateArray(0, #var);
-
 /**
- * @class DataArray DataArray.hpp DREAM3DLib/Common/DataArray.hpp
- * @brief Template class for wrapping raw arrays of data.
- * @author mjackson
- * @date July 3, 2008
- * @version $Revision: 1.2 $
+ * @class DataArray
+ * @brief Template class for wrapping raw arrays of data and is the basis for storing data within the SIMPL data structure.
  */
 template <typename T> class DataArray : public IDataArray
 {
@@ -81,13 +67,246 @@ public:
   SIMPL_TYPE_MACRO_SUPER(DataArray<T>, IDataArray)
   SIMPL_CLASS_VERSION(2)
 
-  DataArray(const DataArray&) = default;           // Copy Constructor Not Implemented
+  DataArray(const DataArray&) = default;           // Copy Constructor default Implemented
   DataArray(DataArray&&) = delete;                 // Move Constructor Not Implemented
   DataArray& operator=(const DataArray&) = delete; // Copy Assignment Not Implemented
   DataArray& operator=(DataArray&&) = delete;      // Move Assignment Not Implemented
 
-  using ContainterType = QVector<Pointer>;
+  //========================================= STL INTERFACE COMPATIBILITY =================================
+  using comp_dims_type = std::vector<size_t>;
+  using size_type = size_t;
+  using value_type = T;
+  using reference = T&;
+  using iterator_category = std::input_iterator_tag;
+  using pointer = T*;
+  using difference_type = value_type;
 
+  //========================================= SIMPL INTERFACE COMPATIBILITY =================================
+  using ContainterType = std::vector<Pointer>;
+
+  //========================================= Constructing DataArray Objects =================================
+  DataArray() = default;
+
+  /**
+   * @brief Constructor
+   * @param numTuples The number of Tuples in the DataArray
+   * @param name The name of the DataArray
+   * @param initValue The value to use when initializing each element of the array
+   */
+  DataArray(size_t numTuples, const QString& name, T initValue)
+  : IDataArray(name)
+  {
+    m_NumComponents = 1;
+    resizeTuples(numTuples);
+  }
+
+  /**
+   * @brief DataArray
+   * @param numTuples The number of Tuples in the DataArray
+   * @param name The name of the DataArray
+   * @param compDims The number of elements in each axis dimension.
+   * @param initValue The value to use when initializing each element of the array
+   *
+   * For example if you have a 2D image dimensions of 80(w) x 60(h) then the "cdims" would be [80][60]
+   */
+  DataArray(size_t numTuples, const QString& name, comp_dims_type compDims, T initValue)
+  : IDataArray(name)
+  , m_NumTuples(numTuples)
+  , m_CompDims(std::move(compDims))
+  {
+    m_NumComponents = std::accumulate(m_CompDims.begin(), m_CompDims.end(), 1, std::multiplies<>());
+    m_InitValue = initValue;
+    m_Array = resizeAndExtend(m_NumTuples * m_NumComponents);
+  }
+
+  /**
+   * @brief Protected Constructor
+   * @param numTuples The number of Tuples in the DataArray
+   * @param name The name of the DataArray
+   * @param compDims The number of elements in each axis dimension.
+   * @param initValue The value to use when initializing each element of the array
+   * @param allocate Will all the memory be allocated at time of construction
+   */
+  DataArray(size_t numTuples, const QString& name, comp_dims_type compDims, T initValue, bool allocate)
+  : IDataArray(name)
+  , m_NumTuples(numTuples)
+  , m_CompDims(std::move(compDims))
+  {
+    m_NumComponents = std::accumulate(m_CompDims.begin(), m_CompDims.end(), 1, std::multiplies<>());
+    m_InitValue = static_cast<T>(0);
+    if(allocate)
+    {
+      resizeTuples(numTuples);
+    }
+    else
+    {
+      m_Size = m_NumTuples * m_NumComponents;
+      m_MaxId = (m_Size > 0) ? m_Size - 1 : m_Size;
+    }
+#if 0
+      MUD_FLAP_0 = MUD_FLAP_1 = MUD_FLAP_2 = MUD_FLAP_3 = MUD_FLAP_4 = MUD_FLAP_5 = 0xABABABABABABABABul;
+#endif
+  }
+
+  ~DataArray() override
+  {
+    clear();
+  }
+
+  //========================================= Static Constructing DataArray Objects =================================
+  /**
+   * @brief Static constructor
+   * @param numElements The number of elements in the internal array.
+   * @param name The name of the array
+   * @param allocate Will all the memory be allocated at time of construction
+   * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
+   */
+  static Pointer CreateArray(size_t numTuples, const QString& name, bool allocate = true)
+  {
+    if(name.isEmpty())
+    {
+      return NullPointer();
+    }
+    comp_dims_type cDims = {1};
+    auto d = new DataArray<T>(numTuples, name, cDims, static_cast<T>(0), allocate);
+    if(allocate)
+    {
+      if(d->allocate() < 0)
+      {
+        // Could not allocate enough memory, reset the pointer to null and return
+        delete d;
+        return DataArray<T>::NullPointer();
+      }
+    }
+    Pointer ptr(d);
+    return ptr;
+  }
+
+  /**
+   * @brief Static constructor
+   * @param numTuples The number of tuples in the array.
+   * @param rank The number of dimensions of the attribute on each Tuple
+   * @param dims The actual dimensions of the attribute on each Tuple
+   * @param name The name of the array
+   * @param allocate Will all the memory be allocated at time of construction
+   * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
+   */
+  static Pointer CreateArray(size_t numTuples, int rank, const size_t* dims, const QString& name, bool allocate = true)
+  {
+    if(name.isEmpty())
+    {
+      return NullPointer();
+    }
+    comp_dims_type cDims(rank);
+    for(int i = 0; i < rank; i++)
+    {
+      cDims[i] = dims[i];
+    }
+    auto d = new DataArray<T>(numTuples, name, cDims, allocate);
+    if(allocate)
+    {
+      if(d->allocate() < 0)
+      {
+        // Could not allocate enough memory, reset the pointer to null and return
+        delete d;
+        return DataArray<T>::NullPointer();
+      }
+    }
+    Pointer ptr(d);
+    return ptr;
+  }
+
+  /**
+   * @brief Static constructor
+   * @param numTuples The number of tuples in the array.
+   * @param compDims The actual dimensions of the attribute on each Tuple
+   * @param name The name of the array
+   * @param allocate Will all the memory be allocated at time of construction
+   * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
+   */
+  static Pointer CreateArray(size_t numTuples, const comp_dims_type& compDims, const QString& name, bool allocate = true)
+  {
+    if(name.isEmpty())
+    {
+      return NullPointer();
+    }
+    DataArray<T>* d = new DataArray<T>(numTuples, name, compDims, allocate);
+    if(allocate)
+    {
+      if(d->allocate() < 0)
+      {
+        // Could not allocate enough memory, reset the pointer to null and return
+        delete d;
+        return DataArray<T>::NullPointer();
+      }
+    }
+    Pointer ptr(d);
+    return ptr;
+  }
+
+  /**
+   * @brief Static constructor
+   * @param numTuples The number of tuples in the array.
+   * @param tDims The actual dimensions of the Tuples
+   * @param compDims The number of elements in each axis dimension.
+   * @param name The name of the array
+   * @param allocate Will all the memory be allocated at time of construction
+   * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
+   */
+  static Pointer CreateArray(const comp_dims_type& tupleDims, const comp_dims_type& compDims, const QString& name, bool allocate = true)
+  {
+    if(name.isEmpty())
+    {
+      return NullPointer();
+    }
+
+    size_t numTuples = std::accumulate(tupleDims.begin(), tupleDims.end(), 1, std::multiplies<>());
+
+    auto d = new DataArray<T>(numTuples, name, compDims, allocate);
+    if(allocate)
+    {
+      if(d->allocate() < 0)
+      {
+        // Could not allocate enough memory, reset the pointer to null and return
+        delete d;
+        return DataArray<T>::NullPointer();
+      }
+    }
+    Pointer ptr(d);
+    return ptr;
+  }
+
+  //========================================= Instance Constructing DataArray Objects =================================
+  /**
+   * @brief createNewArray Creates a new DataArray object using the same POD type as the existing instance
+   * @param numTuples The number of tuples in the array.
+   * @param rank The number of dimensions of the attribute on each Tuple
+   * @param dims The actual dimensions of the attribute on each Tuple
+   * @param name The name of the array
+   * @param allocate Will all the memory be allocated at time of construction
+   * @return
+   */
+  IDataArray::Pointer createNewArray(size_t numTuples, int rank, const size_t* compDims, const QString& name, bool allocate = true) override
+  {
+    IDataArray::Pointer p = DataArray<T>::CreateArray(numTuples, rank, compDims, name, allocate);
+    return p;
+  }
+
+  /**
+   * @brief createNewArray
+   * @param numTuples The number of tuples in the array.
+   * @param compDims The number of elements in each axis dimension.
+   * @param name The name of the array
+   * @param allocate Will all the memory be allocated at time of construction
+   * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
+   */
+  IDataArray::Pointer createNewArray(size_t numTuples, const comp_dims_type& compDims, const QString& name, bool allocate = true) override
+  {
+    IDataArray::Pointer p = DataArray<T>::CreateArray(numTuples, compDims, name, allocate);
+    return p;
+  }
+
+  //========================================= Begin API =================================
   /**
    * @brief GetTypeName Returns a string representation of the type of data that is stored by this class. This
    * can be a primitive like char, float, int or the name of a class.
@@ -223,153 +442,6 @@ public:
   }
 
   /**
-   * @brief Static constructor
-   * @param numElements The number of elements in the internal array.
-   * @param name The name of the array
-   * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
-   */
-  static Pointer CreateArray(size_t numElements, const QString& name, bool allocate = true)
-  {
-    if(name.isEmpty())
-    {
-      return NullPointer();
-    }
-    QVector<size_t> cDims(1, 1);
-    auto d = new DataArray<T>(numElements, cDims, name, allocate);
-    if(allocate)
-    {
-      if(d->allocate() < 0)
-      {
-        // Could not allocate enough memory, reset the pointer to null and return
-        delete d;
-        return DataArray<T>::NullPointer();
-      }
-    }
-    Pointer ptr(d);
-    return ptr;
-  }
-
-  /**
-   * @brief Static constructor
-   * @param numTuples The number of tuples in the array.
-   * @param rank The number of dimensions of the attribute on each Tuple
-   * @param dims The actual dimensions of the attribute on each Tuple
-   * @param name The name of the array
-   * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
-   */
-  static Pointer CreateArray(size_t numTuples, int rank, const size_t* dims, const QString& name, bool allocate = true)
-  {
-    if(name.isEmpty())
-    {
-      return NullPointer();
-    }
-    QVector<size_t> cDims(rank);
-    for(int i = 0; i < rank; i++)
-    {
-      cDims[i] = dims[i];
-    }
-    auto d = new DataArray<T>(numTuples, cDims, name, allocate);
-    if(allocate)
-    {
-      if(d->allocate() < 0)
-      {
-        // Could not allocate enough memory, reset the pointer to null and return
-        delete d;
-        return DataArray<T>::NullPointer();
-      }
-    }
-    Pointer ptr(d);
-    return ptr;
-  }
-
-  /**
-   * @brief Static constructor
-   * @param numTuples The number of tuples in the array.
-   * @param dims The actual dimensions of the attribute on each Tuple
-   * @param name The name of the array
-   * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
-   */
-  static Pointer CreateArray(size_t numTuples, const std::vector<size_t>& cDims, const QString& name, bool allocate = true)
-  {
-    if(name.isEmpty())
-    {
-      return NullPointer();
-    }
-    DataArray<T>* d = new DataArray<T>(numTuples, QVector<size_t>::fromStdVector(cDims), name, allocate);
-    if(allocate)
-    {
-      if(d->allocate() < 0)
-      {
-        // Could not allocate enough memory, reset the pointer to null and return
-        delete d;
-        return DataArray<T>::NullPointer();
-      }
-    }
-    Pointer ptr(d);
-    return ptr;
-  }
-
-  /**
-   * @brief Static constructor
-   * @param numTuples The number of tuples in the array.
-   * @param dims The actual dimensions of the attribute on each Tuple
-   * @param name The name of the array
-   * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
-   */
-  static Pointer CreateArray(size_t numTuples, QVector<size_t> cDims, const QString& name, bool allocate = true)
-  {
-    if(name.isEmpty())
-    {
-      return NullPointer();
-    }
-    auto d = new DataArray<T>(numTuples, cDims, name, allocate);
-    if(allocate)
-    {
-      if(d->allocate() < 0)
-      {
-        // Could not allocate enough memory, reset the pointer to null and return
-        delete d;
-        return DataArray<T>::NullPointer();
-      }
-    }
-    Pointer ptr(d);
-    return ptr;
-  }
-
-  /**
-   * @brief Static constructor
-   * @param numTuples The number of tuples in the array.
-   * @param tDims The actual dimensions of the Tuples
-   * @param cDims The actual dimensions of the attribute on each Tuple
-   * @param name The name of the array
-   * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
-   */
-  static Pointer CreateArray(QVector<size_t> tDims, QVector<size_t> cDims, const QString& name, bool allocate = true)
-  {
-    if(name.isEmpty())
-    {
-      return NullPointer();
-    }
-    size_t numTuples = tDims[0];
-    for(int i = 1; i < tDims.size(); i++)
-    {
-      numTuples *= tDims[i];
-    }
-    auto d = new DataArray<T>(numTuples, cDims, name, allocate);
-    if(allocate)
-    {
-      if(d->allocate() < 0)
-      {
-        // Could not allocate enough memory, reset the pointer to null and return
-        delete d;
-        return DataArray<T>::NullPointer();
-      }
-    }
-    Pointer ptr(d);
-    return ptr;
-  }
-
-  /**
    * @brief Static Method to create a DataArray from a QVector through a deep copy of the data
    * contained in the vector. The number of components will be set to 1.
    * @param vec The vector to copy the data from
@@ -388,7 +460,7 @@ public:
   }
 
   /**
-   * @brief Static Method to create a DataArray from a QVector through a deep copy of the data
+   * @brief Static Method to create a DataArray from a std::vector through a deep copy of the data
    * contained in the vector. The number of components will be set to 1.
    * @param vec The vector to copy the data from
    * @param name The name of the array
@@ -396,7 +468,7 @@ public:
    */
   static Pointer FromStdVector(std::vector<T>& vec, const QString& name, bool allocate = true)
   {
-    QVector<size_t> cDims(1, 1);
+    comp_dims_type cDims(1, 1);
     Pointer p = CreateArray(vec.size(), cDims, name, allocate);
     if(nullptr != p.get())
     {
@@ -433,10 +505,10 @@ public:
    * @param ownsData
    * @return
    */
-  static Pointer WrapPointer(T* data, size_t numTuples, QVector<size_t> cDims, const QString& name, bool ownsData)
+  static Pointer WrapPointer(T* data, size_t numTuples, const comp_dims_type& compDims, const QString& name, bool ownsData)
   {
     // Allocate on the heap
-    auto d = new DataArray(numTuples, cDims, name, false);
+    auto d = new DataArray(numTuples, name, compDims, false);
     // Wrap that heap pointer with a shared_pointer to make it reference counted
     Pointer p(d);
 
@@ -531,46 +603,6 @@ public:
       return true;
     }
     return false;
-  }
-
-  /**
-   * @brief createNewArray
-   * @param numTuples
-   * @param rank
-   * @param dims
-   * @param name
-   * @return
-   */
-  IDataArray::Pointer createNewArray(size_t numTuples, int rank, size_t* dims, const QString& name, bool allocate = true) override
-  {
-    IDataArray::Pointer p = DataArray<T>::CreateArray(numTuples, rank, dims, name, allocate);
-    return p;
-  }
-
-  /**
-   * @brief createNewArray
-   * @param numTuples
-   * @param dims
-   * @param name
-   * @return
-   */
-  IDataArray::Pointer createNewArray(size_t numTuples, std::vector<size_t> dims, const QString& name, bool allocate = true) override
-  {
-    IDataArray::Pointer p = DataArray<T>::CreateArray(numTuples, dims, name, allocate);
-    return p;
-  }
-
-  /**
-   * @brief createNewArray
-   * @param numTuples
-   * @param dims
-   * @param name
-   * @return
-   */
-  IDataArray::Pointer createNewArray(size_t numTuples, QVector<size_t> dims, const QString& name, bool allocate = true) override
-  {
-    IDataArray::Pointer p = DataArray<T>::CreateArray(numTuples, dims, name, allocate);
-    return p;
   }
 
   /**
@@ -678,7 +710,7 @@ public:
    * @param idxs The indices to remove
    * @return error code.
    */
-  int eraseTuples(QVector<size_t>& idxs) override
+  int eraseTuples(comp_dims_type& idxs) override
   {
     int err = 0;
 
@@ -743,9 +775,9 @@ public:
       return 0;
     }
 
-    QVector<size_t> srcIdx(idxs.size() + 1);
-    QVector<size_t> destIdx(idxs.size() + 1);
-    QVector<size_t> copyElements(idxs.size() + 1);
+    comp_dims_type srcIdx(idxs.size() + 1);
+    comp_dims_type destIdx(idxs.size() + 1);
+    comp_dims_type copyElements(idxs.size() + 1);
     srcIdx[0] = 0;
     destIdx[0] = 0;
     copyElements[0] = (idxs[0] - 0) * m_NumComponents;
@@ -841,9 +873,9 @@ public:
    * at each tuple then this will return a single element QVector. If you have a 1x3 array (like EUler Angles) then
    * this will return a 3 Element QVector.
    */
-  QVector<size_t> getComponentDimensions() override
+  comp_dims_type getComponentDimensions() override
   {
-    return QVector<size_type>::fromStdVector(m_CompDims);
+    return m_CompDims;
   }
 
   /**
@@ -1299,7 +1331,7 @@ public:
    * @param parentId
    * @return
    */
-  int writeH5Data(hid_t parentId, QVector<size_t> tDims) override
+  int writeH5Data(hid_t parentId, comp_dims_type tDims) override
   {
     if(m_Array == nullptr)
     {
@@ -1440,7 +1472,7 @@ public:
     m_IsAllocated = true;
     setName(p->getName());
     m_NumTuples = p->getNumberOfTuples();
-    m_CompDims = p->getComponentDimensions().toStdVector();
+    m_CompDims = p->getComponentDimensions();
     m_NumComponents = p->getNumberOfComponents();
 
     // Tell the intermediate DataArray to release ownership of the data as we are going to be responsible
@@ -1477,70 +1509,6 @@ public:
       }
       ptr += size; // increment the pointer
     }
-  }
-
-  //========================================= STL INTERFACE COMPATIBILITY =================================
-
-  using comp_dims_type = std::vector<size_t>;
-  using size_type = size_t;
-  using value_type = T;
-  using reference = T&;
-  using iterator_category = std::input_iterator_tag;
-  using pointer = T*;
-  using difference_type = value_type;
-
-  DataArray() = default;
-  /**
-   * @brief DataArray
-   * @param ntuples
-   * @param name
-   * @param allocate
-   */
-  DataArray(size_t ntuples, const std::string& name, bool allocate = true)
-  : IDataArray(QString::fromStdString(name))
-  {
-    m_NumComponents = 1;
-    if(allocate)
-    {
-      resizeTuples(ntuples);
-    }
-    else
-    {
-      m_Size = ntuples;
-      m_MaxId = (ntuples == 0) ? 0 : ntuples - 1;
-      m_NumTuples = ntuples;
-      m_NumComponents = 1;
-    }
-  }
-
-  /**
-   * @brief DataArray
-   * @param ntuples
-   * @param cdims
-   * @param name
-   * @param allocate
-   */
-  DataArray(size_t ntuples, comp_dims_type cdims, const std::string& name, bool allocate = true)
-  : IDataArray(QString::fromStdString(name))
-  , m_NumTuples(ntuples)
-  , m_CompDims(std::move(cdims))
-  {
-    m_NumComponents = std::accumulate(m_CompDims.begin(), m_CompDims.end(), 1, std::multiplies<T>());
-    m_InitValue = static_cast<T>(0);
-    if(allocate)
-    {
-      m_Array = resizeAndExtend(m_NumTuples * m_NumComponents);
-    }
-    else
-    {
-      m_Size = m_NumTuples * m_NumComponents;
-      m_MaxId = (m_Size == 0) ? 0 : m_Size - 1;
-    }
-  }
-
-  ~DataArray() override
-  {
-    clear();
   }
 
   //========================================= STL INTERFACE COMPATIBILITY =================================
@@ -1984,32 +1952,6 @@ public:
   // =================================== END STL COMPATIBLE INTERFACe ===================================================
 
 protected:
-  /**
-   * @brief Protected Constructor
-   * @param numTuples The number of elements in the internal array.
-   * @param rank The number of dimensions the attribute on each Tuple has.
-   * @param dims The actual dimensions the attribute on each Tuple has.
-   * @param takeOwnership Will the class clean up the memory. Default=true
-   */
-  DataArray(size_t numTuples, const QVector<size_t>& compDims, const QString& name, bool ownsData = true)
-  : IDataArray(name)
-  , m_NumTuples(numTuples)
-  , m_OwnsData(ownsData)
-  {
-    // Set the Component Dimensions and compute the number of components at each tuple for caching
-    m_CompDims = std::vector<size_type>(compDims.begin(), compDims.end());
-    m_NumComponents = m_CompDims[0];
-    for(int i = 1; i < m_CompDims.size(); i++)
-    {
-      m_NumComponents = m_NumComponents * m_CompDims[i];
-    }
-
-    m_Size = m_NumTuples * m_NumComponents;
-    m_MaxId = (m_Size > 0) ? m_Size - 1 : m_Size;
-
-    m_InitValue = static_cast<T>(0);
-    //  MUD_FLAP_0 = MUD_FLAP_1 = MUD_FLAP_2 = MUD_FLAP_3 = MUD_FLAP_4 = MUD_FLAP_5 = 0xABABABABABABABABul;
-  }
 
   /**
    * @brief deallocates the memory block
@@ -2187,7 +2129,7 @@ private:
   size_t m_NumTuples = 0;
   size_t m_NumComponents = 1;
   T m_InitValue = static_cast<T>(0);
-  std::vector<size_t> m_CompDims = {1};
+  comp_dims_type m_CompDims = {1};
   bool m_IsAllocated = false;
   bool m_OwnsData = true;
 };

--- a/Source/SIMPLib/DataArrays/IDataArray.h
+++ b/Source/SIMPLib/DataArrays/IDataArray.h
@@ -17,8 +17,8 @@
 #include <hdf5.h>
 
 //--Qt Includes
+#include <QtCore/QDebug>
 #include <QtCore/QString>
-#include <QtCore/QtDebug>
 
 //SIMPLib Includes
 #include "SIMPLib/SIMPLib.h"
@@ -44,7 +44,7 @@ class SIMPLib_EXPORT IDataArray : public IDataStructureNode
   PYB11_PROPERTY(QString Name READ getName WRITE setName)
 
   PYB11_METHOD(QString getTypeAsString)
-  PYB11_METHOD(QVector<size_t> getComponentDimensions)
+  PYB11_METHOD(std::vector<size_t> getComponentDimensions)
   PYB11_METHOD(size_t getNumberOfTuples)
   PYB11_METHOD(int getNumberOfComponents)
 
@@ -78,9 +78,9 @@ class SIMPLib_EXPORT IDataArray : public IDataStructureNode
     IDataArray(const QString& name = "");
     ~IDataArray() override;
 
-    virtual Pointer createNewArray(size_t numElements, int rank, size_t* dims, const QString& name, bool allocate = true) = 0;
-    virtual Pointer createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate = true) = 0;
-    virtual Pointer createNewArray(size_t numElements, QVector<size_t> dims, const QString& name, bool allocate = true) = 0;
+    virtual Pointer createNewArray(size_t numElements, int rank, const size_t* dims, const QString& name, bool allocate = true) = 0;
+    virtual Pointer createNewArray(size_t numElements, const std::vector<size_t>& dims, const QString& name, bool allocate = true) = 0;
+    // virtual Pointer createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate = true) = 0;
 
     /**
      * @brief Creates and returns a DataArrayPath for the DataArray
@@ -129,8 +129,7 @@ class SIMPLib_EXPORT IDataArray : public IDataStructureNode
     virtual size_t getSize() = 0;
 
     virtual int getNumberOfComponents() = 0;
-    virtual QVector<size_t> getComponentDimensions() = 0;
-
+    virtual std::vector<size_t> getComponentDimensions() = 0;
 
     /**
      * @brief Returns the number of bytes that make up the data type.
@@ -153,7 +152,7 @@ class SIMPLib_EXPORT IDataArray : public IDataStructureNode
      * @param idxs The indices to erase
      * @return
      */
-    virtual int eraseTuples(QVector<size_t>& idxs) = 0;
+    virtual int eraseTuples(std::vector<size_t>& idxs) = 0;
 
     /**
      * @brief Copies a Tuple from one position to another.
@@ -261,7 +260,7 @@ class SIMPLib_EXPORT IDataArray : public IDataStructureNode
      * @param tDims
      * @return
      */
-    virtual int writeH5Data(hid_t parentId, QVector<size_t> tDims) = 0;
+    virtual int writeH5Data(hid_t parentId, std::vector<size_t> tDims) = 0;
 
     /**
      * @brief readH5Data

--- a/Source/SIMPLib/DataArrays/NeighborList.hpp
+++ b/Source/SIMPLib/DataArrays/NeighborList.hpp
@@ -106,7 +106,7 @@ class NeighborList : public IDataArray
      * @param allocate
      * @return
      */
-    static Pointer CreateArray(size_t numTuples, int rank, size_t* dims, const QString& name, bool allocate = true)
+    static Pointer CreateArray(size_t numTuples, int rank, const size_t* dims, const QString& name, bool allocate = true)
     {
       //std::cout << "NeighborList::CreateArray  name= " << name.toStdString() << "   numTuples= " << numTuples << std::endl;
       if(name.isEmpty())
@@ -135,17 +135,14 @@ class NeighborList : public IDataArray
      * @param allocate
      * @return
      */
-    static Pointer CreateArray(size_t numTuples, std::vector<size_t> cDims, const QString& name, bool allocate = true)
+    static Pointer CreateArray(size_t numTuples, const std::vector<size_t>& cDims, const QString& name, bool allocate = true)
     {
       if(name.isEmpty())
       {
         return NullPointer();
       }
-      size_t numElements = numTuples;
-      for(size_t iter = 0; iter < cDims.size(); iter++)
-      {
-        numElements *= cDims[iter];
-      }
+      size_t numElements = std::accumulate(cDims.begin(), cDims.end(), numTuples, std::multiplies<>());
+
       Pointer ptr = Pointer(new NeighborList<T>(numElements, name));
       if(allocate)
       {
@@ -162,24 +159,24 @@ class NeighborList : public IDataArray
      * @param allocate
      * @return
      */
-    static Pointer CreateArray(size_t numTuples, QVector<size_t> cDims, const QString& name, bool allocate = true)
-    {
-      if(name.isEmpty())
-      {
-        return NullPointer();
-      }
-      size_t numElements = numTuples;
-      for(int iter = 0; iter < cDims.size(); iter++)
-      {
-        numElements *= cDims[iter];
-      }
-      Pointer ptr = Pointer(new NeighborList<T>(numElements, name));
-      if(allocate)
-      {
-        ptr->resizeTuples(numElements);
-      }
-      return ptr;
-    }
+    //    static Pointer CreateArray(size_t numTuples, std::vector<size_t> cDims, const QString& name, bool allocate = true)
+    //    {
+    //      if(name.isEmpty())
+    //      {
+    //        return NullPointer();
+    //      }
+    //      size_t numElements = numTuples;
+    //      for(int iter = 0; iter < cDims.size(); iter++)
+    //      {
+    //        numElements *= cDims[iter];
+    //      }
+    //      Pointer ptr = Pointer(new NeighborList<T>(numElements, name));
+    //      if(allocate)
+    //      {
+    //        ptr->resizeTuples(numElements);
+    //      }
+    //      return ptr;
+    //    }
 
     /**
      * @brief CreateArray
@@ -189,7 +186,7 @@ class NeighborList : public IDataArray
      * @param allocate
      * @return
      */
-    static Pointer CreateArray(QVector<size_t> tDims, QVector<size_t> cDims, const QString& name, bool allocate = true)
+    static Pointer CreateArray(const std::vector<size_t>& tDims, const std::vector<size_t>& cDims, const QString& name, bool allocate = true)
     {
       if(name.isEmpty())
       {
@@ -220,7 +217,7 @@ class NeighborList : public IDataArray
      * @param name
      * @return
      */
-    IDataArray::Pointer createNewArray(size_t numElements, int rank, size_t* dims, const QString& name, bool allocate = true) override
+    IDataArray::Pointer createNewArray(size_t numElements, int rank, const size_t* dims, const QString& name, bool allocate = true) override
     {
       return NeighborList<T>::CreateArray(numElements, rank, dims, name, allocate);
     }
@@ -232,7 +229,7 @@ class NeighborList : public IDataArray
      * @param name
      * @return
      */
-    IDataArray::Pointer createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate = true) override
+    IDataArray::Pointer createNewArray(size_t numElements, const std::vector<size_t>& dims, const QString& name, bool allocate = true) override
     {
       return NeighborList<T>::CreateArray(numElements, dims, name, allocate);
     }
@@ -244,10 +241,10 @@ class NeighborList : public IDataArray
      * @param name
      * @return
      */
-    IDataArray::Pointer createNewArray(size_t numElements, QVector<size_t> dims, const QString& name, bool allocate = true) override
-    {
-      return NeighborList<T>::CreateArray(numElements, dims, name, allocate);
-    }
+    //    IDataArray::Pointer createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate = true) override
+    //    {
+    //      return NeighborList<T>::CreateArray(numElements, dims, name, allocate);
+    //    }
 
     using VectorType = std::vector<T>;
     using SharedVectorType = std::shared_ptr<VectorType>;
@@ -338,7 +335,7 @@ class NeighborList : public IDataArray
      * @param idxs The indices to remove
      * @return error code.
      */
-    int eraseTuples(QVector<size_t>& idxs) override
+    int eraseTuples(std::vector<size_t>& idxs) override
     {
       int err = 0;
       // If nothing is to be erased just return
@@ -357,7 +354,7 @@ class NeighborList : public IDataArray
       size_t arraySize = m_Array.size();
       // Sanity Check the Indices in the vector to make sure we are not trying to remove any indices that are
       // off the end of the array and return an error code.
-      for(QVector<size_t>::size_type i = 0; i < idxs.size(); ++i)
+      for(std::vector<size_t>::size_type i = 0; i < idxs.size(); ++i)
       {
         if (idxs[i] >= arraySize) { return -100; }
       }
@@ -519,9 +516,9 @@ class NeighborList : public IDataArray
      * @brief getComponentDimensions
      * @return
      */
-    QVector<size_t> getComponentDimensions() override
+    std::vector<size_t> getComponentDimensions() override
     {
-      QVector<size_t> dims(1, 1);
+      std::vector<size_t> dims = {1};
       return dims;
     }
 
@@ -630,7 +627,7 @@ class NeighborList : public IDataArray
      * @param parentId
      * @return
      */
-    int writeH5Data(hid_t parentId, QVector<size_t> tDims) override
+    int writeH5Data(hid_t parentId, std::vector<size_t> tDims) override
     {
       int err = 0;
 
@@ -741,7 +738,7 @@ class NeighborList : public IDataArray
           return -609;
         }
 
-        QVector<size_t> cDims = getComponentDimensions();
+        std::vector<size_t> cDims = getComponentDimensions();
         // write the component dimensions as  an attribute
         size = cDims.size();
         err = QH5Lite::writePointerAttribute(parentId, getName(), SIMPL::HDF5::ComponentDimensions, 1, &size, cDims.data());

--- a/Source/SIMPLib/DataArrays/StatsDataArray.cpp
+++ b/Source/SIMPLib/DataArrays/StatsDataArray.cpp
@@ -83,7 +83,7 @@ StatsDataArray::Pointer StatsDataArray::CreateArray(size_t numElements, const QS
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-StatsDataArray::Pointer StatsDataArray::CreateArray(size_t numTuples, int rank, size_t* dims, const QString& name, bool allocate)
+StatsDataArray::Pointer StatsDataArray::CreateArray(size_t numTuples, int rank, const size_t* dims, const QString& name, bool allocate)
 {
   if(name.isEmpty())
   {
@@ -102,7 +102,7 @@ StatsDataArray::Pointer StatsDataArray::CreateArray(size_t numTuples, int rank, 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-StatsDataArray::Pointer StatsDataArray::CreateArray(size_t numTuples, std::vector<size_t> cDims, const QString& name, bool allocate)
+StatsDataArray::Pointer StatsDataArray::CreateArray(size_t numTuples, const std::vector<size_t>& cDims, const QString& name, bool allocate)
 {
   if(name.isEmpty())
   {
@@ -118,29 +118,11 @@ StatsDataArray::Pointer StatsDataArray::CreateArray(size_t numTuples, std::vecto
   return ptr;
 }
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-StatsDataArray::Pointer StatsDataArray::CreateArray(size_t numTuples, QVector<size_t> cDims, const QString& name, bool allocate)
-{
-  if(name.isEmpty())
-  {
-    return NullPointer();
-  }
-  StatsDataArray::Pointer ptr = StatsDataArray::New();
-  ptr->setName(name);
-  std::vector<PhaseType::Type> phase_types(numTuples, PhaseType::Type::Unknown);
-  if(allocate)
-  {
-    ptr->fillArrayWithNewStatsData(numTuples, &(phase_types.front()));
-  }
-  return ptr;
-}
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-StatsDataArray::Pointer StatsDataArray::CreateArray(QVector<size_t> tDims, QVector<size_t> cDims, const QString& name, bool allocate)
+StatsDataArray::Pointer StatsDataArray::CreateArray(const std::vector<size_t>& tDims, const std::vector<size_t>& cDims, const QString& name, bool allocate)
 {
   if(name.isEmpty())
   {
@@ -165,7 +147,7 @@ StatsDataArray::Pointer StatsDataArray::CreateArray(QVector<size_t> tDims, QVect
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IDataArray::Pointer StatsDataArray::createNewArray(size_t numElements, int rank, size_t* dims, const QString& name, bool allocate)
+IDataArray::Pointer StatsDataArray::createNewArray(size_t numElements, int rank, const size_t* dims, const QString& name, bool allocate)
 {
   return StatsDataArray::NullPointer();
 }
@@ -173,15 +155,7 @@ IDataArray::Pointer StatsDataArray::createNewArray(size_t numElements, int rank,
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IDataArray::Pointer StatsDataArray::createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate)
-{
-  return StatsDataArray::NullPointer();
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-IDataArray::Pointer StatsDataArray::createNewArray(size_t numElements, QVector<size_t> dims, const QString& name, bool allocate)
+IDataArray::Pointer StatsDataArray::createNewArray(size_t numElements, const std::vector<size_t>& dims, const QString& name, bool allocate)
 {
   return StatsDataArray::NullPointer();
 }
@@ -253,9 +227,9 @@ int StatsDataArray::getNumberOfComponents()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<size_t> StatsDataArray::getComponentDimensions()
+std::vector<size_t> StatsDataArray::getComponentDimensions()
 {
-  QVector<size_t> dims(1, 1);
+  std::vector<size_t> dims = {1};
   return dims;
 }
 
@@ -270,7 +244,7 @@ size_t StatsDataArray::getTypeSize()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-int StatsDataArray::eraseTuples(QVector<size_t>& idxs)
+int StatsDataArray::eraseTuples(std::vector<size_t>& idxs)
 {
   int err = 0;
 
@@ -288,9 +262,9 @@ int StatsDataArray::eraseTuples(QVector<size_t>& idxs)
 
   // Sanity Check the Indices in the vector to make sure we are not trying to remove any indices that are
   // off the end of the array and return an error code.
-  for(QVector<size_t>::size_type i = 0; i < idxs.size(); ++i)
+  for(const auto& idx : idxs)
   {
-    if(idxs[i] >= static_cast<size_t>(m_StatsDataArray.size()))
+    if(idx >= static_cast<size_t>(m_StatsDataArray.size()))
     {
       return -100;
     }
@@ -454,7 +428,7 @@ void StatsDataArray::printComponent(QTextStream& out, size_t i, int j)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-int StatsDataArray::writeH5Data(hid_t parentId, QVector<size_t> tDims)
+int StatsDataArray::writeH5Data(hid_t parentId, std::vector<size_t> tDims)
 {
   herr_t err = 0;
   hid_t gid = QH5Utilities::createGroup(parentId, getName());
@@ -480,7 +454,7 @@ int StatsDataArray::writeH5Data(hid_t parentId, QVector<size_t> tDims)
     }
   }
 
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   err = H5DataArrayWriter::writeDataArrayAttributes<StatsDataArray>(parentId, this, tDims, cDims);
 
   return err;

--- a/Source/SIMPLib/DataArrays/StatsDataArray.h
+++ b/Source/SIMPLib/DataArrays/StatsDataArray.h
@@ -52,8 +52,8 @@ class SIMPLib_EXPORT StatsDataArray : public IDataArray
   PYB11_STATIC_CREATION(CreateArray OVERLOAD size_t QString bool)
   PYB11_STATIC_CREATION(CreateArray OVERLOAD size_t int size_t* QString bool)
   PYB11_STATIC_CREATION(CreateArray OVERLOAD size_t std::vector<size_t> QString bool)
-  PYB11_STATIC_CREATION(CreateArray OVERLOAD size_t QVector<size_t> QString bool)
-  PYB11_STATIC_CREATION(CreateArray OVERLOAD QVector<size_t> QVector<size_t> QString bool)
+  PYB11_STATIC_CREATION(CreateArray OVERLOAD size_t std::vector<size_t> QString bool)
+  PYB11_STATIC_CREATION(CreateArray OVERLOAD std::vector<size_t> std::vector<size_t> QString bool)
   PYB11_METHOD(void setStatsData ARGS int,index StatsData::Pointer,statsData)
   PYB11_METHOD(StatsData::Pointer getStatsData ARGS int,index)
   PYB11_METHOD(void fillArrayWithNewStatsData OVERLOAD size_t,n PhaseType::Type*,phase_types)
@@ -85,7 +85,7 @@ public:
    * @param allocate
    * @return
    */
-  static Pointer CreateArray(size_t numTuples, int rank, size_t* dims, const QString& name, bool allocate = true);
+  static Pointer CreateArray(size_t numTuples, int rank, const size_t* dims, const QString& name, bool allocate = true);
 
   /**
    * @brief CreateArray
@@ -95,17 +95,7 @@ public:
    * @param allocate
    * @return
    */
-  static Pointer CreateArray(size_t numTuples, std::vector<size_t> cDims, const QString& name, bool allocate = true);
-
-  /**
-   * @brief CreateArray
-   * @param numTuples
-   * @param cDims
-   * @param name
-   * @param allocate
-   * @return
-   */
-  static Pointer CreateArray(size_t numTuples, QVector<size_t> cDims, const QString& name, bool allocate = true);
+  static Pointer CreateArray(size_t numTuples, const std::vector<size_t>& cDims, const QString& name, bool allocate = true);
 
   /**
    * @brief CreateArray
@@ -115,7 +105,7 @@ public:
    * @param allocate
    * @return
    */
-  static Pointer CreateArray(QVector<size_t> tDims, QVector<size_t> cDims, const QString& name, bool allocate = true);
+  static Pointer CreateArray(const std::vector<size_t>& tDims, const std::vector<size_t>& cDims, const QString& name, bool allocate = true);
 
   /**
    * @brief GetTypeName Returns a string representation of the type of data that is stored by this class. This
@@ -132,11 +122,9 @@ public:
 
   SIMPL_INSTANCE_PROPERTY(QVector<StatsData::Pointer>, StatsDataArray)
 
-  IDataArray::Pointer createNewArray(size_t numElements, int rank, size_t* dims, const QString& name, bool allocate = true) override;
+  IDataArray::Pointer createNewArray(size_t numElements, int rank, const size_t* dims, const QString& name, bool allocate = true) override;
 
-  IDataArray::Pointer createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate = true) override;
-
-  IDataArray::Pointer createNewArray(size_t numElements, QVector<size_t> dims, const QString& name, bool allocate = true) override;
+  IDataArray::Pointer createNewArray(size_t numElements, const std::vector<size_t>& dims, const QString& name, bool allocate = true) override;
 
   /**
    * @brief
@@ -226,7 +214,7 @@ public:
    * @brief getComponentDimensions
    * @return
    */
-  QVector<size_t> getComponentDimensions() override;
+  std::vector<size_t> getComponentDimensions() override;
 
   /**
    * @brief Returns the number of bytes that make up the data type.
@@ -245,7 +233,7 @@ public:
    * @param idxs The indices to remove
    * @return error code.
    */
-  int eraseTuples(QVector<size_t>& idxs) override;
+  int eraseTuples(std::vector<size_t>& idxs) override;
 
   /**
    * @brief Copies a Tuple from one position to another.
@@ -333,7 +321,7 @@ public:
    * @param parentId
    * @return
    */
-  int writeH5Data(hid_t parentId, QVector<size_t> tDims) override;
+  int writeH5Data(hid_t parentId, std::vector<size_t> tDims) override;
 
   /**
    * @brief readH5Data

--- a/Source/SIMPLib/DataArrays/StringDataArray.cpp
+++ b/Source/SIMPLib/DataArrays/StringDataArray.cpp
@@ -74,7 +74,7 @@ StringDataArray::Pointer StringDataArray::CreateArray(size_t numTuples, const QS
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-StringDataArray::Pointer StringDataArray::CreateArray(size_t numTuples, QVector<size_t> compDims, const QString& name, bool allocate)
+StringDataArray::Pointer StringDataArray::CreateArray(size_t numTuples, const std::vector<size_t>& compDims, const QString& name, bool allocate)
 {
   if(name.isEmpty())
   {
@@ -88,7 +88,7 @@ StringDataArray::Pointer StringDataArray::CreateArray(size_t numTuples, QVector<
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IDataArray::Pointer StringDataArray::createNewArray(size_t numElements, int rank, size_t* dims, const QString& name, bool allocate)
+IDataArray::Pointer StringDataArray::createNewArray(size_t numElements, int rank, const size_t* dims, const QString& name, bool allocate)
 {
   IDataArray::Pointer p = StringDataArray::CreateArray(numElements, name, allocate);
   return p;
@@ -97,7 +97,7 @@ IDataArray::Pointer StringDataArray::createNewArray(size_t numElements, int rank
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IDataArray::Pointer StringDataArray::createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate)
+IDataArray::Pointer StringDataArray::createNewArray(size_t numElements, const std::vector<size_t>& dims, const QString& name, bool allocate)
 {
   IDataArray::Pointer p = StringDataArray::CreateArray(numElements, name, allocate);
   return p;
@@ -106,11 +106,11 @@ IDataArray::Pointer StringDataArray::createNewArray(size_t numElements, std::vec
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IDataArray::Pointer StringDataArray::createNewArray(size_t numElements, QVector<size_t> dims, const QString& name, bool allocate)
-{
-  IDataArray::Pointer p = StringDataArray::CreateArray(numElements, name, allocate);
-  return p;
-}
+// IDataArray::Pointer StringDataArray::createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate)
+//{
+//  IDataArray::Pointer p = StringDataArray::CreateArray(numElements, name, allocate);
+//  return p;
+//}
 
 StringDataArray::~StringDataArray() = default;
 
@@ -206,9 +206,9 @@ int StringDataArray::getNumberOfComponents()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<size_t> StringDataArray::getComponentDimensions()
+std::vector<size_t> StringDataArray::getComponentDimensions()
 {
-  QVector<size_t> dims(1, 1);
+  std::vector<size_t> dims = {1};
   return dims;
 }
 
@@ -238,7 +238,7 @@ size_t StringDataArray::getTypeSize()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-int StringDataArray::eraseTuples(QVector<size_t>& idxs)
+int StringDataArray::eraseTuples(std::vector<size_t>& idxs)
 {
 
   int err = 0;
@@ -257,7 +257,7 @@ int StringDataArray::eraseTuples(QVector<size_t>& idxs)
 
   // Sanity Check the Indices in the vector to make sure we are not trying to remove any indices that are
   // off the end of the array and return an error code.
-  // for(QVector<size_t>::size_type i = 0; i < idxs.size(); ++i)
+  // for(std::vector<size_t>::size_type i = 0; i < idxs.size(); ++i)
   for(auto& value : idxs)
   {
     if(value >= static_cast<size_t>(m_Array.size()))
@@ -272,7 +272,7 @@ int StringDataArray::eraseTuples(QVector<size_t>& idxs)
   for(QVector<QString>::size_type i = 0; i < m_Array.size(); ++i)
   {
     bool keep = true;
-    for(QVector<size_t>::size_type j = start; j < idxs.size(); ++j)
+    for(std::vector<size_t>::size_type j = start; j < idxs.size(); ++j)
     {
       if(static_cast<size_t>(i) == idxs[j])
       {
@@ -443,7 +443,7 @@ QString StringDataArray::getFullNameOfClass()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-int StringDataArray::writeH5Data(hid_t parentId, QVector<size_t> tDims)
+int StringDataArray::writeH5Data(hid_t parentId, std::vector<size_t> tDims)
 {
   return H5DataArrayWriter::writeStringDataArray<StringDataArray>(parentId, this);
 }

--- a/Source/SIMPLib/DataArrays/StringDataArray.h
+++ b/Source/SIMPLib/DataArrays/StringDataArray.h
@@ -58,7 +58,7 @@ class SIMPLib_EXPORT StringDataArray : public IDataArray
   // clang-format off
   PYB11_CREATE_BINDINGS(StringDataArray SUPER IDataArray)
   PYB11_STATIC_CREATION(CreateArray OVERLOAD size_t QString bool)
-  PYB11_STATIC_CREATION(CreateArray OVERLOAD size_t QVector<size_t> QString bool)
+  PYB11_STATIC_CREATION(CreateArray OVERLOAD size_t std::vector<size_t> QString bool)
   PYB11_PROPERTY(QString Name READ getName WRITE setName)
   PYB11_METHOD(QString getValue ARGS size_t,i)
   PYB11_METHOD(void setValue ARGS size_t,i const.QString.&,value)
@@ -69,7 +69,7 @@ class SIMPLib_EXPORT StringDataArray : public IDataArray
 public:
   SIMPL_SHARED_POINTERS(StringDataArray)
   SIMPL_STATIC_NEW_MACRO(StringDataArray)
-  SIMPL_TYPE_MACRO_SUPER(StringDataArray, IDataArray)
+  SIMPL_TYPE_MACRO_SUPER_OVERRIDE(StringDataArray, IDataArray)
   SIMPL_CLASS_VERSION(2)
 
   /**
@@ -89,7 +89,7 @@ public:
    * @param allocate
    * @return
    */
-  static Pointer CreateArray(size_t numTuples, QVector<size_t> compDims, const QString& name, bool allocate = true);
+  static Pointer CreateArray(size_t numTuples, const std::vector<size_t>& compDims, const QString& name, bool allocate = true);
   /**
    * @brief createNewArray
    * @param numElements
@@ -97,7 +97,7 @@ public:
    * @param name
    * @return
    */
-  IDataArray::Pointer createNewArray(size_t numElements, int rank, size_t* dims, const QString& name, bool allocate = true) override;
+  IDataArray::Pointer createNewArray(size_t numElements, int rank, const size_t* dims, const QString& name, bool allocate = true) override;
 
   /**
    * @brief createNewArray
@@ -107,7 +107,7 @@ public:
    * @param allocate
    * @return
    */
-  IDataArray::Pointer createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate = true) override;
+  IDataArray::Pointer createNewArray(size_t numElements, const std::vector<size_t>& dims, const QString& name, bool allocate = true) override;
 
   /**
    * @brief createNewArray
@@ -117,7 +117,7 @@ public:
    * @param allocate
    * @return
    */
-  IDataArray::Pointer createNewArray(size_t numElements, QVector<size_t> dims, const QString& name, bool allocate = true) override;
+  // IDataArray::Pointer createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate = true) override;
 
   /**
    * @brief ~StringDataArray
@@ -185,7 +185,7 @@ public:
 
   int getNumberOfComponents() override;
 
-  QVector<size_t> getComponentDimensions() override;
+  std::vector<size_t> getComponentDimensions() override;
 
   // Description:
   // Set/Get the dimension (n) of the rank. Must be >= 1. Make sure that
@@ -215,7 +215,7 @@ public:
    * @param idxs The indices to remove
    * @return error code.
    */
-  int eraseTuples(QVector<size_t>& idxs) override;
+  int eraseTuples(std::vector<size_t>& idxs) override;
 
   /**
    * @brief Copies a Tuple from one position to another.
@@ -326,7 +326,7 @@ public:
    * @param parentId
    * @return
    */
-  int writeH5Data(hid_t parentId, QVector<size_t> tDims) override;
+  int writeH5Data(hid_t parentId, std::vector<size_t> tDims) override;
 
   /**
    * @brief writeXdmfAttribute

--- a/Source/SIMPLib/DataArrays/StructArray.hpp
+++ b/Source/SIMPLib/DataArrays/StructArray.hpp
@@ -90,23 +90,23 @@ class StructArray : public IDataArray
      * @param name The name of the array
      * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
      */
-    IDataArray::Pointer createNewArray(size_t numElements, int rank, size_t* dims, const QString& name, bool allocate = true) override
+    IDataArray::Pointer createNewArray(size_t numElements, int rank, const size_t* dims, const QString& name, bool allocate = true) override
     {
       IDataArray::Pointer p = StructArray<T>::CreateArray(numElements, name, allocate);
       return p;
     }
 
-    IDataArray::Pointer createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate = true) override
+    IDataArray::Pointer createNewArray(size_t numElements, const std::vector<size_t>& dims, const QString& name, bool allocate = true) override
     {
       IDataArray::Pointer p = StructArray<T>::CreateArray(numElements, name, allocate);
       return p;
     }
 
-    IDataArray::Pointer createNewArray(size_t numElements, QVector<size_t> dims, const QString& name, bool allocate = true) override
-    {
-      IDataArray::Pointer p = StructArray<T>::CreateArray(numElements, name, allocate);
-      return p;
-    }
+    //    IDataArray::Pointer createNewArray(size_t numElements, std::vector<size_t> dims, const QString& name, bool allocate = true) override
+    //    {
+    //      IDataArray::Pointer p = StructArray<T>::CreateArray(numElements, name, allocate);
+    //      return p;
+    //    }
 
     /**
      * @brief Destructor
@@ -259,13 +259,13 @@ class StructArray : public IDataArray
      * @param idxs The indices to remove
      * @return error code.
      */
-    int eraseTuples(QVector<size_t>& idxs) override
+    int eraseTuples(std::vector<size_t>& idxs) override
     {
 
       int err = 0;
 
       // If nothing is to be erased just return
-      if(idxs.size() == 0)
+      if(idxs.empty())
       {
         return 0;
       }
@@ -279,7 +279,7 @@ class StructArray : public IDataArray
 
       // Sanity Check the Indices in the vector to make sure we are not trying to remove any indices that are
       // off the end of the array and return an error code.
-      for(QVector<size_t>::size_type i = 0; i < idxs.size(); ++i)
+      for(std::vector<size_t>::size_type i = 0; i < idxs.size(); ++i)
       {
         if (idxs[i] > this->m_MaxId) { return -100; }
       }
@@ -323,9 +323,9 @@ class StructArray : public IDataArray
         return 0;
       }
 
-      QVector<size_t> srcIdx(idxs.size() + 1);
-      QVector<size_t> destIdx(idxs.size() + 1);
-      QVector<size_t> copyElements(idxs.size() + 1);
+      std::vector<size_t> srcIdx(idxs.size() + 1);
+      std::vector<size_t> destIdx(idxs.size() + 1);
+      std::vector<size_t> copyElements(idxs.size() + 1);
       srcIdx[0] = 0;
       destIdx[0] = 0;
       copyElements[0] = (idxs[0] - 0);
@@ -496,9 +496,9 @@ class StructArray : public IDataArray
      * @brief getNumberOfComponents
      * @return
      */
-    QVector<size_t> getComponentDimensions() override
+    std::vector<size_t> getComponentDimensions() override
     {
-      QVector<size_t> dims(1, 1);
+      std::vector<size_t> dims(1, 1);
       return dims;
     }
 
@@ -571,7 +571,7 @@ class StructArray : public IDataArray
     IDataArray::Pointer deepCopy(bool forceNoAllocate = false) override
     {
       IDataArray::Pointer daCopy = createNewArray(getNumberOfTuples(), getComponentDimensions(), getName(), m_IsAllocated);
-      if(m_IsAllocated == true && forceNoAllocate == false)
+      if(m_IsAllocated && !forceNoAllocate)
       {
         T* src = getPointer(0);
         void* dest = daCopy->getVoidPointer(0);
@@ -638,7 +638,7 @@ class StructArray : public IDataArray
      * @param parentId
      * @return
      */
-    int writeH5Data(hid_t parentId, QVector<size_t> tDims) override
+    int writeH5Data(hid_t parentId, std::vector<size_t> tDims) override
     {
       Q_ASSERT(false);
       return -1;

--- a/Source/SIMPLib/DataArrays/Testing/Cxx/DataArrayTest.cpp
+++ b/Source/SIMPLib/DataArrays/Testing/Cxx/DataArrayTest.cpp
@@ -128,7 +128,7 @@ public:
   template <typename T> void TestcopyTuplesForType()
   {
     int err = 0;
-    QVector<size_t> dims(1, NUM_COMPONENTS_2);
+    std::vector<size_t> dims(1, NUM_COMPONENTS_2);
     typename DataArray<T>::Pointer array = DataArray<T>::CreateArray(NUM_TUPLES_2, dims, "TestcopyTuples");
     DREAM3D_REQUIRE_EQUAL(array->isAllocated(), true);
 
@@ -190,7 +190,7 @@ public:
         array->setComponent(i, 0, static_cast<T>(i));
       }
 
-      QVector<size_t> eraseElements;
+      std::vector<size_t> eraseElements;
       eraseElements.push_back(0);
       eraseElements.push_back(1);
 
@@ -204,7 +204,7 @@ public:
 
     // Test Dropping of internal elements
     {
-      QVector<size_t> dims(1, NUM_COMPONENTS_2);
+      std::vector<size_t> dims(1, NUM_COMPONENTS_2);
       typename DataArray<T>::Pointer array = DataArray<T>::CreateArray(NUM_ELEMENTS_2, dims, "Test2");
       DREAM3D_REQUIRE_EQUAL(array->isAllocated(), true);
       for(size_t i = 0; i < NUM_TUPLES_2; ++i)
@@ -213,7 +213,7 @@ public:
         array->setComponent(i, 1, static_cast<T>(i));
       }
 
-      QVector<size_t> eraseElements;
+      std::vector<size_t> eraseElements;
       eraseElements.push_back(3);
       eraseElements.push_back(6);
       eraseElements.push_back(8);
@@ -230,7 +230,7 @@ public:
 
     // Test Dropping of internal elements
     {
-      QVector<size_t> dims(1, NUM_COMPONENTS_2);
+      std::vector<size_t> dims(1, NUM_COMPONENTS_2);
       typename DataArray<T>::Pointer array = DataArray<T>::CreateArray(NUM_ELEMENTS_2, dims, "Test3");
       DREAM3D_REQUIRE_EQUAL(array->isAllocated(), true);
       for(size_t i = 0; i < NUM_TUPLES_2; ++i)
@@ -239,7 +239,7 @@ public:
         array->setComponent(i, 1, static_cast<T>(i));
       }
 
-      QVector<size_t> eraseElements;
+      std::vector<size_t> eraseElements;
       eraseElements.push_back(3);
       eraseElements.push_back(6);
       eraseElements.push_back(9);
@@ -255,7 +255,7 @@ public:
 
     // Test Dropping of internal continuous elements
     {
-      QVector<size_t> dims(1, NUM_COMPONENTS_2);
+      std::vector<size_t> dims(1, NUM_COMPONENTS_2);
       typename DataArray<T>::Pointer array = DataArray<T>::CreateArray(NUM_ELEMENTS_2, dims, "Test4");
       DREAM3D_REQUIRE_EQUAL(array->isAllocated(), true);
       for(size_t i = 0; i < NUM_TUPLES_2; ++i)
@@ -264,7 +264,7 @@ public:
         array->setComponent(i, 1, static_cast<T>(i));
       }
 
-      QVector<size_t> eraseElements;
+      std::vector<size_t> eraseElements;
       eraseElements.push_back(3);
       eraseElements.push_back(4);
       eraseElements.push_back(5);
@@ -280,7 +280,7 @@ public:
 
     // Test Dropping of Front and Back Elements
     {
-      QVector<size_t> dims(1, NUM_COMPONENTS_2);
+      std::vector<size_t> dims(1, NUM_COMPONENTS_2);
       typename DataArray<T>::Pointer array = DataArray<T>::CreateArray(NUM_ELEMENTS_2, dims, "Test5");
       DREAM3D_REQUIRE_EQUAL(array->isAllocated(), true);
       for(size_t i = 0; i < NUM_TUPLES_2; ++i)
@@ -289,7 +289,7 @@ public:
         array->setComponent(i, 1, static_cast<T>(i));
       }
 
-      QVector<size_t> eraseElements;
+      std::vector<size_t> eraseElements;
       eraseElements.push_back(0);
       eraseElements.push_back(9);
 
@@ -303,7 +303,7 @@ public:
 
     // Test Dropping of Back Elements
     {
-      QVector<size_t> dims(1, NUM_COMPONENTS_2);
+      std::vector<size_t> dims(1, NUM_COMPONENTS_2);
       typename DataArray<T>::Pointer array = DataArray<T>::CreateArray(NUM_ELEMENTS_2, dims, "Test6");
       DREAM3D_REQUIRE_EQUAL(array->isAllocated(), true);
       for(size_t i = 0; i < NUM_TUPLES_2; ++i)
@@ -312,7 +312,7 @@ public:
         array->setComponent(i, 1, static_cast<T>(i));
       }
 
-      QVector<size_t> eraseElements;
+      std::vector<size_t> eraseElements;
       eraseElements.push_back(7);
       eraseElements.push_back(8);
       eraseElements.push_back(9);
@@ -326,7 +326,7 @@ public:
 
     // Test Dropping of indices larger than the number of tuples
     {
-      QVector<size_t> dims(1, NUM_COMPONENTS_2);
+      std::vector<size_t> dims(1, NUM_COMPONENTS_2);
       typename DataArray<T>::Pointer array = DataArray<T>::CreateArray(NUM_TUPLES_2, dims, "Test6");
       DREAM3D_REQUIRE_EQUAL(array->isAllocated(), true);
       for(size_t i = 0; i < NUM_TUPLES_2; ++i)
@@ -335,7 +335,7 @@ public:
         array->setComponent(i, 1, static_cast<T>(i));
       }
 
-      QVector<size_t> eraseElements;
+      std::vector<size_t> eraseElements;
       eraseElements.push_back(10);
       int err = array->eraseTuples(eraseElements);
       DREAM3D_REQUIRE_EQUAL(err, -100)
@@ -465,7 +465,7 @@ public:
     }
 
     {
-      QVector<size_t> dims(1, NUM_COMPONENTS);
+      std::vector<size_t> dims(1, NUM_COMPONENTS);
       Int32ArrayType::Pointer int32Array = Int32ArrayType::CreateArray(NUM_ELEMENTS, dims, "Test8");
       ptr = int32Array->getPointer(0);
       DREAM3D_REQUIRE_EQUAL(int32Array->isAllocated(), true);
@@ -551,7 +551,7 @@ public:
     }
 
     // Remove the front 2 elements and test
-    QVector<size_t> eraseElements;
+    std::vector<size_t> eraseElements;
     eraseElements.push_back(0);
     eraseElements.push_back(1);
 
@@ -629,7 +629,7 @@ public:
   template <typename T> void TestNeighborListDeepCopyForType()
   {
 
-    QVector<size_t> tDims(10);
+    std::vector<size_t> tDims(10);
     AttributeMatrix::Pointer am = AttributeMatrix::New(tDims, "AttributeMatrix", AttributeMatrix::Type::Cell);
 
     typename NeighborList<T>::Pointer neiList = NeighborList<T>::CreateArray(10, "NeighborList");
@@ -754,7 +754,7 @@ public:
       }
     }
 
-    ///     virtual QVector<size_t> getComponentDimensions()
+    ///     virtual std::vector<size_t> getComponentDimensions()
     // Test resizing the array based on a give number of tuples. The number of Components will stay the same at each tuple
     array->resizeTuples(numTuples);
     array->initializeWithZeros(); // Init the grown array to all Zeros
@@ -834,7 +834,7 @@ public:
 
     {
       numComp = DIM0 * DIM1 * DIM2;
-      QVector<size_t> vDims(3, 0);
+      std::vector<size_t> vDims(3, 0);
       vDims[0] = DIM0;
       vDims[1] = DIM1;
       vDims[2] = DIM2;
@@ -844,8 +844,8 @@ public:
     }
 
     {
-      QVector<size_t> tDims(2, 4);
-      QVector<size_t> vDims(3, 0);
+      std::vector<size_t> tDims(2, 4);
+      std::vector<size_t> vDims(3, 0);
       vDims[0] = DIM0;
       vDims[1] = DIM1;
       vDims[2] = DIM2;
@@ -870,7 +870,7 @@ public:
         } mudflap;
         unsigned char* cptr = nullptr;
 
-        QVector<size_t> tDims(1, 10);
+        std::vector<size_t> tDims(1, 10);
         typename DataArray<T>::Pointer array = DataArray<T>::CreateArray(DIM0, "TEST");
         array->initializeWithZeros();
         cptr = reinterpret_cast<uint8_t*>(array->getPointer(0));
@@ -946,7 +946,7 @@ public:
   template <typename T> void TestDeepCopyDataArrayForType()
   {
     size_t numTuples = 10;
-    QVector<size_t> cDims(1, 5);
+    std::vector<size_t> cDims(1, 5);
     QString name("Source Array");
 
     // First lets try it without allocating any memory
@@ -1002,7 +1002,7 @@ public:
   template <typename T> void TestCopyDataForType()
   {
     size_t numTuples = 10;
-    QVector<size_t> cDims(1, 5);
+    std::vector<size_t> cDims(1, 5);
     QString name("Source Array");
 
     // First lets try it without allocating any memory
@@ -1123,7 +1123,7 @@ public:
   // -----------------------------------------------------------------------------
   template <typename T> void TestWrapPointerForType()
   {
-    QVector<size_t> cDims = {1};
+    std::vector<size_t> cDims = {1};
     T* ptr = new T[TEST_SIZE]; // Allocate on the heap
     {
       // Wrap the pointer, write some data to it, and then let the object go
@@ -1189,7 +1189,7 @@ public:
   template <typename T> void TestSetTupleForType()
   {
     size_t numTuples = 10;
-    QVector<size_t> cDims(1, 5);
+    std::vector<size_t> cDims(1, 5);
     QString name("Source Array");
 
     // Each index of the vector is a tuple with a vector containing the components for that tuple
@@ -1249,8 +1249,8 @@ public:
   {
     std::cout << "STLInterfaceTest Test Starting...." << std::endl;
 
-    DataArray<int32_t> i32Array(10, "Test Array");
-    DataArray<int32_t> i32Array1(10, "Other Array");
+    DataArray<int32_t> i32Array(10, "Test Array", 0);
+    DataArray<int32_t> i32Array1(10, "Other Array", 0);
 
     // Initialize with a value
     for(auto& value : i32Array)
@@ -1317,7 +1317,7 @@ public:
     std::cout << "" << std::endl;
 
     std::cout << "std::transform from int32_t to float using a back_inserter" << std::endl;
-    DataArray<float> f32Array(0, "Float Array");
+    DataArray<float> f32Array(0, "Float Array", 0.0f);
     std::transform(i32Array.begin(), i32Array.end(), std::back_inserter(f32Array), [](int32_t i) -> float { return i * 2.5; });
     std::for_each(f32Array.begin(), f32Array.end(), print<float>);
     std::cout << std::endl;
@@ -1363,7 +1363,7 @@ public:
     using RgbaIterator = RgbaType::tuple_iterator;
 
     CompDimsType cDims = {4};
-    RgbaType rgba(static_cast<size_t>(10), cDims, "RGBA Array");
+    RgbaType rgba(10, QString("RGBA Array"), cDims, 0);
 
     RgbaIterator begin = rgba.begin<RgbaIterator>();
     rgba.initializeWithValue(0xFF);

--- a/Source/SIMPLib/DataArrays/Testing/Cxx/StringDataArrayTest.cpp
+++ b/Source/SIMPLib/DataArrays/Testing/Cxx/StringDataArrayTest.cpp
@@ -297,7 +297,7 @@ public:
   {
     // Create an Array of 10 Structs
     StringDataArray::Pointer nodes = initializeStringDataArray();
-    QVector<size_t> idxs(k_ArraySize + 1, 0);
+    std::vector<size_t> idxs(k_ArraySize + 1, 0);
     // Try to erase more indices than there are in the struct array
     int err = nodes->eraseTuples(idxs);
     DREAM3D_REQUIRE_EQUAL(err, 0)

--- a/Source/SIMPLib/DataArrays/Testing/Cxx/StructArrayTest.cpp
+++ b/Source/SIMPLib/DataArrays/Testing/Cxx/StructArrayTest.cpp
@@ -388,7 +388,7 @@ public:
   {
     // Create an Array of 10 Structs
     Vec3IntListPointer_t nodes = initializeStructArray();
-    QVector<size_t> idxs(k_ArraySize + 1, 0);
+    std::vector<size_t> idxs(k_ArraySize + 1, 0);
     // Try to erase more indices than there are in the struct array
     int err = nodes->eraseTuples(idxs);
     DREAM3D_REQUIRE_EQUAL(err, 0)
@@ -461,7 +461,7 @@ public:
   template <typename T> void _TestDeepCopyStructArray()
   {
     size_t numTuples = 10;
-    QVector<size_t> cDims(1, 1);
+    std::vector<size_t> cDims(1, 1);
     QString name("Source Array");
     typename StructArray<T>::Pointer src = StructArray<T>::CreateArray(numTuples, name, false);
     typename StructArray<T>::Pointer copy = std::dynamic_pointer_cast<StructArray<T>>(src->deepCopy());

--- a/Source/SIMPLib/DataContainers/AttributeMatrix.cpp
+++ b/Source/SIMPLib/DataContainers/AttributeMatrix.cpp
@@ -59,7 +59,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AttributeMatrix::AttributeMatrix(const QVector<size_t>& tDims, const QString& name, AttributeMatrix::Type attrType)
+AttributeMatrix::AttributeMatrix(const std::vector<size_t>& tDims, const QString& name, AttributeMatrix::Type attrType)
 : IDataStructureContainerNode(name)
 , m_Type(attrType)
 , m_TupleDims(tDims)
@@ -368,7 +368,7 @@ RenameErrorCodes AttributeMatrix::renameAttributeArray(const QString& oldname, c
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<size_t> AttributeMatrix::getTupleDimensions()
+std::vector<size_t> AttributeMatrix::getTupleDimensions()
 {
   return m_TupleDims;
 }
@@ -376,7 +376,7 @@ QVector<size_t> AttributeMatrix::getTupleDimensions()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void AttributeMatrix::setTupleDimensions(const QVector<size_t>& tupleDims)
+void AttributeMatrix::setTupleDimensions(const std::vector<size_t>& tupleDims)
 {
   resizeAttributeArrays(tupleDims);
 }
@@ -416,8 +416,8 @@ bool AttributeMatrix::removeInactiveObjects(const QVector<bool> &activeObjects, 
   if(static_cast<size_t>(activeObjects.size()) == totalTuples && acceptableMatrix)
   {
     size_t goodcount = 1;
-    QVector<size_t> newNames(totalTuples, 0);
-    QVector<size_t> removeList;
+    std::vector<size_t> newNames(totalTuples, 0);
+    std::vector<size_t> removeList;
 
     for(qint32 i = 1; i < activeObjects.size(); i++)
     {
@@ -449,7 +449,7 @@ bool AttributeMatrix::removeInactiveObjects(const QVector<bool> &activeObjects, 
           p->eraseTuples(removeList);
         }
       }
-      QVector<size_t> tDims(1, (totalTuples - removeList.size()));
+      std::vector<size_t> tDims(1, (totalTuples - removeList.size()));
       setTupleDimensions(tDims);
 
       // Loop over all the points and correct all the feature names
@@ -474,7 +474,7 @@ bool AttributeMatrix::removeInactiveObjects(const QVector<bool> &activeObjects, 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void AttributeMatrix::resizeAttributeArrays(const QVector<size_t>& tDims)
+void AttributeMatrix::resizeAttributeArrays(const std::vector<size_t>& tDims)
 {
   m_TupleDims = tDims;
   size_t numTuples = m_TupleDims[0];

--- a/Source/SIMPLib/DataContainers/AttributeMatrix.h
+++ b/Source/SIMPLib/DataContainers/AttributeMatrix.h
@@ -92,7 +92,7 @@ class SIMPLib_EXPORT AttributeMatrix : public Observable, public IDataStructureC
   PYB11_ENUMERATION(Category)
  
   PYB11_PROPERTY(QString Name READ getName WRITE setName)
-  PYB11_PROPERTY(QVector<size_t> TupleDimensions READ getTupleDimensions WRITE setTupleDimensions)
+  PYB11_PROPERTY(std::vector<size_t> TupleDimensions READ getTupleDimensions WRITE setTupleDimensions)
 
   PYB11_METHOD(bool doesAttributeArrayExist ARGS Name)
   PYB11_METHOD(bool addOrReplaceAttributeArray OVERLOAD const.IDataArray::Pointer.&,Data)
@@ -171,7 +171,7 @@ public:
     Unknown = 999, //!<
   };
 
-  using Categories = QVector<Category>;
+  using Categories = std::vector<Category>;
 
   /**
    * @brief New Creates an AttributeMatrix with the give name
@@ -180,74 +180,61 @@ public:
    * @param attrType The type of AttributeMatrix, one of
    * @return
    */
-  static Pointer New(const QVector<size_t> &tupleDims, const QString& name, AttributeMatrix::Type attrType)
+  static Pointer New(const std::vector<size_t>& tupleDims, const QString& name, AttributeMatrix::Type attrType)
   {
     Pointer sharedPtr(new AttributeMatrix(tupleDims, name, attrType));
     return sharedPtr;
   }
 
   /**
-   * @brief New Creates an AttributeMatrix with the give name
-   * @param tupleDims The dimensions of the Attribute matrix given in the order fastest moving to slowest moving (XYZ)
-   * @param name The name of the AttributeMatrix. Each AttributeMatrix should have a unique name.
-   * @param attrType The type of AttributeMatrix, one of
+   * @brief ReadAttributeMatrixStructure
+   * @param containerId
+   * @param dataContainer
+   * @param h5InternalPath
+   */
+  static void ReadAttributeMatrixStructure(hid_t containerId, DataContainerProxy* dcProxy, SIMPLH5DataReaderRequirements* req, const QString& h5InternalPath);
+
+  /**
+   * @brief Creates and returns a DataArrayPath for the AttributeMatrix
    * @return
    */
-  static Pointer Create(const std::vector<size_t> &tupleDims, const QString& name, AttributeMatrix::Type attrType)
+  DataArrayPath getDataArrayPath() const override;
+
+  /**
+   * @brief Type
+   */
+  SIMPL_INSTANCE_PROPERTY(AttributeMatrix::Type, Type)
+
+  /**
+   * @brief Adds the IDataArray to the AttributeMatrix.
+   * @param data The IDataArray::Pointer that will hold the data
+   * @return Bool: True if the addition happened, FALSE if an IDataArray with the same name already exists.
+   */
+  bool addOrReplaceAttributeArray(const IDataArray::Pointer& data)
   {
-    Pointer sharedPtr(new AttributeMatrix(QVector<size_t>::fromStdVector(tupleDims), name, static_cast<AttributeMatrix::Type>(attrType)));
-    return sharedPtr;
+    // Can not insert a null IDataArray object
+    if(data.get() == nullptr)
+    {
+      return false;
+    }
+    if(getNumberOfTuples() != data->getNumberOfTuples())
+    {
+      qDebug() << "AttributeMatrix::Name: " << getName() << "  dataArray::name:  " << data->getName() << " Type: " << data->getTypeAsString();
+      qDebug() << "getNumberOfTuples(): " << getNumberOfTuples() << "  data->getNumberOfTuples(): " << data->getNumberOfTuples();
+    }
+    Q_ASSERT(getNumberOfTuples() == data->getNumberOfTuples());
+    return insertOrAssign(data);
   }
 
-    /**
-     * @brief ReadAttributeMatrixStructure
-     * @param containerId
-     * @param dataContainer
-     * @param h5InternalPath
-     */
-    static void ReadAttributeMatrixStructure(hid_t containerId, DataContainerProxy* dcProxy, SIMPLH5DataReaderRequirements* req, const QString& h5InternalPath);
-
-    /**
-     * @brief Creates and returns a DataArrayPath for the AttributeMatrix
-     * @return
-     */
-    DataArrayPath getDataArrayPath() const override;
-
-    /**
-    * @brief Type
-    */
-    SIMPL_INSTANCE_PROPERTY(AttributeMatrix::Type, Type)
-
-    /**
-     * @brief Adds the IDataArray to the AttributeMatrix.
-     * @param data The IDataArray::Pointer that will hold the data
-     * @return Bool: True if the addition happened, FALSE if an IDataArray with the same name already exists.
-     */
-    bool addOrReplaceAttributeArray(const IDataArray::Pointer& data)
-    {
-      // Can not insert a null IDataArray object
-      if(data.get() == nullptr)
-      {
-        return false;
-      }
-      if(getNumberOfTuples() != data->getNumberOfTuples())
-      {
-        qDebug() << "AttributeMatrix::Name: " << getName() << "  dataArray::name:  " << data->getName() << " Type: " << data->getTypeAsString();
-        qDebug() << "getNumberOfTuples(): " << getNumberOfTuples() << "  data->getNumberOfTuples(): " << data->getNumberOfTuples();
-      }
-      Q_ASSERT(getNumberOfTuples() == data->getNumberOfTuples());
-      return insertOrAssign(data);
-    }
-    
-    /**
-     * @brief Returns the array for a given named array or the equivelant to a
-     * null pointer if the name does not exist.
-     * @param name The name of the data array
-     */
-    IDataArray::Pointer getAttributeArray(const QString& name)
-    {
-      return getChildByName(name);
-    }
+  /**
+   * @brief Returns the array for a given named array or the equivelant to a
+   * null pointer if the name does not exist.
+   * @param name The name of the data array
+   */
+  IDataArray::Pointer getAttributeArray(const QString& name)
+  {
+    return getChildByName(name);
+  }
 
     /**
      * @brief getAttributeArray
@@ -332,7 +319,7 @@ public:
     * @brief Resizes an array from the Attribute Matrix
     * @param size The new size of the array
     */
-    void resizeAttributeArrays(const QVector<size_t>& tDims);
+    void resizeAttributeArrays(const std::vector<size_t>& tDims);
 
     /**
      * @brief Returns bool of whether a named array exists
@@ -349,11 +336,8 @@ public:
      * @param cDims The component Dimensions of the Data Array
      * @return A valid IDataArray Subclass if the array exists otherwise a null shared pointer.
      */
-    template<class ArrayType, class Filter>
-    typename ArrayType::Pointer getPrereqArray(Filter* filter,
-                                               QString attributeArrayName,
-                                               int err,
-                                               QVector<size_t> cDims)
+    template <class ArrayType, class Filter>
+    typename ArrayType::Pointer getPrereqArray(Filter* filter, QString attributeArrayName, int err, std::vector<size_t> cDims)
     {
       QString ss;
       typename ArrayType::Pointer attributeArray = ArrayType::NullPointer();
@@ -453,11 +437,8 @@ public:
      * @param dims The dimensions of the components of the AttributeArray
      * @return A Shared Pointer to the newly created array
      */
-    template<class ArrayType, class Filter, typename T>
-    typename ArrayType::Pointer createNonPrereqArray(Filter* filter,
-                                                     const QString& attributeArrayName,
-                                                     T initValue,
-                                                     QVector<size_t> compDims,
+    template <class ArrayType, class Filter, typename T>
+    typename ArrayType::Pointer createNonPrereqArray(Filter* filter, const QString& attributeArrayName, T initValue, const std::vector<size_t>& compDims,
                                                      RenameDataPath::DataID_t id = RenameDataPath::k_Invalid_ID)
     {
       typename ArrayType::Pointer attributeArray = ArrayType::NullPointer();
@@ -510,8 +491,8 @@ public:
     * @param name The name that the array will be known by
     * @param dims The size the data on each tuple
     */
-    template<class ArrayType, class Filter, typename T>
-    void createAndAddAttributeArray(Filter* filter, const QString& name, T initValue, QVector<size_t> compDims, RenameDataPath::DataID_t id = RenameDataPath::k_Invalid_ID)
+    template <class ArrayType, class Filter, typename T>
+    void createAndAddAttributeArray(Filter* filter, const QString& name, T initValue, std::vector<size_t> compDims, RenameDataPath::DataID_t id = RenameDataPath::k_Invalid_ID)
     {
       bool allocateData = false;
       if(nullptr == filter) { allocateData = true; }
@@ -608,14 +589,13 @@ public:
      * @brief Sets the Tuple Dimensions for the Attribute Matrix
      * @param tupleDims
      */
-    void setTupleDimensions(const QVector<size_t>& tupleDims);
+    void setTupleDimensions(const std::vector<size_t>& tupleDims);
 
     /**
      * @brief Returns the Tuple Dimensions of the AttributeMatrix
      * @return
      */
-    QVector<size_t> getTupleDimensions();
-
+    std::vector<size_t> getTupleDimensions();
 
     /**
     * @brief Returns the number of Tuples that the feature data has. For example if there are 32 features
@@ -674,7 +654,7 @@ public:
     virtual QString getInfoString(SIMPL::InfoStringFormat format);
 
   protected:
-    AttributeMatrix(const QVector<size_t>& tDims, const QString& name, AttributeMatrix::Type attrType);
+    AttributeMatrix(const std::vector<size_t>& tDims, const QString& name, AttributeMatrix::Type attrType);
 
     /**
      * @brief writeXdmfAttributeData
@@ -704,7 +684,7 @@ public:
                                                  const QString& xdmfTypeName, const QString& hdfFileName, uint8_t gridType = 0);
 
   private:
-    QVector<size_t> m_TupleDims;
+    std::vector<size_t> m_TupleDims;
 
     AttributeMatrix(const AttributeMatrix&);
     void operator =(const AttributeMatrix&);

--- a/Source/SIMPLib/DataContainers/AttributeMatrix.h
+++ b/Source/SIMPLib/DataContainers/AttributeMatrix.h
@@ -86,7 +86,7 @@ class SIMPLib_EXPORT AttributeMatrix : public Observable, public IDataStructureC
 {
   // clang-format off
   PYB11_CREATE_BINDINGS(AttributeMatrix)
-  PYB11_STATIC_CREATION(Create ARGS std::vector<size_t> QString AttributeMatrix::Type)
+  PYB11_STATIC_CREATION(New ARGS std::vector<size_t> QString AttributeMatrix::Type)
   
   PYB11_ENUMERATION(Type)
   PYB11_ENUMERATION(Category)

--- a/Source/SIMPLib/DataContainers/DataArrayProxy.cpp
+++ b/Source/SIMPLib/DataContainers/DataArrayProxy.cpp
@@ -119,7 +119,7 @@ void DataArrayProxy::ReadDataArrayStructure(hid_t attrMatGid, QMap<QString, Data
 
   QList<QString> dataArrayNames;
   QH5Utilities::getGroupObjects(attrMatGid, H5Utilities::H5Support_DATASET | H5Utilities::H5Support_GROUP, dataArrayNames);
-  foreach(QString dataArrayName, dataArrayNames)
+  for(const auto& dataArrayName : dataArrayNames)
   {
     DataArrayProxy proxy(h5InternalPath, dataArrayName, SIMPL::Unchecked);
 
@@ -138,10 +138,20 @@ void DataArrayProxy::ReadDataArrayStructure(hid_t attrMatGid, QMap<QString, Data
     bool cDimsResult = false;
     if(req != nullptr)
     {
-      QVector<QVector<size_t>> cDims = req->getComponentDimensions();
-      if(cDims.empty() || cDims.contains(proxy.m_CompDims))
+      std::vector<std::vector<size_t>> cDims = req->getComponentDimensions();
+      if(cDims.empty())
       {
         cDimsResult = true;
+      }
+      if(!cDimsResult)
+      {
+        for(const auto& cDim : cDims)
+        {
+          if(cDim == proxy.m_CompDims)
+          {
+            cDimsResult = true;
+          }
+        }
       }
     }
 
@@ -187,7 +197,7 @@ bool DataArrayProxy::operator==(const DataArrayProxy& rhs) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QJsonArray DataArrayProxy::writeVector(QVector<size_t> vector) const
+QJsonArray DataArrayProxy::writeVector(const std::vector<size_t>& vector) const
 {
   QJsonArray jsonArray;
   for(const auto& num : vector)
@@ -200,9 +210,9 @@ QJsonArray DataArrayProxy::writeVector(QVector<size_t> vector) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<size_t> DataArrayProxy::readVector(QJsonArray jsonArray)
+std::vector<size_t> DataArrayProxy::readVector(QJsonArray jsonArray)
 {
-  QVector<size_t> vector;
+  std::vector<size_t> vector;
   for(const auto& val : jsonArray)
   {
     if(val.isDouble())
@@ -377,7 +387,7 @@ QString DataArrayProxy::getObjectType() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataArrayProxy::setTupleDims(const QVector<size_t>& tDims)
+void DataArrayProxy::setTupleDims(const std::vector<size_t>& tDims)
 {
   m_TupleDims = tDims;
 }
@@ -385,7 +395,7 @@ void DataArrayProxy::setTupleDims(const QVector<size_t>& tDims)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<size_t> DataArrayProxy::getTupleDims() const
+std::vector<size_t> DataArrayProxy::getTupleDims() const
 {
   return m_TupleDims;
 }
@@ -393,7 +403,7 @@ QVector<size_t> DataArrayProxy::getTupleDims() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void DataArrayProxy::setCompDims(const QVector<size_t>& cDims)
+void DataArrayProxy::setCompDims(const std::vector<size_t>& cDims)
 {
   m_CompDims = cDims;
 }
@@ -401,7 +411,7 @@ void DataArrayProxy::setCompDims(const QVector<size_t>& cDims)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<size_t> DataArrayProxy::getCompDims() const
+std::vector<size_t> DataArrayProxy::getCompDims() const
 {
   return m_CompDims;
 }

--- a/Source/SIMPLib/DataContainers/DataArrayProxy.h
+++ b/Source/SIMPLib/DataContainers/DataArrayProxy.h
@@ -35,12 +35,13 @@
 
 #pragma once
 
+#include <vector>
+
+#include <hdf5.h>
+
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonObject>
 #include <QtCore/QString>
-#include <QtCore/QVector>
-
-#include <hdf5.h>
 
 #include "SIMPLib/Common/Constants.h"
 #include "SIMPLib/DataContainers/DataArrayPath.h"
@@ -54,13 +55,13 @@ class SIMPLib_EXPORT DataArrayProxy
 {
   PYB11_CREATE_BINDINGS(DataArrayProxy)
   PYB11_CREATION()
-  PYB11_PROPERTY(QVector<size_t> TupleDims READ getTupleDims WRITE setTupleDims)
-  PYB11_PROPERTY(QVector<size_t> CompDims READ getCompDims WRITE setCompDims)
+  PYB11_PROPERTY(std::vector<size_t> TupleDims READ getTupleDims WRITE setTupleDims)
+  PYB11_PROPERTY(std::vector<size_t> CompDims READ getCompDims WRITE setCompDims)
   PYB11_PROPERTY(QString Path READ getPath WRITE setPath)
   PYB11_PROPERTY(QString Name READ getName WRITE setName)
   PYB11_PROPERTY(uint8_t Flag READ getFlag WRITE setFlag)
 public:
-  using CompDimsVector = QVector<QVector<size_t>>;
+  using CompDimsVector = std::vector<std::vector<size_t>>;
 
   // This enumeration is not a class enumeration because it is not possible to
   // do a bit-wise NOT operation on a class enumeration value.  We need to be
@@ -215,25 +216,25 @@ public:
    * @brief setTupleDims
    * @param tDims
    */
-  void setTupleDims(const QVector<size_t>& tDims);
+  void setTupleDims(const std::vector<size_t>& tDims);
 
   /**
    * @brief getTupleDims
    * @return
    */
-  QVector<size_t> getTupleDims() const;
+  std::vector<size_t> getTupleDims() const;
 
   /**
    * @brief setCompDims
    * @param cDims
    */
-  void setCompDims(const QVector<size_t>& cDims);
+  void setCompDims(const std::vector<size_t>& cDims);
 
   /**
    * @brief getCompDims
    * @return
    */
-  QVector<size_t> getCompDims() const;
+  std::vector<size_t> getCompDims() const;
 
 private:
   uint8_t m_Flag = SIMPL::Unchecked;
@@ -241,22 +242,22 @@ private:
   QString m_Path;
   QString m_Name;
   QString m_ObjectType;
-  QVector<size_t> m_TupleDims;
-  QVector<size_t> m_CompDims;
+  std::vector<size_t> m_TupleDims;
+  std::vector<size_t> m_CompDims;
 
   /**
    * @brief writeVector
    * @param vector
    * @return
    */
-  QJsonArray writeVector(QVector<size_t> vector) const;
+  QJsonArray writeVector(const std::vector<size_t>& vector) const;
 
   /**
    * @brief readVector
    * @param jsonArray
    * @return
    */
-  QVector<size_t> readVector(QJsonArray jsonArray);
+  std::vector<size_t> readVector(QJsonArray jsonArray);
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(DataArrayProxy::PrimitiveTypeFlags)

--- a/Source/SIMPLib/DataContainers/DataContainer.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainer.cpp
@@ -181,7 +181,7 @@ IGeometry::Pointer DataContainer::getGeometry()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AttributeMatrix::Pointer DataContainer::createAndAddAttributeMatrix(const QVector<size_t>& tDims, const QString& attrMatName, AttributeMatrix::Type attrType)
+AttributeMatrix::Pointer DataContainer::createAndAddAttributeMatrix(const std::vector<size_t>& tDims, const QString& attrMatName, AttributeMatrix::Type attrType)
 {
   AttributeMatrix::Pointer attrMat = AttributeMatrix::New(tDims, attrMatName, attrType);
   addOrReplaceAttributeMatrix(attrMat);
@@ -276,7 +276,7 @@ int DataContainer::writeAttributeMatricesToHDF5(hid_t parentId)
 int DataContainer::readAttributeMatricesFromHDF5(bool preflight, hid_t dcGid, DataContainerProxy& dcProxy)
 {
   int err = 0;
-  QVector<size_t> tDims;
+  std::vector<size_t> tDims;
 
   DataContainerProxy::StorageType& attrMatsToRead = dcProxy.getAttributeMatricies();
   AttributeMatrix::Type amType = AttributeMatrix::Type::Unknown;
@@ -822,7 +822,8 @@ AttributeMatrixShPtr DataContainer::getPrereqAttributeMatrix(AbstractFilter* fil
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AttributeMatrixShPtr DataContainer::createNonPrereqAttributeMatrix(AbstractFilter* filter, const DataArrayPath& path, const QVector<size_t>& tDims, AttributeMatrix::Type amType, RenameDataPath::DataID_t id)
+AttributeMatrixShPtr DataContainer::createNonPrereqAttributeMatrix(AbstractFilter* filter, const DataArrayPath& path, const std::vector<size_t>& tDims, AttributeMatrix::Type amType,
+                                                                   RenameDataPath::DataID_t id)
 {
   return createNonPrereqAttributeMatrix(filter, path.getAttributeMatrixName(), tDims, amType, id);
 }
@@ -833,7 +834,7 @@ AttributeMatrixShPtr DataContainer::createNonPrereqAttributeMatrix(AbstractFilte
 AttributeMatrixShPtr DataContainer::createNonPrereqAttributeMatrix(AbstractFilter* filter, const DataArrayPath& path, const SizeVec3Type& tDims, AttributeMatrix::Type amType,
                                                                    RenameDataPath::DataID_t id)
 {
-  QVector<size_t> tupleDims;
+  std::vector<size_t> tupleDims;
   for(const auto& value : tDims)
   {
     tupleDims.push_back(value);
@@ -844,7 +845,8 @@ AttributeMatrixShPtr DataContainer::createNonPrereqAttributeMatrix(AbstractFilte
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AttributeMatrixShPtr DataContainer::createNonPrereqAttributeMatrix(AbstractFilter* filter, const QString& attributeMatrixName, const QVector<size_t> &tDims, AttributeMatrix::Type amType, RenameDataPath::DataID_t id)
+AttributeMatrixShPtr DataContainer::createNonPrereqAttributeMatrix(AbstractFilter* filter, const QString& attributeMatrixName, const std::vector<size_t>& tDims, AttributeMatrix::Type amType,
+                                                                   RenameDataPath::DataID_t id)
 {
   QString ss;
   if(attributeMatrixName.isEmpty())

--- a/Source/SIMPLib/DataContainers/DataContainer.h
+++ b/Source/SIMPLib/DataContainers/DataContainer.h
@@ -283,7 +283,8 @@ public:
    * @param amType The Type of AttributeMatrix
    * @return A Shared Pointer to the AttributeMatrix
    */
-  AttributeMatrixShPtr createNonPrereqAttributeMatrix(AbstractFilter* filter, const DataArrayPath& path, const QVector<size_t>& tDims, AttributeMatrix::Type amType, RenameDataPath::DataID_t id = RenameDataPath::k_Invalid_ID);
+  AttributeMatrixShPtr createNonPrereqAttributeMatrix(AbstractFilter* filter, const DataArrayPath& path, const std::vector<size_t>& tDims, AttributeMatrix::Type amType,
+                                                      RenameDataPath::DataID_t id = RenameDataPath::k_Invalid_ID);
 
   /**
    * @brief createNonPrereqAttributeMatrix
@@ -306,7 +307,8 @@ public:
    * @param amType The Type of AttributeMatrix
    * @return A Shared Pointer to the AttributeMatrix
    */
-  AttributeMatrixShPtr createNonPrereqAttributeMatrix(AbstractFilter* filter, const QString& attributeMatrixName, const QVector<size_t>& tDims, AttributeMatrix::Type amType, RenameDataPath::DataID_t id = RenameDataPath::k_Invalid_ID);
+  AttributeMatrixShPtr createNonPrereqAttributeMatrix(AbstractFilter* filter, const QString& attributeMatrixName, const std::vector<size_t>& tDims, AttributeMatrix::Type amType,
+                                                      RenameDataPath::DataID_t id = RenameDataPath::k_Invalid_ID);
 
   /**
    * @brief Returns the geometry as the templated type
@@ -358,7 +360,7 @@ public:
    * @param attrType The Type of AttributeMatrix to create
    * @return
    */
-  virtual AttributeMatrixShPtr createAndAddAttributeMatrix(const QVector<size_t>& tDims, const QString& attrMatName, AttributeMatrix::Type attrType);
+  virtual AttributeMatrixShPtr createAndAddAttributeMatrix(const std::vector<size_t>& tDims, const QString& attrMatName, AttributeMatrix::Type attrType);
 
   /**
    * @brief Writes all the Attribute Matrices to HDF5 file

--- a/Source/SIMPLib/DataContainers/DataContainerArray.h
+++ b/Source/SIMPLib/DataContainers/DataContainerArray.h
@@ -442,8 +442,8 @@ public:
      * @param cDims The component dimensions of the IDataArray subclass
      * @return Valid or nullptr shared pointer based on availability of the array
      */
-    template<class ArrayType, class Filter>
-    typename ArrayType::Pointer getPrereqArrayFromPath(Filter* filter, const DataArrayPath& path, QVector<size_t> cDims)
+    template <class ArrayType, class Filter>
+    typename ArrayType::Pointer getPrereqArrayFromPath(Filter* filter, const DataArrayPath& path, std::vector<size_t> cDims)
     {
 
       QString ss;
@@ -575,12 +575,8 @@ public:
      * @param dims The dimensions of the components of the AttributeArray
      * @return A Shared Pointer to the newly created array
      */
-    template<class ArrayType, class Filter, typename T>
-    typename ArrayType::Pointer createNonPrereqArrayFromPath(Filter* filter,
-                                                             const DataArrayPath& path,
-                                                             T initValue,
-                                                             QVector<size_t> compDims,
-                                                             const QString& property = "",
+    template <class ArrayType, class Filter, typename T>
+    typename ArrayType::Pointer createNonPrereqArrayFromPath(Filter* filter, const DataArrayPath& path, T initValue, const std::vector<size_t>& compDims, const QString& property = "",
                                                              RenameDataPath::DataID_t id = RenameDataPath::k_Invalid_ID)
     {
       typename ArrayType::Pointer dataArray = ArrayType::NullPointer();

--- a/Source/SIMPLib/DataContainers/DataStructureUtilities.h
+++ b/Source/SIMPLib/DataContainers/DataStructureUtilities.h
@@ -149,7 +149,7 @@ public:
    * @return Valid or nullptr shared pointer based on availability of the array
    */
   template <class ArrayType, class Filter>
-  typename ArrayType::Pointer getPrereqArrayFromPath(const DataContainerArrayShPtrType& dca, Filter* filter, const DataArrayPath& path, QVector<size_t> cDims)
+  typename ArrayType::Pointer getPrereqArrayFromPath(const DataContainerArrayShPtrType& dca, Filter* filter, const DataArrayPath& path, std::vector<size_t> cDims)
   {
 
     QString ss;
@@ -284,7 +284,7 @@ public:
    * @return A Shared Pointer to the newly created array
    */
   template <class ArrayType, class Filter, typename T>
-  typename ArrayType::Pointer createNonPrereqArrayFromPath(const DataContainerArrayShPtrType& dca, Filter* filter, const DataArrayPath& path, T initValue, QVector<size_t> compDims,
+  typename ArrayType::Pointer createNonPrereqArrayFromPath(const DataContainerArrayShPtrType& dca, Filter* filter, const DataArrayPath& path, T initValue, std::vector<size_t> compDims,
                                                            const QString& property = "", RenameDataPath::DataID_t id = RenameDataPath::k_Invalid_ID)
   {
     typename ArrayType::Pointer dataArray = ArrayType::NullPointer();

--- a/Source/SIMPLib/DataContainers/Testing/Cxx/DataContainerBundleTest.cpp
+++ b/Source/SIMPLib/DataContainers/Testing/Cxx/DataContainerBundleTest.cpp
@@ -67,7 +67,8 @@ public:
   // -----------------------------------------------------------------------------
   //
   // -----------------------------------------------------------------------------
-  template <typename T> void AddDataArray(AttributeMatrix::Pointer am, const QString name, QVector<size_t>& tDims, QVector<size_t>& cDims)
+  template <typename T>
+  void AddDataArray(AttributeMatrix::Pointer am, const QString name, std::vector<size_t>& tDims, std::vector<size_t>& cDims)
   {
 
     typename DataArray<T>::Pointer data = DataArray<T>::CreateArray(tDims, cDims, name);
@@ -81,11 +82,11 @@ public:
   void TestDataBundleCommonPaths()
   {
 
-    QVector<size_t> tDims(3, 0);
+    std::vector<size_t> tDims(3, 0);
     tDims[0] = 10;
     tDims[1] = 20;
     tDims[2] = 30;
-    QVector<size_t> cDims(2);
+    std::vector<size_t> cDims(2);
     cDims[0] = 3;
     cDims[1] = 3;
 
@@ -96,7 +97,7 @@ public:
     AddDataArray<int32_t>(am, "int32 Array", tDims, cDims);
     dc0->addOrReplaceAttributeMatrix(am);
 
-    QVector<size_t> tupleDims(1, 1);
+    std::vector<size_t> tupleDims(1, 1);
     AttributeMatrix::Pointer metaAm = AttributeMatrix::New(tupleDims, DataContainerBundle::GetMetaDataName(), AttributeMatrix::Type::MetaData);
     dc0->addOrReplaceAttributeMatrix(metaAm);
 

--- a/Source/SIMPLib/FilterParameters/AxisAngleFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/AxisAngleFilterParameter.cpp
@@ -49,7 +49,7 @@ AxisAngleFilterParameter::~AxisAngleFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 AxisAngleFilterParameter::Pointer AxisAngleFilterParameter::New(const QString& humanLabel, const QString& propertyName, const AxisAngleInput_t& defaultValue, Category category,
-                                                                SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+                                                                const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
   AxisAngleFilterParameter::Pointer ptr = AxisAngleFilterParameter::New();
   ptr->setHumanLabel(humanLabel);

--- a/Source/SIMPLib/FilterParameters/AxisAngleFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/AxisAngleFilterParameter.h
@@ -90,7 +90,7 @@ class SIMPLib_EXPORT AxisAngleFilterParameter : public FilterParameter
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                        const AxisAngleInput_t& defaultValue, Category category,
-                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                        int groupIndex = -1);
 
     ~AxisAngleFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/BooleanFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/BooleanFilterParameter.cpp
@@ -48,8 +48,8 @@ BooleanFilterParameter::~BooleanFilterParameter() = default;
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-BooleanFilterParameter::Pointer BooleanFilterParameter::New(const QString& humanLabel, const QString& propertyName, const bool& defaultValue, Category category, SetterCallbackType setterCallback,
-                                                            GetterCallbackType getterCallback, int groupIndex)
+BooleanFilterParameter::Pointer BooleanFilterParameter::New(const QString& humanLabel, const QString& propertyName, const bool& defaultValue, Category category,
+                                                            const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   BooleanFilterParameter::Pointer ptr = BooleanFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/BooleanFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/BooleanFilterParameter.h
@@ -87,8 +87,7 @@ public:
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-    const bool& defaultValue, Category category, SetterCallbackType setterCallback,
-    GetterCallbackType getterCallback, int groupIndex = -1);
+    const bool& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     ~BooleanFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/CalculatorFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/CalculatorFilterParameter.cpp
@@ -52,7 +52,7 @@ CalculatorFilterParameter::~CalculatorFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 CalculatorFilterParameter::Pointer CalculatorFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category,
-                                                                  SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+                                                                  const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   CalculatorFilterParameter::Pointer ptr = CalculatorFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/CalculatorFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/CalculatorFilterParameter.h
@@ -88,7 +88,7 @@ public:
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
     const QString& defaultValue, Category category,
-    SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex = -1);
+    const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     ~CalculatorFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/ChoiceFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ChoiceFilterParameter.cpp
@@ -51,8 +51,7 @@ ChoiceFilterParameter::~ChoiceFilterParameter() = default;
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ChoiceFilterParameter::Pointer ChoiceFilterParameter::New(const QString& humanLabel, const QString& propertyName, const int& defaultValue, Category category, SetterCallbackType setterCallback,
-                                                          GetterCallbackType getterCallback, QVector<QString> choices, bool editable, int groupIndex)
+ChoiceFilterParameter::Pointer ChoiceFilterParameter::New(const QString& humanLabel, const QString& propertyName, const int& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, QVector<QString> choices, bool editable, int groupIndex)
 
 {
   ChoiceFilterParameter::Pointer ptr = ChoiceFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/ChoiceFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ChoiceFilterParameter.h
@@ -90,7 +90,7 @@ class SIMPLib_EXPORT ChoiceFilterParameter : public FilterParameter
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                        const int& defaultValue, Category category,
-                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                        QVector<QString> choices, bool editable,
                        int groupIndex = -1);
 

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionAdvancedFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionAdvancedFilterParameter.cpp
@@ -56,7 +56,7 @@ ComparisonSelectionAdvancedFilterParameter::~ComparisonSelectionAdvancedFilterPa
 //
 // -----------------------------------------------------------------------------
 ComparisonSelectionAdvancedFilterParameter::Pointer ComparisonSelectionAdvancedFilterParameter::New(const QString& humanLabel, const QString& propertyName, ComparisonInputsAdvanced defaultValue, Category category,
-                                                                                    SetterCallbackType setterCallback, GetterCallbackType getterCallback, QVector<QString> choices, bool showOperators,
+                                                                                    const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, QVector<QString> choices, bool showOperators,
                                                                                     int groupIndex)
 {
   ComparisonSelectionAdvancedFilterParameter::Pointer ptr = ComparisonSelectionAdvancedFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionAdvancedFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionAdvancedFilterParameter.h
@@ -93,8 +93,7 @@ class SIMPLib_EXPORT ComparisonSelectionAdvancedFilterParameter : public FilterP
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-                       ComparisonInputsAdvanced defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, QVector<QString> choices,
+                       ComparisonInputsAdvanced defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, QVector<QString> choices,
                        bool showOperators, int groupIndex = -1);
 
     ~ComparisonSelectionAdvancedFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.cpp
@@ -56,7 +56,7 @@ ComparisonSelectionFilterParameter::~ComparisonSelectionFilterParameter() = defa
 //
 // -----------------------------------------------------------------------------
 ComparisonSelectionFilterParameter::Pointer ComparisonSelectionFilterParameter::New(const QString& humanLabel, const QString& propertyName, ComparisonInputs defaultValue, Category category,
-                                                                                    SetterCallbackType setterCallback, GetterCallbackType getterCallback, QVector<QString> choices, bool showOperators,
+                                                                                    const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, QVector<QString> choices, bool showOperators,
                                                                                     int groupIndex)
 {
   ComparisonSelectionFilterParameter::Pointer ptr = ComparisonSelectionFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ComparisonSelectionFilterParameter.h
@@ -92,8 +92,7 @@ class SIMPLib_EXPORT ComparisonSelectionFilterParameter : public FilterParameter
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-                       ComparisonInputs defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, QVector<QString> choices,
+                       ComparisonInputs defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, QVector<QString> choices,
                        bool showOperators, int groupIndex = -1);
 
     ~ComparisonSelectionFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/ConstrainedDoubleFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ConstrainedDoubleFilterParameter.cpp
@@ -49,7 +49,7 @@ ConstrainedDoubleFilterParameter::~ConstrainedDoubleFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 ConstrainedDoubleFilterParameter::Pointer ConstrainedDoubleFilterParameter::New(const QString& humanLabel, const QString& propertyName,
-  const double& defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+  const double& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   ConstrainedDoubleFilterParameter::Pointer ptr = ConstrainedDoubleFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/ConstrainedDoubleFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ConstrainedDoubleFilterParameter.h
@@ -88,8 +88,7 @@ class SIMPLib_EXPORT ConstrainedDoubleFilterParameter : public FilterParameter
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-                       const double& defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, int groupIndex = -1);
+                       const double& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     ~ConstrainedDoubleFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/ConstrainedIntFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ConstrainedIntFilterParameter.cpp
@@ -49,7 +49,7 @@ ConstrainedIntFilterParameter::~ConstrainedIntFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 ConstrainedIntFilterParameter::Pointer ConstrainedIntFilterParameter::New(const QString& humanLabel, const QString& propertyName,
-  const int& defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+  const int& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
   int groupIndex)
 {
 

--- a/Source/SIMPLib/FilterParameters/ConstrainedIntFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ConstrainedIntFilterParameter.h
@@ -87,8 +87,7 @@ class SIMPLib_EXPORT ConstrainedIntFilterParameter : public FilterParameter
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-                       const int& defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, int groupIndex = -1);
+                       const int& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     ~ConstrainedIntFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/DataArrayCreationFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataArrayCreationFilterParameter.cpp
@@ -52,7 +52,7 @@ DataArrayCreationFilterParameter::~DataArrayCreationFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 DataArrayCreationFilterParameter::Pointer DataArrayCreationFilterParameter::New(const QString& humanLabel, const QString& propertyName, const DataArrayPath& defaultValue, Category category,
-                                                                                SetterCallbackType setterCallback, GetterCallbackType getterCallback, const RequirementType req, int groupIndex)
+                                                                                const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, RequirementType req, int groupIndex)
 {
 
   DataArrayCreationFilterParameter::Pointer ptr = DataArrayCreationFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/DataArrayCreationFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataArrayCreationFilterParameter.h
@@ -104,8 +104,8 @@ class SIMPLib_EXPORT DataArrayCreationFilterParameter : public FilterParameter
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                        const DataArrayPath& defaultValue, Category category,
-                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
-                       const RequirementType req, int groupIndex = -1);
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
+                       RequirementType req, int groupIndex = -1);
 
     ~DataArrayCreationFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
@@ -88,7 +88,7 @@ DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParam
                                                                                                                 size_t allowedCompDim,
                                                                                                                 AttributeMatrix::Category attributeMatrixCategory)
 {
-  using QVectorOfSizeType = std::vector<size_t>;
+  using SizeTVectorType = std::vector<size_t>;
   DataArraySelectionFilterParameter::RequirementType req;
   AttributeMatrix::Types amTypes;
   if(attributeMatrixCategory == AttributeMatrix::Category::Element)
@@ -119,7 +119,7 @@ DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParam
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-    req.componentDimensions = std::vector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+    req.componentDimensions = std::vector<SizeTVectorType>(1, SizeTVectorType(1, allowedCompDim));
   }
   //  if(IGeometry::Type::Unknown != geometryType)
   //  {
@@ -136,7 +136,7 @@ DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParam
                                                                                                         AttributeMatrix::Type attributeMatrixType,
                                                                                                         IGeometry::Type geometryType)
 {
-  using QVectorOfSizeType = std::vector<size_t>;
+  using SizeTVectorType = std::vector<size_t>;
   DataArraySelectionFilterParameter::RequirementType req;
   if(primitiveType.compare(SIMPL::Defaults::AnyPrimitive) != 0)
   {
@@ -144,7 +144,7 @@ DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParam
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-    req.componentDimensions = std::vector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+    req.componentDimensions = std::vector<SizeTVectorType>(1, SizeTVectorType(1, allowedCompDim));
   }
   if(AttributeMatrix::Type::Any != attributeMatrixType)
   {

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
@@ -50,13 +50,8 @@ DataArraySelectionFilterParameter::~DataArraySelectionFilterParameter() = defaul
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DataArraySelectionFilterParameter::Pointer DataArraySelectionFilterParameter::New(const QString& humanLabel,
-                                                                                  const QString& propertyName,
-                                                                                  const DataArrayPath& defaultValue,
-                                                                                  Category category,
-                                                                                  SetterCallbackType setterCallback,
-                                                                                  GetterCallbackType getterCallback,
-                                                                                  const RequirementType req,
+DataArraySelectionFilterParameter::Pointer DataArraySelectionFilterParameter::New(const QString& humanLabel, const QString& propertyName, const DataArrayPath& defaultValue, Category category,
+                                                                                  const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, RequirementType req,
                                                                                   int groupIndex)
 {
 
@@ -93,7 +88,7 @@ DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParam
                                                                                                                 size_t allowedCompDim,
                                                                                                                 AttributeMatrix::Category attributeMatrixCategory)
 {
-  typedef QVector<size_t> QVectorOfSizeType;
+  using QVectorOfSizeType = std::vector<size_t>;
   DataArraySelectionFilterParameter::RequirementType req;
   AttributeMatrix::Types amTypes;
   if(attributeMatrixCategory == AttributeMatrix::Category::Element)
@@ -124,7 +119,7 @@ DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParam
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-    req.componentDimensions = QVector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+    req.componentDimensions = std::vector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
   }
   //  if(IGeometry::Type::Unknown != geometryType)
   //  {
@@ -141,7 +136,7 @@ DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParam
                                                                                                         AttributeMatrix::Type attributeMatrixType,
                                                                                                         IGeometry::Type geometryType)
 {
-  typedef QVector<size_t> QVectorOfSizeType;
+  using QVectorOfSizeType = std::vector<size_t>;
   DataArraySelectionFilterParameter::RequirementType req;
   if(primitiveType.compare(SIMPL::Defaults::AnyPrimitive) != 0)
   {
@@ -149,7 +144,7 @@ DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParam
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-    req.componentDimensions = QVector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+    req.componentDimensions = std::vector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
   }
   if(AttributeMatrix::Type::Any != attributeMatrixType)
   {

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
@@ -76,13 +76,13 @@ class SIMPLib_EXPORT DataArraySelectionFilterParameter : public FilterParameter
     using SetterCallbackType = std::function<void(DataArrayPath)>;
     using GetterCallbackType = std::function<DataArrayPath(void)>;
 
-    typedef struct
+    using RequirementType = struct
     {
       IGeometry::Types dcGeometryTypes;
       AttributeMatrix::Types amTypes;
       QVector<QString> daTypes;
-      QVector< QVector<size_t> > componentDimensions;
-    } RequirementType;
+      std::vector<std::vector<size_t>> componentDimensions;
+    };
 
     /**
      * @brief New This function instantiates an instance of the DataArraySelectionFilterParameter.  Specifying a RequirementType will
@@ -106,8 +106,8 @@ class SIMPLib_EXPORT DataArraySelectionFilterParameter : public FilterParameter
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                        const DataArrayPath& defaultValue, Category category,
-                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
-                       const RequirementType req, int groupIndex = -1);
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
+                       RequirementType req, int groupIndex = -1);
 
     ~DataArraySelectionFilterParameter() override;
 
@@ -183,7 +183,7 @@ class SIMPLib_EXPORT DataArraySelectionFilterParameter : public FilterParameter
     * @param DefaultComponentDimensions Default component dimensions required for Attribute Array selections
     * @return
     */
-    SIMPL_INSTANCE_PROPERTY(QVector< QVector<size_t> >, DefaultComponentDimensions)
+    SIMPL_INSTANCE_PROPERTY(std::vector<std::vector<size_t>>, DefaultComponentDimensions)
 
     /**
     * @param SetterCallback The method in the AbstractFilter subclass that <i>sets</i> the value of the property

--- a/Source/SIMPLib/FilterParameters/DataContainerArrayProxyFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataContainerArrayProxyFilterParameter.cpp
@@ -54,7 +54,7 @@ DataContainerArrayProxyFilterParameter::~DataContainerArrayProxyFilterParameter(
 //
 // -----------------------------------------------------------------------------
 DataContainerArrayProxyFilterParameter::Pointer DataContainerArrayProxyFilterParameter::New(const QString& humanLabel, const QString& propertyName, DataContainerArrayProxy defaultValue,
-                                                                                            Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                                                                                            Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                                                                                             DataContainerArrayProxy proxy, Qt::CheckState defValue, int groupIndex)
 {
   DataContainerArrayProxyFilterParameter::Pointer ptr = DataContainerArrayProxyFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/DataContainerArrayProxyFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerArrayProxyFilterParameter.h
@@ -91,8 +91,7 @@ class SIMPLib_EXPORT DataContainerArrayProxyFilterParameter : public FilterParam
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-                       DataContainerArrayProxy defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, DataContainerArrayProxy proxy,
+                       DataContainerArrayProxy defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, DataContainerArrayProxy proxy,
                        Qt::CheckState defState, int groupIndex = -1);
 
     ~DataContainerArrayProxyFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/DataContainerCreationFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataContainerCreationFilterParameter.cpp
@@ -51,7 +51,7 @@ DataContainerCreationFilterParameter::~DataContainerCreationFilterParameter() = 
 //
 // -----------------------------------------------------------------------------
 DataContainerCreationFilterParameter::Pointer DataContainerCreationFilterParameter::New(const QString& humanLabel, const QString& propertyName, const DataArrayPath& defaultValue, Category category,
-                                                                                        SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+                                                                                        const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   DataContainerCreationFilterParameter::Pointer ptr = DataContainerCreationFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/DataContainerCreationFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerCreationFilterParameter.h
@@ -87,7 +87,7 @@ public:
    * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
    * @return
    */
-  static Pointer New(const QString& humanLabel, const QString& propertyName, const DataArrayPath& defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+  static Pointer New(const QString& humanLabel, const QString& propertyName, const DataArrayPath& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                      int groupIndex = -1);
 
   ~DataContainerCreationFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.cpp
@@ -51,7 +51,7 @@ DataContainerSelectionFilterParameter::~DataContainerSelectionFilterParameter() 
 //
 // -----------------------------------------------------------------------------
 DataContainerSelectionFilterParameter::Pointer DataContainerSelectionFilterParameter::New(const QString& humanLabel, const QString& propertyName, const DataArrayPath& defaultValue, Category category,
-                                                                                          SetterCallbackType setterCallback, GetterCallbackType getterCallback, const RequirementType& req,
+                                                                                          const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, const RequirementType& req,
                                                                                           int groupIndex)
 {
   DataContainerSelectionFilterParameter::Pointer ptr = DataContainerSelectionFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataContainerSelectionFilterParameter.h
@@ -98,8 +98,7 @@ class SIMPLib_EXPORT DataContainerSelectionFilterParameter : public FilterParame
      * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
      * @return
      */
-    static Pointer New(const QString& humanLabel, const QString& propertyName, const DataArrayPath& defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, const RequirementType& req, int groupIndex = -1);
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const DataArrayPath& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, const RequirementType& req, int groupIndex = -1);
 
     ~DataContainerSelectionFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/DoubleFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DoubleFilterParameter.cpp
@@ -49,8 +49,7 @@ DoubleFilterParameter::~DoubleFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 DoubleFilterParameter::Pointer DoubleFilterParameter::New(const QString& humanLabel, const QString& propertyName,
-                                                          const double& defaultValue, Category category, SetterCallbackType setterCallback,
-                                                          GetterCallbackType getterCallback, int groupIndex)
+                                                          const double& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   DoubleFilterParameter::Pointer ptr = DoubleFilterParameter::New();
@@ -70,8 +69,7 @@ DoubleFilterParameter::Pointer DoubleFilterParameter::New(const QString& humanLa
 //
 // -----------------------------------------------------------------------------
 DoubleFilterParameter::Pointer DoubleFilterParameter::New(const QString& humanLabel, const QString& propertyName,
-                                                          const float& defaultValue, Category category, SetterCallbackType setterCallback,
-                                                          GetterCallbackType getterCallback, int groupIndex)
+                                                          const float& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   DoubleFilterParameter::Pointer ptr = DoubleFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/DoubleFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DoubleFilterParameter.h
@@ -88,8 +88,7 @@ class SIMPLib_EXPORT DoubleFilterParameter : public FilterParameter
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-                       const double& defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, int groupIndex = -1);
+                       const double& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     /**
      * @brief New This function instantiates an instance of the DoubleFilterParameter. Although this function is available to be used,
@@ -108,8 +107,7 @@ class SIMPLib_EXPORT DoubleFilterParameter : public FilterParameter
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-                       const float& defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, int groupIndex = -1);
+                       const float& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     ~DoubleFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/DynamicChoiceFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DynamicChoiceFilterParameter.cpp
@@ -49,7 +49,7 @@ DynamicChoiceFilterParameter::~DynamicChoiceFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 DynamicChoiceFilterParameter::Pointer DynamicChoiceFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category,
-                                                                        SetterCallbackType setterCallback, GetterCallbackType getterCallback, const QString& listProperty, int groupIndex)
+                                                                        const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, const QString& listProperty, int groupIndex)
 {
   DynamicChoiceFilterParameter::Pointer ptr = DynamicChoiceFilterParameter::New();
   ptr->setHumanLabel(humanLabel);

--- a/Source/SIMPLib/FilterParameters/DynamicChoiceFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DynamicChoiceFilterParameter.h
@@ -89,7 +89,7 @@ class SIMPLib_EXPORT DynamicChoiceFilterParameter : public FilterParameter
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                        const QString& defaultValue, Category category,
-                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                        const QString& listProperty, int groupIndex = -1);
 
     ~DynamicChoiceFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/DynamicTableFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DynamicTableFilterParameter.cpp
@@ -51,7 +51,7 @@ DynamicTableFilterParameter::~DynamicTableFilterParameter() = default;
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DynamicTableFilterParameter::Pointer DynamicTableFilterParameter::New(const QString& humanLabel, const QString& propertyName, DynamicTableData defaultTableData, FilterParameter::Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+DynamicTableFilterParameter::Pointer DynamicTableFilterParameter::New(const QString& humanLabel, const QString& propertyName, DynamicTableData defaultTableData, FilterParameter::Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
   DynamicTableFilterParameter::Pointer ptr = DynamicTableFilterParameter::New();
   ptr->setHumanLabel(humanLabel);

--- a/Source/SIMPLib/FilterParameters/DynamicTableFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DynamicTableFilterParameter.h
@@ -94,7 +94,7 @@ class SIMPLib_EXPORT DynamicTableFilterParameter : public FilterParameter
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                        DynamicTableData defaultTableData, FilterParameter::Category category,
-                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                        int groupIndex = -1);
 
     ~DynamicTableFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/FloatFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/FloatFilterParameter.cpp
@@ -45,8 +45,10 @@ FloatFilterParameter::~FloatFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 FloatFilterParameter::Pointer FloatFilterParameter::New(const QString& humanLabel, const QString& propertyName,
-                                                          const float& defaultValue, Category category, SetterCallbackType setterCallback,
-                                                          GetterCallbackType getterCallback, int groupIndex)
+                       const float& defaultValue, Category category, 
+                       const SetterCallbackType& setterCallback, 
+                       const GetterCallbackType& getterCallback, 
+                       int groupIndex)
 {
 
   FloatFilterParameter::Pointer ptr = FloatFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/FloatFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FloatFilterParameter.h
@@ -88,8 +88,7 @@ class SIMPLib_EXPORT FloatFilterParameter : public FilterParameter
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-                       const float& defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, int groupIndex = -1);
+                       const float& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     ~FloatFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/FloatVec2FilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/FloatVec2FilterParameter.cpp
@@ -47,7 +47,7 @@ FloatVec2FilterParameter::~FloatVec2FilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 FloatVec2FilterParameter::Pointer FloatVec2FilterParameter::New(const QString& humanLabel, const QString& propertyName, const FloatVec2Type& defaultValue, Category category,
-                                                                SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+                                                                const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   FloatVec2FilterParameter::Pointer ptr = FloatVec2FilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/FloatVec2FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FloatVec2FilterParameter.h
@@ -93,8 +93,7 @@ public:
      * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
      * @return
      */
-    static Pointer New(const QString& humanLabel, const QString& propertyName, const FloatVec2Type& defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, int groupIndex = -1);
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const FloatVec2Type& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     ~FloatVec2FilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/FloatVec3FilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/FloatVec3FilterParameter.cpp
@@ -49,7 +49,7 @@ FloatVec3FilterParameter::~FloatVec3FilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 FloatVec3FilterParameter::Pointer FloatVec3FilterParameter::New(const QString& humanLabel, const QString& propertyName, const FloatVec3Type& defaultValue, Category category,
-                                                                SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+                                                                const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   FloatVec3FilterParameter::Pointer ptr = FloatVec3FilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/FloatVec3FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FloatVec3FilterParameter.h
@@ -94,8 +94,7 @@ public:
      * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
      * @return
      */
-    static Pointer New(const QString& humanLabel, const QString& propertyName, const FloatVec3Type& defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, int groupIndex = -1);
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const FloatVec3Type& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     ~FloatVec3FilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/FourthOrderPolynomialFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/FourthOrderPolynomialFilterParameter.cpp
@@ -49,7 +49,7 @@ FourthOrderPolynomialFilterParameter::~FourthOrderPolynomialFilterParameter() = 
 //
 // -----------------------------------------------------------------------------
 FourthOrderPolynomialFilterParameter::Pointer FourthOrderPolynomialFilterParameter::New(const QString& humanLabel, const QString& propertyName, const Float4thOrderPoly_t& defaultValue,
-                                                                                        Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+                                                                                        Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   FourthOrderPolynomialFilterParameter::Pointer ptr = FourthOrderPolynomialFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/FourthOrderPolynomialFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/FourthOrderPolynomialFilterParameter.h
@@ -169,9 +169,8 @@ public:
      * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
      * @return
      */
-    static Pointer New(const QString& humanLabel, const QString& propertyName,
-    const Float4thOrderPoly_t& defaultValue, Category category, SetterCallbackType setterCallback,
-    GetterCallbackType getterCallback, int groupIndex = -1);
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const Float4thOrderPoly_t& defaultValue, Category category, const SetterCallbackType& setterCallback,
+                       const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     ~FourthOrderPolynomialFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/InputFileFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/InputFileFilterParameter.cpp
@@ -53,7 +53,7 @@ InputFileFilterParameter::~InputFileFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 InputFileFilterParameter::Pointer InputFileFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category,
-                                                                SetterCallbackType setterCallback, GetterCallbackType getterCallback, const QString& fileExtension, const QString& fileType,
+                                                                const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, const QString& fileExtension, const QString& fileType,
                                                                 int groupIndex)
 {
   InputFileFilterParameter::Pointer ptr = InputFileFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/InputFileFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/InputFileFilterParameter.h
@@ -89,8 +89,7 @@ public:
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-    const QString& defaultValue, Category category, SetterCallbackType setterCallback,
-    GetterCallbackType getterCallback, const QString& fileExtension = QString(""),
+    const QString& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, const QString& fileExtension = QString(""),
     const QString& fileType = QString(""), int groupIndex = -1);
 
     ~InputFileFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/InputPathFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/InputPathFilterParameter.cpp
@@ -49,7 +49,7 @@ InputPathFilterParameter::~InputPathFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 InputPathFilterParameter::Pointer InputPathFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category,
-                                                                SetterCallbackType setterCallback, GetterCallbackType getterCallback, const QString& fileExtension, const QString& fileType,
+                                                                const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, const QString& fileExtension, const QString& fileType,
                                                                 int groupIndex)
 {
   InputPathFilterParameter::Pointer ptr = InputPathFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/InputPathFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/InputPathFilterParameter.h
@@ -89,8 +89,7 @@ public:
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-    const QString& defaultValue, Category category, SetterCallbackType setterCallback,
-    GetterCallbackType getterCallback, const QString& fileExtension = QString(""),
+    const QString& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, const QString& fileExtension = QString(""),
     const QString& fileType = QString(""), int groupIndex = -1);
 
     ~InputPathFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/IntFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/IntFilterParameter.cpp
@@ -48,8 +48,8 @@ IntFilterParameter::~IntFilterParameter() = default;
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntFilterParameter::Pointer IntFilterParameter::New(const QString& humanLabel, const QString& propertyName, const int& defaultValue, Category category, SetterCallbackType setterCallback,
-                                                    GetterCallbackType getterCallback, int groupIndex)
+IntFilterParameter::Pointer IntFilterParameter::New(const QString& humanLabel, const QString& propertyName, const int& defaultValue, Category category, const SetterCallbackType& setterCallback,
+                                                    const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   IntFilterParameter::Pointer ptr = IntFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/IntFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/IntFilterParameter.h
@@ -87,8 +87,7 @@ class SIMPLib_EXPORT IntFilterParameter : public FilterParameter
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-                       const int& defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, int groupIndex = -1);
+                       const int& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     ~IntFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/LinkedBooleanFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/LinkedBooleanFilterParameter.cpp
@@ -49,7 +49,7 @@ LinkedBooleanFilterParameter::~LinkedBooleanFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 LinkedBooleanFilterParameter::Pointer LinkedBooleanFilterParameter::New(const QString& humanLabel, const QString& propertyName, const bool& defaultValue, Category category,
-                                                                        SetterCallbackType setterCallback, GetterCallbackType getterCallback, QStringList conditionalProperties, int groupIndex)
+                                                                        const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, QStringList conditionalProperties, int groupIndex)
 {
   LinkedBooleanFilterParameter::Pointer ptr = LinkedBooleanFilterParameter::New();
   ptr->setHumanLabel(humanLabel);

--- a/Source/SIMPLib/FilterParameters/LinkedBooleanFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/LinkedBooleanFilterParameter.h
@@ -89,7 +89,7 @@ class SIMPLib_EXPORT LinkedBooleanFilterParameter : public FilterParameter
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                        const bool& defaultValue, Category category,
-                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                        QStringList conditionalProperties, int groupIndex = -1);
 
     ~LinkedBooleanFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/LinkedChoicesFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/LinkedChoicesFilterParameter.cpp
@@ -49,7 +49,7 @@ LinkedChoicesFilterParameter::~LinkedChoicesFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 LinkedChoicesFilterParameter::Pointer LinkedChoicesFilterParameter::New(const QString& humanLabel, const QString& propertyName, const int& defaultValue, Category category,
-                                                                        SetterCallbackType setterCallback, GetterCallbackType getterCallback, QVector<QString> choices, QStringList linkedProperties,
+                                                                        const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, QVector<QString> choices, QStringList linkedProperties,
                                                                         int groupIndex)
 {
   LinkedChoicesFilterParameter::Pointer ptr = LinkedChoicesFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/LinkedChoicesFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/LinkedChoicesFilterParameter.h
@@ -74,7 +74,7 @@ class SIMPLib_EXPORT LinkedChoicesFilterParameter : public ChoiceFilterParameter
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                        const int& defaultValue, Category category,
-                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                        QVector<QString> choices, QStringList linkedProperties,
                        int groupIndex = -1);
 

--- a/Source/SIMPLib/FilterParameters/LinkedPathCreationFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/LinkedPathCreationFilterParameter.cpp
@@ -107,7 +107,7 @@ LinkedPathCreationFilterParameter::~LinkedPathCreationFilterParameter() = defaul
 //
 // -----------------------------------------------------------------------------
 LinkedPathCreationFilterParameter::Pointer LinkedPathCreationFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category,
-                                                                                  SetterCallbackType setterCallback, GetterCallbackType getterCallback, ILinkedPath* linkedPath, int groupIndex)
+                                                                                  const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, ILinkedPath* linkedPath, int groupIndex)
 {
 
   LinkedPathCreationFilterParameter::Pointer ptr = LinkedPathCreationFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/LinkedPathCreationFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/LinkedPathCreationFilterParameter.h
@@ -294,7 +294,7 @@ public:
    * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
    * @return
    */
-  static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+  static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                      ILinkedPath* linkedPath, int groupIndex = -1);
 
   ~LinkedPathCreationFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.cpp
@@ -93,7 +93,7 @@ QString MultiAttributeMatrixSelectionFilterParameter::getWidgetType() const
 MultiAttributeMatrixSelectionFilterParameter::RequirementType MultiAttributeMatrixSelectionFilterParameter::CreateCategoryRequirement(const QString& primitiveType, size_t allowedCompDim,
                                                                                                                           AttributeMatrix::Category attributeMatrixCategory)
 {
-  typedef std::vector<size_t> QVectorOfSizeType;
+  typedef std::vector<size_t> SizeTVectorType;
   MultiAttributeMatrixSelectionFilterParameter::RequirementType req;
   AttributeMatrix::Types amTypes;
   if(attributeMatrixCategory == AttributeMatrix::Category::Element)
@@ -124,7 +124,7 @@ MultiAttributeMatrixSelectionFilterParameter::RequirementType MultiAttributeMatr
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-    req.componentDimensions = QVector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+    req.componentDimensions = QVector<SizeTVectorType>(1, SizeTVectorType(1, allowedCompDim));
   }
   //  if(IGeometry::Type::Unknown != geometryType)
   //  {
@@ -139,7 +139,7 @@ MultiAttributeMatrixSelectionFilterParameter::RequirementType MultiAttributeMatr
 MultiAttributeMatrixSelectionFilterParameter::RequirementType MultiAttributeMatrixSelectionFilterParameter::CreateRequirement(const QString& primitiveType, size_t allowedCompDim, AttributeMatrix::Type attributeMatrixType,
                                                                                                                   IGeometry::Type geometryType)
 {
-  typedef std::vector<size_t> QVectorOfSizeType;
+  typedef std::vector<size_t> SizeTVectorType;
   MultiAttributeMatrixSelectionFilterParameter::RequirementType req;
   if(primitiveType.compare(SIMPL::Defaults::AnyPrimitive) != 0)
   {
@@ -147,7 +147,7 @@ MultiAttributeMatrixSelectionFilterParameter::RequirementType MultiAttributeMatr
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-    req.componentDimensions = QVector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+    req.componentDimensions = QVector<SizeTVectorType>(1, SizeTVectorType(1, allowedCompDim));
   }
   if(AttributeMatrix::Type::Any != attributeMatrixType)
   {

--- a/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.cpp
@@ -57,8 +57,8 @@ MultiAttributeMatrixSelectionFilterParameter::~MultiAttributeMatrixSelectionFilt
 //
 // -----------------------------------------------------------------------------
 MultiAttributeMatrixSelectionFilterParameter::Pointer MultiAttributeMatrixSelectionFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QVector<DataArrayPath>& defaultValue,
-                                                                                            Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
-                                                                                            const RequirementType req, int groupIndex)
+                                                                                            Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
+                                                                                            RequirementType req, int groupIndex)
 {
 
   MultiAttributeMatrixSelectionFilterParameter::Pointer ptr = MultiAttributeMatrixSelectionFilterParameter::New();
@@ -93,7 +93,7 @@ QString MultiAttributeMatrixSelectionFilterParameter::getWidgetType() const
 MultiAttributeMatrixSelectionFilterParameter::RequirementType MultiAttributeMatrixSelectionFilterParameter::CreateCategoryRequirement(const QString& primitiveType, size_t allowedCompDim,
                                                                                                                           AttributeMatrix::Category attributeMatrixCategory)
 {
-  typedef QVector<size_t> QVectorOfSizeType;
+  typedef std::vector<size_t> QVectorOfSizeType;
   MultiAttributeMatrixSelectionFilterParameter::RequirementType req;
   AttributeMatrix::Types amTypes;
   if(attributeMatrixCategory == AttributeMatrix::Category::Element)
@@ -139,7 +139,7 @@ MultiAttributeMatrixSelectionFilterParameter::RequirementType MultiAttributeMatr
 MultiAttributeMatrixSelectionFilterParameter::RequirementType MultiAttributeMatrixSelectionFilterParameter::CreateRequirement(const QString& primitiveType, size_t allowedCompDim, AttributeMatrix::Type attributeMatrixType,
                                                                                                                   IGeometry::Type geometryType)
 {
-  typedef QVector<size_t> QVectorOfSizeType;
+  typedef std::vector<size_t> QVectorOfSizeType;
   MultiAttributeMatrixSelectionFilterParameter::RequirementType req;
   if(primitiveType.compare(SIMPL::Defaults::AnyPrimitive) != 0)
   {

--- a/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/MultiAttributeMatrixSelectionFilterParameter.h
@@ -79,7 +79,7 @@ class SIMPLib_EXPORT MultiAttributeMatrixSelectionFilterParameter : public Filte
       IGeometry::Types dcGeometryTypes;
       AttributeMatrix::Types amTypes;
       QVector<QString> daTypes;
-      QVector< QVector<size_t> > componentDimensions;
+      QVector< std::vector<size_t> > componentDimensions;
     } RequirementType;
 
     /**
@@ -104,8 +104,8 @@ class SIMPLib_EXPORT MultiAttributeMatrixSelectionFilterParameter : public Filte
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                        const QVector<DataArrayPath>& defaultValue, Category category,
-                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
-                       const RequirementType req, int groupIndex = -1);
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
+                       RequirementType req, int groupIndex = -1);
 
     ~MultiAttributeMatrixSelectionFilterParameter() override;
 
@@ -157,7 +157,7 @@ class SIMPLib_EXPORT MultiAttributeMatrixSelectionFilterParameter : public Filte
     SIMPL_INSTANCE_PROPERTY(IGeometry::Types, DefaultGeometryTypes)
     SIMPL_INSTANCE_PROPERTY(QVector<AttributeMatrix::Type>, DefaultAttributeMatrixTypes)
     SIMPL_INSTANCE_PROPERTY(QVector<QString>, DefaultAttributeArrayTypes)
-    SIMPL_INSTANCE_PROPERTY(QVector< QVector<size_t> >, DefaultComponentDimensions)
+    SIMPL_INSTANCE_PROPERTY(QVector< std::vector<size_t> >, DefaultComponentDimensions)
 
     /**
     * @param SetterCallback The method in the AbstractFilter subclass that <i>sets</i> the value of the property

--- a/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.cpp
@@ -93,7 +93,7 @@ QString MultiDataArraySelectionFilterParameter::getWidgetType() const
 MultiDataArraySelectionFilterParameter::RequirementType MultiDataArraySelectionFilterParameter::CreateCategoryRequirement(const QString& primitiveType, size_t allowedCompDim,
                                                                                                                           AttributeMatrix::Category attributeMatrixCategory)
 {
-  typedef std::vector<size_t> QVectorOfSizeType;
+  typedef std::vector<size_t> SizeTVectorType;
   MultiDataArraySelectionFilterParameter::RequirementType req;
   AttributeMatrix::Types amTypes;
   if(attributeMatrixCategory == AttributeMatrix::Category::Element)
@@ -124,7 +124,7 @@ MultiDataArraySelectionFilterParameter::RequirementType MultiDataArraySelectionF
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-    req.componentDimensions = QVector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+    req.componentDimensions = QVector<SizeTVectorType>(1, SizeTVectorType(1, allowedCompDim));
   }
   //  if(IGeometry::Type::Unknown != geometryType)
   //  {
@@ -139,7 +139,7 @@ MultiDataArraySelectionFilterParameter::RequirementType MultiDataArraySelectionF
 MultiDataArraySelectionFilterParameter::RequirementType MultiDataArraySelectionFilterParameter::CreateRequirement(const QString& primitiveType, size_t allowedCompDim, AttributeMatrix::Type attributeMatrixType,
                                                                                                                   IGeometry::Type geometryType)
 {
-  typedef std::vector<size_t> QVectorOfSizeType;
+  typedef std::vector<size_t> SizeTVectorType;
   MultiDataArraySelectionFilterParameter::RequirementType req;
   if(primitiveType.compare(SIMPL::Defaults::AnyPrimitive) != 0)
   {
@@ -147,7 +147,7 @@ MultiDataArraySelectionFilterParameter::RequirementType MultiDataArraySelectionF
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-    req.componentDimensions = QVector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+    req.componentDimensions = QVector<SizeTVectorType>(1, SizeTVectorType(1, allowedCompDim));
   }
   if(AttributeMatrix::Type::Any != attributeMatrixType)
   {

--- a/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.cpp
@@ -57,8 +57,8 @@ MultiDataArraySelectionFilterParameter::~MultiDataArraySelectionFilterParameter(
 //
 // -----------------------------------------------------------------------------
 MultiDataArraySelectionFilterParameter::Pointer MultiDataArraySelectionFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QVector<DataArrayPath>& defaultValue,
-                                                                                            Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
-                                                                                            const RequirementType req, int groupIndex)
+                                                                                            Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
+                                                                                            RequirementType req, int groupIndex)
 {
 
   MultiDataArraySelectionFilterParameter::Pointer ptr = MultiDataArraySelectionFilterParameter::New();
@@ -93,7 +93,7 @@ QString MultiDataArraySelectionFilterParameter::getWidgetType() const
 MultiDataArraySelectionFilterParameter::RequirementType MultiDataArraySelectionFilterParameter::CreateCategoryRequirement(const QString& primitiveType, size_t allowedCompDim,
                                                                                                                           AttributeMatrix::Category attributeMatrixCategory)
 {
-  typedef QVector<size_t> QVectorOfSizeType;
+  typedef std::vector<size_t> QVectorOfSizeType;
   MultiDataArraySelectionFilterParameter::RequirementType req;
   AttributeMatrix::Types amTypes;
   if(attributeMatrixCategory == AttributeMatrix::Category::Element)
@@ -139,7 +139,7 @@ MultiDataArraySelectionFilterParameter::RequirementType MultiDataArraySelectionF
 MultiDataArraySelectionFilterParameter::RequirementType MultiDataArraySelectionFilterParameter::CreateRequirement(const QString& primitiveType, size_t allowedCompDim, AttributeMatrix::Type attributeMatrixType,
                                                                                                                   IGeometry::Type geometryType)
 {
-  typedef QVector<size_t> QVectorOfSizeType;
+  typedef std::vector<size_t> QVectorOfSizeType;
   MultiDataArraySelectionFilterParameter::RequirementType req;
   if(primitiveType.compare(SIMPL::Defaults::AnyPrimitive) != 0)
   {

--- a/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/MultiDataArraySelectionFilterParameter.h
@@ -79,7 +79,7 @@ class SIMPLib_EXPORT MultiDataArraySelectionFilterParameter : public FilterParam
       IGeometry::Types dcGeometryTypes;
       AttributeMatrix::Types amTypes;
       QVector<QString> daTypes;
-      QVector< QVector<size_t> > componentDimensions;
+      QVector< std::vector<size_t> > componentDimensions;
     } RequirementType;
 
     /**
@@ -104,8 +104,8 @@ class SIMPLib_EXPORT MultiDataArraySelectionFilterParameter : public FilterParam
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                        const QVector<DataArrayPath>& defaultValue, Category category,
-                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
-                       const RequirementType req, int groupIndex = -1);
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
+                       RequirementType req, int groupIndex = -1);
 
     ~MultiDataArraySelectionFilterParameter() override;
 
@@ -157,7 +157,7 @@ class SIMPLib_EXPORT MultiDataArraySelectionFilterParameter : public FilterParam
     SIMPL_INSTANCE_PROPERTY(IGeometry::Types, DefaultGeometryTypes)
     SIMPL_INSTANCE_PROPERTY(QVector<AttributeMatrix::Type>, DefaultAttributeMatrixTypes)
     SIMPL_INSTANCE_PROPERTY(QVector<QString>, DefaultAttributeArrayTypes)
-    SIMPL_INSTANCE_PROPERTY(QVector< QVector<size_t> >, DefaultComponentDimensions)
+    SIMPL_INSTANCE_PROPERTY(QVector< std::vector<size_t> >, DefaultComponentDimensions)
 
     /**
     * @param SetterCallback The method in the AbstractFilter subclass that <i>sets</i> the value of the property

--- a/Source/SIMPLib/FilterParameters/MultiDataContainerSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/MultiDataContainerSelectionFilterParameter.cpp
@@ -94,7 +94,7 @@ QString MultiDataContainerSelectionFilterParameter::getWidgetType() const
 MultiDataContainerSelectionFilterParameter::RequirementType MultiDataContainerSelectionFilterParameter::CreateCategoryRequirement(const QString& primitiveType, size_t allowedCompDim,
 	AttributeMatrix::Category attributeMatrixCategory)
 {
-  using QVectorOfSizeType = std::vector<size_t>;
+  using SizeTVectorType = std::vector<size_t>;
   MultiDataContainerSelectionFilterParameter::RequirementType req;
 	AttributeMatrix::Types amTypes;
 	if (attributeMatrixCategory == AttributeMatrix::Category::Element)
@@ -125,7 +125,7 @@ MultiDataContainerSelectionFilterParameter::RequirementType MultiDataContainerSe
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-    req.componentDimensions = std::vector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+    req.componentDimensions = std::vector<SizeTVectorType>(1, SizeTVectorType(1, allowedCompDim));
   }
   //  if(IGeometry::Type::Unknown != geometryType)
   //  {
@@ -140,7 +140,7 @@ MultiDataContainerSelectionFilterParameter::RequirementType MultiDataContainerSe
 MultiDataContainerSelectionFilterParameter::RequirementType MultiDataContainerSelectionFilterParameter::CreateRequirement(const QString& primitiveType, size_t allowedCompDim, AttributeMatrix::Type attributeMatrixType,
 	IGeometry::Type geometryType)
 {
-  using QVectorOfSizeType = std::vector<size_t>;
+  using SizeTVectorType = std::vector<size_t>;
   MultiDataContainerSelectionFilterParameter::RequirementType req;
   if(primitiveType.compare(SIMPL::Defaults::AnyPrimitive) != 0)
   {
@@ -148,7 +148,7 @@ MultiDataContainerSelectionFilterParameter::RequirementType MultiDataContainerSe
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-    req.componentDimensions = std::vector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+    req.componentDimensions = std::vector<SizeTVectorType>(1, SizeTVectorType(1, allowedCompDim));
   }
   if(AttributeMatrix::Type::Any != attributeMatrixType)
   {

--- a/Source/SIMPLib/FilterParameters/MultiDataContainerSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/MultiDataContainerSelectionFilterParameter.cpp
@@ -94,7 +94,7 @@ QString MultiDataContainerSelectionFilterParameter::getWidgetType() const
 MultiDataContainerSelectionFilterParameter::RequirementType MultiDataContainerSelectionFilterParameter::CreateCategoryRequirement(const QString& primitiveType, size_t allowedCompDim,
 	AttributeMatrix::Category attributeMatrixCategory)
 {
-  using QVectorOfSizeType = QVector<size_t>;
+  using QVectorOfSizeType = std::vector<size_t>;
   MultiDataContainerSelectionFilterParameter::RequirementType req;
 	AttributeMatrix::Types amTypes;
 	if (attributeMatrixCategory == AttributeMatrix::Category::Element)
@@ -121,17 +121,17 @@ MultiDataContainerSelectionFilterParameter::RequirementType MultiDataContainerSe
 	req.amTypes = amTypes;
 	if (primitiveType.compare(SIMPL::Defaults::AnyPrimitive) != 0)
 	{
-		req.daTypes = QVector<QString>(1, primitiveType);
-	}
-	if (SIMPL::Defaults::AnyComponentSize != allowedCompDim)
-	{
-		req.componentDimensions = QVector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
-	}
-	//  if(IGeometry::Type::Unknown != geometryType)
-	//  {
-	//    req.dcGeometryTypes = IGeometry::Types(1, geometryType);
-	//  }
-	return req;
+    req.daTypes = QVector<QString>(1, primitiveType);
+  }
+  if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
+  {
+    req.componentDimensions = std::vector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+  }
+  //  if(IGeometry::Type::Unknown != geometryType)
+  //  {
+  //    req.dcGeometryTypes = IGeometry::Types(1, geometryType);
+  //  }
+  return req;
 }
 
 // -----------------------------------------------------------------------------
@@ -140,7 +140,7 @@ MultiDataContainerSelectionFilterParameter::RequirementType MultiDataContainerSe
 MultiDataContainerSelectionFilterParameter::RequirementType MultiDataContainerSelectionFilterParameter::CreateRequirement(const QString& primitiveType, size_t allowedCompDim, AttributeMatrix::Type attributeMatrixType,
 	IGeometry::Type geometryType)
 {
-  using QVectorOfSizeType = QVector<size_t>;
+  using QVectorOfSizeType = std::vector<size_t>;
   MultiDataContainerSelectionFilterParameter::RequirementType req;
   if(primitiveType.compare(SIMPL::Defaults::AnyPrimitive) != 0)
   {
@@ -148,10 +148,10 @@ MultiDataContainerSelectionFilterParameter::RequirementType MultiDataContainerSe
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-		req.componentDimensions = QVector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
-	}
-	if (AttributeMatrix::Type::Any != attributeMatrixType)
-	{
+    req.componentDimensions = std::vector<QVectorOfSizeType>(1, QVectorOfSizeType(1, allowedCompDim));
+  }
+  if(AttributeMatrix::Type::Any != attributeMatrixType)
+  {
 		QVector<AttributeMatrix::Type> amTypes(1, attributeMatrixType);
 		req.amTypes = amTypes;
 	}

--- a/Source/SIMPLib/FilterParameters/MultiDataContainerSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/MultiDataContainerSelectionFilterParameter.h
@@ -74,13 +74,13 @@ class SIMPLib_EXPORT MultiDataContainerSelectionFilterParameter : public FilterP
     using SetterCallbackType = std::function<void(QStringList)>;
     using GetterCallbackType = std::function<QStringList(void)>;
 
-    typedef struct
+    using RequirementType = struct
     {
       IGeometry::Types dcGeometryTypes;
       AttributeMatrix::Types amTypes;
       QVector<QString> daTypes;
-      QVector<QVector<size_t>> componentDimensions;
-    } RequirementType;
+      std::vector<std::vector<size_t>> componentDimensions;
+    };
 
     /**
      * @brief New This function instantiates an instance of the MultiDataContainerSelectionFilterParameter.  Specifying a RequirementType will
@@ -155,7 +155,7 @@ class SIMPLib_EXPORT MultiDataContainerSelectionFilterParameter : public FilterP
     SIMPL_INSTANCE_PROPERTY(IGeometry::Types, DefaultGeometryTypes)
     SIMPL_INSTANCE_PROPERTY(QVector<AttributeMatrix::Type>, DefaultAttributeMatrixTypes)
     SIMPL_INSTANCE_PROPERTY(QVector<QString>, DefaultAttributeArrayTypes)
-    SIMPL_INSTANCE_PROPERTY(QVector< QVector<size_t> >, DefaultComponentDimensions)
+    SIMPL_INSTANCE_PROPERTY(std::vector<std::vector<size_t>>, DefaultComponentDimensions)
 
     /**
     * @param SetterCallback The method in the AbstractFilter subclass that <i>sets</i> the value of the property

--- a/Source/SIMPLib/FilterParameters/NumericTypeFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/NumericTypeFilterParameter.cpp
@@ -50,7 +50,7 @@ NumericTypeFilterParameter::~NumericTypeFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 NumericTypeFilterParameter::Pointer NumericTypeFilterParameter::New(const QString& humanLabel, const QString& propertyName, SIMPL::NumericTypes::Type defaultValue, Category category,
-                                                                                  SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+                                                                                  const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
   NumericTypeFilterParameter::Pointer ptr = NumericTypeFilterParameter::New();
   ptr->setHumanLabel(humanLabel);

--- a/Source/SIMPLib/FilterParameters/NumericTypeFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/NumericTypeFilterParameter.h
@@ -89,7 +89,7 @@ public:
   * @return
   */
   static Pointer New(const QString& humanLabel, const QString& propertyName, SIMPL::NumericTypes::Type defaultValue, Category category, 
-                     SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex = -1);
+                     const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
   ~NumericTypeFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/OutputFileFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/OutputFileFilterParameter.cpp
@@ -49,7 +49,7 @@ OutputFileFilterParameter::~OutputFileFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 OutputFileFilterParameter::Pointer OutputFileFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category,
-                                                                  SetterCallbackType setterCallback, GetterCallbackType getterCallback, const QString& fileExtension, const QString& fileType,
+                                                                  const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, const QString& fileExtension, const QString& fileType,
                                                                   int groupIndex)
 {
   OutputFileFilterParameter::Pointer ptr = OutputFileFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/OutputFileFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/OutputFileFilterParameter.h
@@ -90,7 +90,7 @@ class SIMPLib_EXPORT OutputFileFilterParameter : public FilterParameter
    */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                        const QString& defaultValue, Category category,
-                       SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                       const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                        const QString& fileExtension = QString(""),
                        const QString& fileType = QString(""),
                        int groupIndex = -1);

--- a/Source/SIMPLib/FilterParameters/OutputPathFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/OutputPathFilterParameter.cpp
@@ -49,7 +49,7 @@ OutputPathFilterParameter::~OutputPathFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 OutputPathFilterParameter::Pointer OutputPathFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category,
-                                                                  SetterCallbackType setterCallback, GetterCallbackType getterCallback, const QString& fileExtension, const QString& fileType,
+                                                                  const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, const QString& fileExtension, const QString& fileType,
                                                                   int groupIndex)
 {
   OutputPathFilterParameter::Pointer ptr = OutputPathFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/OutputPathFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/OutputPathFilterParameter.h
@@ -90,7 +90,7 @@ public:
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
     const QString& defaultValue, Category category,
-    SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+    const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
     const QString& fileExtension = QString(""),
     const QString& fileType = QString(""),
     int groupIndex = -1);

--- a/Source/SIMPLib/FilterParameters/ParagraphFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ParagraphFilterParameter.cpp
@@ -47,7 +47,7 @@ ParagraphFilterParameter::~ParagraphFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 ParagraphFilterParameter::Pointer ParagraphFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category,
-                                                                SetterCallbackType setterCallback, GetterCallbackType getterCallback, bool allowPreflight, int groupIndex)
+                                                                const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, bool allowPreflight, int groupIndex)
 {
 
   ParagraphFilterParameter::Pointer ptr = ParagraphFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/ParagraphFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ParagraphFilterParameter.h
@@ -82,7 +82,7 @@ public:
    * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
    * @return
    */
-  static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, bool allowPreflight = true,
+  static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, bool allowPreflight = true,
                      int groupIndex = -1);
 
   ~ParagraphFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/PhaseTypeSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/PhaseTypeSelectionFilterParameter.cpp
@@ -53,7 +53,7 @@ PhaseTypeSelectionFilterParameter::~PhaseTypeSelectionFilterParameter() = defaul
 //
 // -----------------------------------------------------------------------------
 PhaseTypeSelectionFilterParameter::Pointer PhaseTypeSelectionFilterParameter::New(const QString& humanLabel, const QString& phaseTypeDataProperty, const DataArrayPath& attributeMatrixDefault,
-                                                                                  Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                                                                                  Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                                                                                   const QString& PhaseTypesArrayName, const QString& phaseTypeCountProperty, const QString& attributeMatrixProperty,
                                                                                   const QStringList& phaseListChoices, int groupIndex)
 {

--- a/Source/SIMPLib/FilterParameters/PhaseTypeSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/PhaseTypeSelectionFilterParameter.h
@@ -88,8 +88,8 @@ public:
   * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
   * @return
   */
-  static Pointer New(const QString& humanLabel, const QString& phaseTypeDataProperty, const DataArrayPath& attributeMatrixDefault, Category category, SetterCallbackType setterCallback,
-                     GetterCallbackType getterCallback, const QString& PhaseTypesArrayName, const QString& phaseTypeCountProperty, const QString& attributeMatrixProperty,
+  static Pointer New(const QString& humanLabel, const QString& phaseTypeDataProperty, const DataArrayPath& attributeMatrixDefault, Category category, const SetterCallbackType& setterCallback,
+                     const GetterCallbackType& getterCallback, const QString& PhaseTypesArrayName, const QString& phaseTypeCountProperty, const QString& attributeMatrixProperty,
                      const QStringList& phaseListChoices, int groupIndex = -1);
 
   ~PhaseTypeSelectionFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/RangeFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/RangeFilterParameter.cpp
@@ -49,7 +49,7 @@ RangeFilterParameter::~RangeFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 RangeFilterParameter::Pointer RangeFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QPair<double, double>& defaultPair, Category category,
-                                                        SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+                                                        const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   RangeFilterParameter::Pointer ptr = RangeFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/RangeFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/RangeFilterParameter.h
@@ -91,7 +91,7 @@ public:
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
                       const QPair<double, double>& defaultPair, Category category,
-                      SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+                      const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                       int groupIndex = -1);
 
     ~RangeFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/ScalarTypeFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ScalarTypeFilterParameter.cpp
@@ -50,7 +50,7 @@ ScalarTypeFilterParameter::~ScalarTypeFilterParameter() = default;
 //
 // -----------------------------------------------------------------------------
 ScalarTypeFilterParameter::Pointer ScalarTypeFilterParameter::New(const QString& humanLabel, const QString& propertyName, SIMPL::ScalarTypes::Type defaultValue, Category category,
-                                                                                  SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+                                                                                  const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
   ScalarTypeFilterParameter::Pointer ptr = ScalarTypeFilterParameter::New();
   ptr->setHumanLabel(humanLabel);

--- a/Source/SIMPLib/FilterParameters/ScalarTypeFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ScalarTypeFilterParameter.h
@@ -89,7 +89,7 @@ public:
   * @return
   */
   static Pointer New(const QString& humanLabel, const QString& propertyName, SIMPL::ScalarTypes::Type defaultValue, Category category, 
-                     SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex = -1);
+                     const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
   ~ScalarTypeFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/SecondOrderPolynomialFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/SecondOrderPolynomialFilterParameter.cpp
@@ -49,7 +49,7 @@ SecondOrderPolynomialFilterParameter::~SecondOrderPolynomialFilterParameter() = 
 //
 // -----------------------------------------------------------------------------
 SecondOrderPolynomialFilterParameter::Pointer SecondOrderPolynomialFilterParameter::New(const QString& humanLabel, const QString& propertyName, const Float2ndOrderPoly_t& defaultValue,
-                                                                                        Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+                                                                                        Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   SecondOrderPolynomialFilterParameter::Pointer ptr = SecondOrderPolynomialFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/SecondOrderPolynomialFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/SecondOrderPolynomialFilterParameter.h
@@ -121,7 +121,7 @@ public:
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
     const Float2ndOrderPoly_t& defaultValue, Category category,
-     SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+     const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
      int groupIndex = -1);
 
     ~SecondOrderPolynomialFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/ShapeTypeSelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ShapeTypeSelectionFilterParameter.cpp
@@ -51,7 +51,7 @@ ShapeTypeSelectionFilterParameter::~ShapeTypeSelectionFilterParameter() = defaul
 //
 // -----------------------------------------------------------------------------
 ShapeTypeSelectionFilterParameter::Pointer ShapeTypeSelectionFilterParameter::New(const QString& humanLabel, const QString& propertyName, ShapeType::Types defaultValue, Category category,
-                                                                                  SetterCallbackType setterCallback, GetterCallbackType getterCallback, const QString& phaseTypeCountProperty,
+                                                                                  const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, const QString& phaseTypeCountProperty,
                                                                                   const QString& phaseTypeArrayPathProperty, int groupIndex)
 {
   ShapeTypeSelectionFilterParameter::Pointer ptr = ShapeTypeSelectionFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/ShapeTypeSelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ShapeTypeSelectionFilterParameter.h
@@ -88,7 +88,7 @@ public:
   * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
   * @return
   */
-  static Pointer New(const QString& humanLabel, const QString& propertyName, ShapeType::Types defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+  static Pointer New(const QString& humanLabel, const QString& propertyName, ShapeType::Types defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                      const QString& phaseTypeCountProperty, const QString& phaseTypeArrayPathProperty, int groupIndex = -1);
 
   ~ShapeTypeSelectionFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/StringFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/StringFilterParameter.cpp
@@ -48,8 +48,7 @@ StringFilterParameter::~StringFilterParameter() = default;
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-StringFilterParameter::Pointer StringFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category, SetterCallbackType setterCallback,
-                                                          GetterCallbackType getterCallback, int groupIndex)
+StringFilterParameter::Pointer StringFilterParameter::New(const QString& humanLabel, const QString& propertyName, const QString& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   StringFilterParameter::Pointer ptr = StringFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/StringFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/StringFilterParameter.h
@@ -87,8 +87,7 @@ class SIMPLib_EXPORT StringFilterParameter : public FilterParameter
      * @return
      */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
-                       const QString& defaultValue, Category category, SetterCallbackType setterCallback,
-                       GetterCallbackType getterCallback, int groupIndex = -1);
+                       const QString& defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex = -1);
 
     ~StringFilterParameter() override;
 

--- a/Source/SIMPLib/FilterParameters/ThirdOrderPolynomialFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/ThirdOrderPolynomialFilterParameter.cpp
@@ -49,7 +49,7 @@ ThirdOrderPolynomialFilterParameter::~ThirdOrderPolynomialFilterParameter() = de
 //
 // -----------------------------------------------------------------------------
 ThirdOrderPolynomialFilterParameter::Pointer ThirdOrderPolynomialFilterParameter::New(const QString& humanLabel, const QString& propertyName, const Float3rdOrderPoly_t& defaultValue,
-                                                                                      Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback, int groupIndex)
+                                                                                      Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   ThirdOrderPolynomialFilterParameter::Pointer ptr = ThirdOrderPolynomialFilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/ThirdOrderPolynomialFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/ThirdOrderPolynomialFilterParameter.h
@@ -89,7 +89,7 @@ public:
    */
     static Pointer New(const QString& humanLabel, const QString& propertyName,
     const Float3rdOrderPoly_t& defaultValue, Category category,
-    SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+    const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
     int groupIndex = -1);
 
     ~ThirdOrderPolynomialFilterParameter() override;

--- a/Source/SIMPLib/FilterParameters/UInt64FilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/UInt64FilterParameter.cpp
@@ -46,8 +46,7 @@ UInt64FilterParameter::~UInt64FilterParameter() = default;
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-UInt64FilterParameter::Pointer UInt64FilterParameter::New(const QString& humanLabel, const QString& propertyName, uint64_t defaultValue, Category category, SetterCallbackType setterCallback,
-                                                          GetterCallbackType getterCallback, int groupIndex)
+UInt64FilterParameter::Pointer UInt64FilterParameter::New(const QString& humanLabel, const QString& propertyName, uint64_t defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback, int groupIndex)
 {
 
   UInt64FilterParameter::Pointer ptr = UInt64FilterParameter::New();

--- a/Source/SIMPLib/FilterParameters/UInt64FilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/UInt64FilterParameter.h
@@ -84,7 +84,7 @@ class SIMPLib_EXPORT UInt64FilterParameter : public FilterParameter
      * @param groupIndex Integer that specifies the group that this filter parameter will be placed in.
      * @return
      */
-    static Pointer New(const QString& humanLabel, const QString& propertyName, uint64_t defaultValue, Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback,
+    static Pointer New(const QString& humanLabel, const QString& propertyName, uint64_t defaultValue, Category category, const SetterCallbackType& setterCallback, const GetterCallbackType& getterCallback,
                        int groupIndex = -1);
 
     ~UInt64FilterParameter() override;

--- a/Source/SIMPLib/Geometry/EdgeGeom.cpp
+++ b/Source/SIMPLib/Geometry/EdgeGeom.cpp
@@ -311,7 +311,7 @@ void EdgeGeom::deleteElementNeighbors()
 // -----------------------------------------------------------------------------
 int EdgeGeom::findElementCentroids()
 {
-  QVector<size_t> cDims(1, 3);
+  std::vector<size_t> cDims(1, 3);
   m_EdgeCentroids = FloatArrayType::CreateArray(getNumberOfElements(), cDims, SIMPL::StringConstants::EdgeCentroids);
   GeometryHelpers::Topology::FindElementCentroids<size_t>(m_EdgeList, m_VertexList, m_EdgeCentroids);
   if(m_EdgeCentroids.get() == nullptr)

--- a/Source/SIMPLib/Geometry/GeometryHelpers.cpp
+++ b/Source/SIMPLib/Geometry/GeometryHelpers.cpp
@@ -98,7 +98,7 @@ int GeomIO::WriteListToHDF5(hid_t parentId, const IDataArray::Pointer& list)
   {
     return err;
   }
-  QVector<size_t> tDims(1, list->getNumberOfTuples());
+  std::vector<size_t> tDims(1, list->getNumberOfTuples());
   err = list->writeH5Data(parentId, tDims);
   return err;
 }

--- a/Source/SIMPLib/Geometry/HexahedralGeom.cpp
+++ b/Source/SIMPLib/Geometry/HexahedralGeom.cpp
@@ -333,7 +333,7 @@ void HexahedralGeom::deleteElementNeighbors()
 // -----------------------------------------------------------------------------
 int HexahedralGeom::findElementCentroids()
 {
-  QVector<size_t> cDims(1, 3);
+  std::vector<size_t> cDims(1, 3);
   m_HexCentroids = FloatArrayType::CreateArray(getNumberOfHexas(), cDims, SIMPL::StringConstants::HexCentroids);
   GeometryHelpers::Topology::FindElementCentroids<size_t>(m_HexList, m_VertexList, m_HexCentroids);
   if(m_HexCentroids.get() == nullptr)
@@ -373,7 +373,7 @@ void HexahedralGeom::deleteElementCentroids()
 // -----------------------------------------------------------------------------
 int HexahedralGeom::findElementSizes()
 {
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   size_t numHexs = getNumberOfHexas();
   m_HexSizes = FloatArrayType::CreateArray(numHexs, cDims, SIMPL::StringConstants::HexVolumes, (numHexs != 0));
   GeometryHelpers::Topology::FindHexVolumes<size_t>(m_HexList, m_VertexList, m_HexSizes);
@@ -413,7 +413,7 @@ void HexahedralGeom::deleteElementSizes()
 // -----------------------------------------------------------------------------
 int HexahedralGeom::findUnsharedEdges()
 {
-  QVector<size_t> cDims(1, 2);
+  std::vector<size_t> cDims(1, 2);
   m_UnsharedEdgeList = SharedEdgeList::CreateArray(0, cDims, SIMPL::Geometry::UnsharedEdgeList, false);
   GeometryHelpers::Connectivity::FindUnsharedHexEdges<size_t>(m_HexList, m_UnsharedEdgeList);
   if(m_UnsharedEdgeList.get() == nullptr)
@@ -452,7 +452,7 @@ void HexahedralGeom::deleteUnsharedEdges()
 // -----------------------------------------------------------------------------
 int HexahedralGeom::findUnsharedFaces()
 {
-  QVector<size_t> cDims(1, 4);
+  std::vector<size_t> cDims(1, 4);
   m_UnsharedQuadList = SharedQuadList::CreateArray(0, cDims, SIMPL::Geometry::UnsharedFaceList, false);
   GeometryHelpers::Connectivity::FindUnsharedHexFaces<size_t>(m_HexList, m_UnsharedQuadList);
   if(m_UnsharedQuadList.get() == nullptr)

--- a/Source/SIMPLib/Geometry/QuadGeom.cpp
+++ b/Source/SIMPLib/Geometry/QuadGeom.cpp
@@ -340,7 +340,7 @@ void QuadGeom::deleteElementNeighbors()
 // -----------------------------------------------------------------------------
 int QuadGeom::findElementCentroids()
 {
-  QVector<size_t> cDims(1, 3);
+  std::vector<size_t> cDims(1, 3);
   m_QuadCentroids = FloatArrayType::CreateArray(getNumberOfQuads(), cDims, SIMPL::StringConstants::QuadCentroids);
   GeometryHelpers::Topology::FindElementCentroids<size_t>(m_QuadList, m_VertexList, m_QuadCentroids);
   if(m_QuadCentroids.get() == nullptr)
@@ -379,7 +379,7 @@ void QuadGeom::deleteElementCentroids()
 // -----------------------------------------------------------------------------
 int QuadGeom::findElementSizes()
 {
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   m_QuadSizes = FloatArrayType::CreateArray(getNumberOfQuads(), cDims, SIMPL::StringConstants::QuadAreas);
   GeometryHelpers::Topology::Find2DElementAreas<size_t>(m_QuadList, m_VertexList, m_QuadSizes);
   if(m_QuadSizes.get() == nullptr)
@@ -418,7 +418,7 @@ void QuadGeom::deleteElementSizes()
 // -----------------------------------------------------------------------------
 int QuadGeom::findUnsharedEdges()
 {
-  QVector<size_t> cDims(1, 2);
+  std::vector<size_t> cDims(1, 2);
   m_UnsharedEdgeList = SharedEdgeList::CreateArray(0, cDims, SIMPL::Geometry::UnsharedEdgeList);
   GeometryHelpers::Connectivity::Find2DUnsharedEdges<size_t>(m_QuadList, m_UnsharedEdgeList);
   if(m_UnsharedEdgeList.get() == nullptr)

--- a/Source/SIMPLib/Geometry/SharedEdgeOps.cpp
+++ b/Source/SIMPLib/Geometry/SharedEdgeOps.cpp
@@ -38,7 +38,7 @@
 // -----------------------------------------------------------------------------
 SharedEdgeList::Pointer GEOM_CLASS_NAME::CreateSharedEdgeList(size_t numEdges, bool allocate)
 {
-  QVector<size_t> edgeDims(1, 2);
+  std::vector<size_t> edgeDims(1, 2);
   SharedEdgeList::Pointer edges = SharedEdgeList::CreateArray(numEdges, edgeDims, SIMPL::Geometry::SharedEdgeList, allocate);
   edges->initializeWithZeros();
   return edges;

--- a/Source/SIMPLib/Geometry/SharedHexOps.cpp
+++ b/Source/SIMPLib/Geometry/SharedHexOps.cpp
@@ -3,7 +3,7 @@
 // -----------------------------------------------------------------------------
 SharedHexList::Pointer GEOM_CLASS_NAME::CreateSharedHexList(size_t numHexas, bool allocate)
 {
-  QVector<size_t> hexDims(1, 8);
+  std::vector<size_t> hexDims(1, 8);
   SharedHexList::Pointer hexas = SharedHexList::CreateArray(numHexas, hexDims, SIMPL::Geometry::SharedHexList, allocate);
   hexas->initializeWithZeros();
   return hexas;

--- a/Source/SIMPLib/Geometry/SharedQuadOps.cpp
+++ b/Source/SIMPLib/Geometry/SharedQuadOps.cpp
@@ -38,7 +38,7 @@
 // -----------------------------------------------------------------------------
 SharedQuadList::Pointer GEOM_CLASS_NAME::CreateSharedQuadList(size_t numQuads, bool allocate)
 {
-  QVector<size_t> quadDims(1, 4);
+  std::vector<size_t> quadDims(1, 4);
   SharedQuadList::Pointer quads = SharedEdgeList::CreateArray(numQuads, quadDims, SIMPL::Geometry::SharedQuadList, allocate);
   quads->initializeWithZeros();
   return quads;

--- a/Source/SIMPLib/Geometry/SharedTetOps.cpp
+++ b/Source/SIMPLib/Geometry/SharedTetOps.cpp
@@ -38,7 +38,7 @@
 // -----------------------------------------------------------------------------
 SharedTetList::Pointer GEOM_CLASS_NAME::CreateSharedTetList(size_t numTets, bool allocate)
 {
-  QVector<size_t> tetDims(1, 4);
+  std::vector<size_t> tetDims(1, 4);
   SharedTetList::Pointer tets = SharedTetList::CreateArray(numTets, tetDims, SIMPL::Geometry::SharedTetList, allocate);
   tets->initializeWithZeros();
   return tets;

--- a/Source/SIMPLib/Geometry/SharedTriOps.cpp
+++ b/Source/SIMPLib/Geometry/SharedTriOps.cpp
@@ -38,7 +38,7 @@
 // -----------------------------------------------------------------------------
 SharedTriList::Pointer GEOM_CLASS_NAME::CreateSharedTriList(size_t numTris, bool allocate)
 {
-  QVector<size_t> triDims(1, 3);
+  std::vector<size_t> triDims(1, 3);
   SharedTriList::Pointer triangles = SharedTriList::CreateArray(numTris, triDims, SIMPL::Geometry::SharedTriList, allocate);
   triangles->initializeWithZeros();
   return triangles;

--- a/Source/SIMPLib/Geometry/SharedVertexOps.cpp
+++ b/Source/SIMPLib/Geometry/SharedVertexOps.cpp
@@ -38,7 +38,7 @@
 // -----------------------------------------------------------------------------
 SharedVertexList::Pointer GEOM_CLASS_NAME::CreateSharedVertexList(size_t numVertices, bool allocate)
 {
-  QVector<size_t> vertDims(1, 3);
+  std::vector<size_t> vertDims = {3};
   SharedVertexList::Pointer vertices = SharedVertexList::CreateArray(numVertices, vertDims, SIMPL::Geometry::SharedVertexList, allocate);
   vertices->initializeWithZeros();
   return vertices;

--- a/Source/SIMPLib/Geometry/TetrahedralGeom.cpp
+++ b/Source/SIMPLib/Geometry/TetrahedralGeom.cpp
@@ -368,7 +368,7 @@ void TetrahedralGeom::deleteElementNeighbors()
 // -----------------------------------------------------------------------------
 int TetrahedralGeom::findElementCentroids()
 {
-  QVector<size_t> cDims(1, 3);
+  std::vector<size_t> cDims(1, 3);
   m_TetCentroids = FloatArrayType::CreateArray(getNumberOfTets(), cDims, SIMPL::StringConstants::TetCentroids);
   GeometryHelpers::Topology::FindElementCentroids<size_t>(m_TetList, m_VertexList, m_TetCentroids);
   if(m_TetCentroids.get() == nullptr)
@@ -408,7 +408,7 @@ void TetrahedralGeom::deleteElementCentroids()
 // -----------------------------------------------------------------------------
 int TetrahedralGeom::findElementSizes()
 {
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   m_TetSizes = FloatArrayType::CreateArray(getNumberOfTets(), cDims, SIMPL::StringConstants::TetVolumes);
   GeometryHelpers::Topology::FindTetVolumes<size_t>(m_TetList, m_VertexList, m_TetSizes);
   if(m_TetSizes.get() == nullptr)
@@ -447,7 +447,7 @@ void TetrahedralGeom::deleteElementSizes()
 // -----------------------------------------------------------------------------
 int TetrahedralGeom::findUnsharedEdges()
 {
-  QVector<size_t> cDims(1, 2);
+  std::vector<size_t> cDims(1, 2);
   m_UnsharedEdgeList = SharedEdgeList::CreateArray(0, cDims, SIMPL::Geometry::UnsharedEdgeList);
   GeometryHelpers::Connectivity::FindUnsharedTetEdges<size_t>(m_TetList, m_UnsharedEdgeList);
   if(m_UnsharedEdgeList.get() == nullptr)
@@ -486,7 +486,7 @@ void TetrahedralGeom::deleteUnsharedEdges()
 // -----------------------------------------------------------------------------
 int TetrahedralGeom::findUnsharedFaces()
 {
-  QVector<size_t> cDims(1, 3);
+  std::vector<size_t> cDims(1, 3);
   m_UnsharedTriList = SharedTriList::CreateArray(0, cDims, SIMPL::Geometry::UnsharedFaceList);
   GeometryHelpers::Connectivity::FindUnsharedTetFaces<size_t>(m_TetList, m_UnsharedTriList);
   if(m_UnsharedTriList.get() == nullptr)

--- a/Source/SIMPLib/Geometry/TriangleGeom.cpp
+++ b/Source/SIMPLib/Geometry/TriangleGeom.cpp
@@ -339,7 +339,7 @@ void TriangleGeom::deleteElementNeighbors()
 // -----------------------------------------------------------------------------
 int TriangleGeom::findElementCentroids()
 {
-  QVector<size_t> cDims(1, 3);
+  std::vector<size_t> cDims(1, 3);
   m_TriangleCentroids = FloatArrayType::CreateArray(getNumberOfTris(), cDims, SIMPL::StringConstants::TriangleCentroids);
   GeometryHelpers::Topology::FindElementCentroids<size_t>(m_TriList, m_VertexList, m_TriangleCentroids);
   if(m_TriangleCentroids.get() == nullptr)
@@ -378,7 +378,7 @@ void TriangleGeom::deleteElementCentroids()
 // -----------------------------------------------------------------------------
 int TriangleGeom::findElementSizes()
 {
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   m_TriangleSizes = FloatArrayType::CreateArray(getNumberOfTris(), cDims, SIMPL::StringConstants::TriangleAreas);
   GeometryHelpers::Topology::Find2DElementAreas<size_t>(m_TriList, m_VertexList, m_TriangleSizes);
   if(m_TriangleSizes.get() == nullptr)
@@ -417,7 +417,7 @@ void TriangleGeom::deleteElementSizes()
 // -----------------------------------------------------------------------------
 int TriangleGeom::findUnsharedEdges()
 {
-  QVector<size_t> cDims(1, 2);
+  std::vector<size_t> cDims(1, 2);
   m_UnsharedEdgeList = SharedEdgeList::CreateArray(0, cDims, SIMPL::Geometry::UnsharedEdgeList);
   GeometryHelpers::Connectivity::Find2DUnsharedEdges<size_t>(m_TriList, m_UnsharedEdgeList);
   if(m_UnsharedEdgeList.get() == nullptr)

--- a/Source/SIMPLib/Geometry/VertexGeom.cpp
+++ b/Source/SIMPLib/Geometry/VertexGeom.cpp
@@ -305,7 +305,7 @@ void VertexGeom::findDerivatives(DoubleArrayType::Pointer field, DoubleArrayType
 int VertexGeom::writeGeometryToHDF5(hid_t parentId, bool writeXdmf)
 {
   herr_t err = 0;
-  QVector<size_t> tDims(1, 0);
+  std::vector<size_t> tDims(1, 0);
 
   if(m_VertexList.get() != nullptr)
   {
@@ -316,7 +316,7 @@ int VertexGeom::writeGeometryToHDF5(hid_t parentId, bool writeXdmf)
     }
     if(writeXdmf)
     {
-      QVector<size_t> cDims(1, 1);
+      std::vector<size_t> cDims(1, 1);
       DataArray<size_t>::Pointer vertsPtr = DataArray<size_t>::CreateArray(getNumberOfVertices(), cDims, SIMPL::StringConstants::VertsName);
       size_t* verts = vertsPtr->getPointer(0);
       for(size_t i = 0; i < vertsPtr->getNumberOfTuples(); i++)

--- a/Source/SIMPLib/HDF5/H5DataArrayReader.cpp
+++ b/Source/SIMPLib/HDF5/H5DataArrayReader.cpp
@@ -61,7 +61,8 @@ namespace Detail
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-template <typename T> IDataArray::Pointer readH5Dataset(hid_t locId, const QString& datasetPath, const QVector<size_t>& tDims, const QVector<size_t>& cDims)
+template <typename T>
+IDataArray::Pointer readH5Dataset(hid_t locId, const QString& datasetPath, const std::vector<size_t>& tDims, const std::vector<size_t>& cDims)
 {
   herr_t err = -1;
   IDataArray::Pointer ptr;
@@ -82,7 +83,7 @@ template <typename T> IDataArray::Pointer readH5Dataset(hid_t locId, const QStri
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-int H5DataArrayReader::ReadRequiredAttributes(hid_t gid, const QString& name, QString& objType, int& version, QVector<size_t>& tDims, QVector<size_t>& cDims)
+int H5DataArrayReader::ReadRequiredAttributes(hid_t gid, const QString& name, QString& objType, int& version, std::vector<size_t>& tDims, std::vector<size_t>& cDims)
 {
   int err = 0;
   int retErr = 0;
@@ -128,7 +129,6 @@ IDataArray::Pointer H5DataArrayReader::ReadStringDataArray(hid_t gid, const QStr
   hid_t typeId = -1;
   H5T_class_t attr_type;
   size_t attr_size;
-  QString res;
 
   QVector<hsize_t> dims; // Reusable for the loop
   IDataArray::Pointer ptr = IDataArray::NullPointer();
@@ -148,8 +148,8 @@ IDataArray::Pointer H5DataArrayReader::ReadStringDataArray(hid_t gid, const QStr
 
   QString classType;
   int version = 0;
-  QVector<size_t> tDims;
-  QVector<size_t> cDims;
+  std::vector<size_t> tDims;
+  std::vector<size_t> cDims;
 
   err = ReadRequiredAttributes(gid, name, classType, version, tDims, cDims);
   if(err < 0)
@@ -223,8 +223,8 @@ IDataArray::Pointer H5DataArrayReader::ReadIDataArray(hid_t gid, const QString& 
   {
     QString classType;
     int version = 0;
-    QVector<size_t> tDims;
-    QVector<size_t> cDims;
+    std::vector<size_t> tDims;
+    std::vector<size_t> cDims;
 
     err = ReadRequiredAttributes(gid, name, classType, version, tDims, cDims);
     if(err < 0)
@@ -413,8 +413,8 @@ IDataArray::Pointer H5DataArrayReader::ReadNeighborListData(hid_t gid, const QSt
   {
     QString classType;
     int version = 0;
-    QVector<size_t> tDims;
-    QVector<size_t> cDims;
+    std::vector<size_t> tDims;
+    std::vector<size_t> cDims;
 
     err = ReadRequiredAttributes(gid, name, classType, version, tDims, cDims);
     if(err < 0)

--- a/Source/SIMPLib/HDF5/H5DataArrayReader.h
+++ b/Source/SIMPLib/HDF5/H5DataArrayReader.h
@@ -65,7 +65,7 @@ class SIMPLib_EXPORT H5DataArrayReader
      * @param cDims The Component Dimensions of the data array
      * @return
      */
-    static int ReadRequiredAttributes(hid_t gid, const QString& name, QString& objType, int& version, QVector<size_t>& tDims, QVector<size_t>& cDims);
+    static int ReadRequiredAttributes(hid_t gid, const QString& name, QString& objType, int& version, std::vector<size_t>& tDims, std::vector<size_t>& cDims);
 
     /**
      * @brief ReadIDataArray Reads an IDataArray subclass from the HDF5 file

--- a/Source/SIMPLib/HDF5/H5DataArrayWriter.hpp
+++ b/Source/SIMPLib/HDF5/H5DataArrayWriter.hpp
@@ -66,8 +66,8 @@ class H5DataArrayWriter
      * @param cDims
      * @return
      */
-    template<typename IDataArrayType>
-    static int writeDataArrayAttributes(hid_t gid, IDataArrayType* dataArray, QVector<size_t> tDims, QVector<size_t> cDims)
+    template <typename IDataArrayType>
+    static int writeDataArrayAttributes(hid_t gid, IDataArrayType* dataArray, std::vector<size_t> tDims, std::vector<size_t> cDims)
     {
       int err = QH5Lite::writeScalarAttribute(gid, dataArray->getName(), SIMPL::HDF5::DataArrayVersion, dataArray->getClassVersion());
       if(err < 0)
@@ -115,12 +115,12 @@ class H5DataArrayWriter
      * @param tDims
      * @return
      */
-    template<class T>
-    static int writeDataArray(hid_t gid, T* dataArray, QVector<size_t> tDims)
+    template <class T>
+    static int writeDataArray(hid_t gid, T* dataArray, std::vector<size_t> tDims)
     {
       int err = 0;
 
-      QVector<size_t> cDims = dataArray->getComponentDimensions();
+      std::vector<size_t> cDims = dataArray->getComponentDimensions();
       hsize_t h5Rank = static_cast<hsize_t>(tDims.size()) + cDims.size();
 
       QVector<hsize_t> h5Dims(tDims.size() + cDims.size());
@@ -205,8 +205,8 @@ class H5DataArrayWriter
       }
 
       err = H5Lite::writeVectorOfStringsDataset(gid, dataArray->getName().toStdString(), data);
-      QVector<size_t> tDims(1, dataArray->getNumberOfTuples());
-      QVector<size_t> cDims(1, 1);
+      std::vector<size_t> tDims(1, dataArray->getNumberOfTuples());
+      std::vector<size_t> cDims(1, 1);
       err = writeDataArrayAttributes<T>(gid, dataArray, tDims, cDims);
 
       return err;

--- a/Source/SIMPLib/HDF5/H5PrecipitateStatsDataDelegate.cpp
+++ b/Source/SIMPLib/HDF5/H5PrecipitateStatsDataDelegate.cpp
@@ -285,7 +285,7 @@ int H5PrecipitateStatsDataDelegate::writePrecipitateStatsData(PrecipitateStatsDa
   // Write the Misorientation Bins
   if(nullptr != data->getMisorientationBins().get())
   {
-    QVector<size_t> tDims(1, data->getMisorientationBins()->getNumberOfTuples());
+    std::vector<size_t> tDims(1, data->getMisorientationBins()->getNumberOfTuples());
     err = data->getMisorientationBins()->writeH5Data(groupId, tDims);
   }
 
@@ -294,7 +294,7 @@ int H5PrecipitateStatsDataDelegate::writePrecipitateStatsData(PrecipitateStatsDa
   // Write the ODF
   if(nullptr != data->getODF().get())
   {
-    QVector<size_t> tDims(1, data->getODF()->getNumberOfTuples());
+    std::vector<size_t> tDims(1, data->getODF()->getNumberOfTuples());
     err = data->getODF()->writeH5Data(groupId, tDims);
   }
   err = writeWeightsData(groupId, SIMPL::StringConstants::ODFWeights, data->getODF_Weights());
@@ -302,7 +302,7 @@ int H5PrecipitateStatsDataDelegate::writePrecipitateStatsData(PrecipitateStatsDa
   // Write the Axis ODF
   if(nullptr != data->getAxisOrientation().get())
   {
-    QVector<size_t> tDims(1, data->getAxisOrientation()->getNumberOfTuples());
+    std::vector<size_t> tDims(1, data->getAxisOrientation()->getNumberOfTuples());
     err = data->getAxisOrientation()->writeH5Data(groupId, tDims);
   }
   err = writeWeightsData(groupId, SIMPL::StringConstants::AxisODFWeights, data->getAxisODF_Weights());
@@ -326,7 +326,7 @@ int H5PrecipitateStatsDataDelegate::writeVectorOfArrays(hid_t pid, VectorOfFloat
     err = -1;
     if(nullptr != colData[c] && colData[c]->getSize() > 0)
     {
-      QVector<size_t> tDims(1, colData[c]->getNumberOfTuples());
+      std::vector<size_t> tDims(1, colData[c]->getNumberOfTuples());
       err = colData[c]->writeH5Data(pid, tDims);
       if(err < 0)
       {
@@ -371,7 +371,7 @@ int H5PrecipitateStatsDataDelegate::readVectorOfArrays(hid_t pid, VectorOfFloatA
 int H5PrecipitateStatsDataDelegate::readMDFWeights(hid_t pid, PrecipitateStatsData* data)
 {
   int err = 0;
-  QVector<size_t> dims(1, 1);
+  std::vector<size_t> dims(1, 1);
   FloatArrayType::Pointer angles = FloatArrayType::CreateArray(1, dims, SIMPL::StringConstants::Angle);
   FloatArrayType::Pointer weight = FloatArrayType::CreateArray(1, SIMPL::StringConstants::Weight);
   dims[0] = 3;
@@ -813,7 +813,7 @@ int H5PrecipitateStatsDataDelegate::writeBinNumbers(PrecipitateStatsData* data, 
   {
     data->generateBinNumbers();
   }
-  QVector<size_t> tDims(1, data->getBinNumbers()->getNumberOfTuples());
+  std::vector<size_t> tDims(1, data->getBinNumbers()->getNumberOfTuples());
   return data->getBinNumbers()->writeH5Data(groupId, tDims);
 }
 

--- a/Source/SIMPLib/HDF5/H5PrimaryStatsDataDelegate.cpp
+++ b/Source/SIMPLib/HDF5/H5PrimaryStatsDataDelegate.cpp
@@ -244,7 +244,7 @@ int H5PrimaryStatsDataDelegate::writePrimaryStatsData(PrimaryStatsData* data, hi
   // Write the Misorientation Bins
   if(nullptr != data->getMisorientationBins().get())
   {
-    QVector<size_t> tDims(1, data->getMisorientationBins()->getNumberOfTuples());
+    std::vector<size_t> tDims(1, data->getMisorientationBins()->getNumberOfTuples());
     err = data->getMisorientationBins()->writeH5Data(groupId, tDims);
   }
 
@@ -253,7 +253,7 @@ int H5PrimaryStatsDataDelegate::writePrimaryStatsData(PrimaryStatsData* data, hi
   // Write the ODF
   if(nullptr != data->getODF().get())
   {
-    QVector<size_t> tDims(1, data->getODF()->getNumberOfTuples());
+    std::vector<size_t> tDims(1, data->getODF()->getNumberOfTuples());
     err = data->getODF()->writeH5Data(groupId, tDims);
   }
   err = writeWeightsData(groupId, SIMPL::StringConstants::ODFWeights, data->getODF_Weights());
@@ -261,7 +261,7 @@ int H5PrimaryStatsDataDelegate::writePrimaryStatsData(PrimaryStatsData* data, hi
   // Write the Axis ODF
   if(nullptr != data->getAxisOrientation().get())
   {
-    QVector<size_t> tDims(1, data->getAxisOrientation()->getNumberOfTuples());
+    std::vector<size_t> tDims(1, data->getAxisOrientation()->getNumberOfTuples());
     err = data->getAxisOrientation()->writeH5Data(groupId, tDims);
   }
   err = writeWeightsData(groupId, SIMPL::StringConstants::AxisODFWeights, data->getAxisODF_Weights());
@@ -285,7 +285,7 @@ int H5PrimaryStatsDataDelegate::writeVectorOfArrays(hid_t pid, VectorOfFloatArra
     err = -1;
     if(nullptr != colData[c] && colData[c]->getSize() > 0)
     {
-      QVector<size_t> tDims(1, colData[c]->getNumberOfTuples());
+      std::vector<size_t> tDims(1, colData[c]->getNumberOfTuples());
       err = colData[c]->writeH5Data(pid, tDims);
       if(err < 0)
       {
@@ -330,7 +330,7 @@ int H5PrimaryStatsDataDelegate::readVectorOfArrays(hid_t pid, VectorOfFloatArray
 int H5PrimaryStatsDataDelegate::readMDFWeights(hid_t pid, PrimaryStatsData* data)
 {
   int err = 0;
-  QVector<size_t> dims(1, 1);
+  std::vector<size_t> dims(1, 1);
   FloatArrayType::Pointer angles = FloatArrayType::CreateArray(1, dims, SIMPL::StringConstants::Angle);
   FloatArrayType::Pointer weight = FloatArrayType::CreateArray(1, SIMPL::StringConstants::Weight);
   dims[0] = 3;
@@ -629,7 +629,7 @@ int H5PrimaryStatsDataDelegate::writeBinNumbers(PrimaryStatsData* data, hid_t gr
   {
     data->generateBinNumbers();
   }
-  QVector<size_t> tDims(1, data->getBinNumbers()->getNumberOfTuples());
+  std::vector<size_t> tDims(1, data->getBinNumbers()->getNumberOfTuples());
   return data->getBinNumbers()->writeH5Data(groupId, tDims);
 }
 

--- a/Source/SIMPLib/HDF5/H5TransformationStatsDataDelegate.cpp
+++ b/Source/SIMPLib/HDF5/H5TransformationStatsDataDelegate.cpp
@@ -238,7 +238,7 @@ int H5TransformationStatsDataDelegate::writeTransformationStatsData(Transformati
   // Write the Misorientation Bins
   if(nullptr != data->getMisorientationBins().get())
   {
-    QVector<size_t> tDims(1, data->getMisorientationBins()->getNumberOfTuples());
+    std::vector<size_t> tDims(1, data->getMisorientationBins()->getNumberOfTuples());
     err = data->getMisorientationBins()->writeH5Data(groupId, tDims);
   }
 
@@ -247,7 +247,7 @@ int H5TransformationStatsDataDelegate::writeTransformationStatsData(Transformati
   // Write the ODF
   if(nullptr != data->getODF().get())
   {
-    QVector<size_t> tDims(1, data->getODF()->getNumberOfTuples());
+    std::vector<size_t> tDims(1, data->getODF()->getNumberOfTuples());
     err = data->getODF()->writeH5Data(groupId, tDims);
   }
   err = writeWeightsData(groupId, SIMPL::StringConstants::ODFWeights, data->getODF_Weights());
@@ -255,7 +255,7 @@ int H5TransformationStatsDataDelegate::writeTransformationStatsData(Transformati
   // Write the Axis ODF
   if(nullptr != data->getAxisOrientation().get())
   {
-    QVector<size_t> tDims(1, data->getAxisOrientation()->getNumberOfTuples());
+    std::vector<size_t> tDims(1, data->getAxisOrientation()->getNumberOfTuples());
     err = data->getAxisOrientation()->writeH5Data(groupId, tDims);
   }
   err = writeWeightsData(groupId, SIMPL::StringConstants::AxisODFWeights, data->getAxisODF_Weights());
@@ -279,7 +279,7 @@ int H5TransformationStatsDataDelegate::writeVectorOfArrays(hid_t pid, VectorOfFl
     err = -1;
     if(nullptr != colData[c] && colData[c]->getSize() > 0)
     {
-      QVector<size_t> tDims(1, colData[c]->getNumberOfTuples());
+      std::vector<size_t> tDims(1, colData[c]->getNumberOfTuples());
       err = colData[c]->writeH5Data(pid, tDims);
       if(err < 0)
       {
@@ -324,7 +324,7 @@ int H5TransformationStatsDataDelegate::readVectorOfArrays(hid_t pid, VectorOfFlo
 int H5TransformationStatsDataDelegate::readMDFWeights(hid_t pid, TransformationStatsData* data)
 {
   int err = 0;
-  QVector<size_t> dims(1, 1);
+  std::vector<size_t> dims(1, 1);
   FloatArrayType::Pointer angles = FloatArrayType::CreateArray(1, dims, SIMPL::StringConstants::Angle);
   FloatArrayType::Pointer weight = FloatArrayType::CreateArray(1, SIMPL::StringConstants::Weight);
   dims[0] = 3;
@@ -639,7 +639,7 @@ int H5TransformationStatsDataDelegate::writeBinNumbers(TransformationStatsData* 
   {
     data->generateBinNumbers();
   }
-  QVector<size_t> tDims(1, data->getBinNumbers()->getNumberOfTuples());
+  std::vector<size_t> tDims(1, data->getBinNumbers()->getNumberOfTuples());
   return data->getBinNumbers()->writeH5Data(groupId, tDims);
 }
 

--- a/Source/SIMPLib/ITK/Dream3DTemplateAliasMacro.h
+++ b/Source/SIMPLib/ITK/Dream3DTemplateAliasMacro.h
@@ -182,7 +182,7 @@
 
 // Select vector, RGB/RGBA, or scalar images
 #define Dream3DTemplateAliasMacroPixelType(typeIN, typeOUT, call, errorCondition, isTypeOUT, typeOUTTypename, dimension)                                                                               \
-  QVector<size_t> cDims = ptr->getComponentDimensions();                                                                                                                                               \
+  std::vector<size_t> cDims = ptr->getComponentDimensions();                                                                                                                                           \
   if(cDims.size() > 1)                                                                                                                                                                                 \
   {                                                                                                                                                                                                    \
     Dream3DTemplateAliasMacroCaseVectorImage0(typeIN, typeOUT, call, errorCondition, isTypeOUT, typeOUTTypename, dimension, DREAM3D_USE_Vector);                                                       \
@@ -329,7 +329,7 @@
       ImageGeom::Pointer imageGeometry = getDataContainerArray()->getPrereqGeometryFromDataContainer<ImageGeom, AbstractFilter>(this, path.getDataContainerName());                                    \
       if(nullptr != imageGeometry)                                                                                                                                                                     \
       {                                                                                                                                                                                                \
-        QVector<size_t> tDims = imageGeometry->getDimensions().toContainer<QVector<size_t>>();                                                                                                         \
+        std::vector<size_t> tDims = imageGeometry->getDimensions().toContainer<std::vector<size_t>>();                                                                                                     \
         if(getErrorCode() >= 0)                                                                                                                                                                        \
         {                                                                                                                                                                                              \
           QString type = ptr->getTypeAsString();                                                                                                                                                       \
@@ -426,7 +426,7 @@
       ImageGeom::Pointer imageGeometry = getDataContainerArray()->getPrereqGeometryFromDataContainer<ImageGeom, AbstractFilter>(this, input2_path.getDataContainerName());                             \
       if(imageGeometry.get() != nullptr)                                                                                                                                                               \
       {                                                                                                                                                                                                \
-        QVector<size_t> tDims(3, 0);                                                                                                                                                                   \
+        std::vector<size_t> tDims(3, 0);                                                                                                                                                               \
         std::tie(tDims[0], tDims[1], tDims[2]) = imageGeometry->getDimensions();                                                                                                                       \
         if(getErrorCode() >= 0)                                                                                                                                                                        \
         {                                                                                                                                                                                              \

--- a/Source/SIMPLib/ITK/itkBridge.h
+++ b/Source/SIMPLib/ITK/itkBridge.h
@@ -54,19 +54,16 @@
 template <typename T, typename K, typename ItkOutPixelType> class Dream3DToItkImageConversion
 {
 public:
-  Dream3DToItkImageConversion()
-  {
-  }
-  virtual ~Dream3DToItkImageConversion()
-  {
-  }
+  Dream3DToItkImageConversion() = default;
+
+  virtual ~Dream3DToItkImageConversion() = default;
 
   /// Itk ImportImage Filter Types
-  typedef itk::ImportImageFilter<K, ImageProcessingConstants::ImageDimension> ItkImportImageFilterType;
-  typedef typename ItkImportImageFilterType::Pointer ItkImportImageFilterPointerType;
+  using ItkImportImageFilterType = itk::ImportImageFilter<K, ImageProcessingConstants::ImageDimension>;
+  using ItkImportImageFilterPointerType = typename ItkImportImageFilterType::Pointer;
 
-  typedef typename itk::Image<ItkOutPixelType, ImageProcessingConstants::ImageDimension> ItkImageOutType; // 3D RGB Image
-  typedef typename ItkImageOutType::Pointer ItkImageOutPointerType;
+  using ItkImageOutType = typename itk::Image<ItkOutPixelType, ImageProcessingConstants::ImageDimension>; // 3D RGB Image
+  using ItkImageOutPointerType = typename ItkImageOutType::Pointer;
 
   /**
    * @brief operator ()
@@ -80,7 +77,7 @@ public:
     AttributeMatrix::Pointer attrMat = m->getAttributeMatrix(attrMatName);
 
     // get size+dimensions of dataset
-    QVector<size_t> udims = attrMat->getTupleDimensions();
+    std::vector<size_t> udims = attrMat->getTupleDimensions();
     size_t totalPoints = attrMat->getNumberOfTuples();
 
     // create and setup import filter
@@ -157,7 +154,7 @@ class ItkBridge2
       AttributeMatrix::Pointer attrMat = m->getAttributeMatrix(attrMatName);
 
       //get size+dimensions of dataset
-      QVector<size_t> udims = attrMat->getTupleDimensions();
+      std::vector<size_t> udims = attrMat->getTupleDimensions();
       size_t totalPoints = attrMat->getNumberOfTuples();
 
       //create and setup import filter
@@ -223,7 +220,7 @@ public:
     AttributeMatrix::Pointer attrMat = m->getAttributeMatrix(attrMatName);
 
     // get size+dimensions of dataset
-    QVector<size_t> udims = attrMat->getTupleDimensions();
+    std::vector<size_t> udims = attrMat->getTupleDimensions();
     size_t totalPoints = attrMat->getNumberOfTuples();
 
     // create and setup import filter
@@ -327,7 +324,7 @@ public:
     AttributeMatrix::Pointer attrMat = m->getAttributeMatrix(attrMatName);
 
     // get size+dimensions of dataset
-    QVector<size_t> udims = attrMat->getTupleDimensions();
+    std::vector<size_t> udims = attrMat->getTupleDimensions();
     size_t totalPoints = attrMat->getNumberOfTuples();
 
     // create and setup import filter

--- a/Source/SIMPLib/ITK/itkGetComponentsDimensions.h
+++ b/Source/SIMPLib/ITK/itkGetComponentsDimensions.h
@@ -1,6 +1,38 @@
+/* ============================================================================
+ * Copyright (c) 2019 BlueQuartz Software, LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the names of any of the BlueQuartz Software contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 #pragma once
 
-#include <QVector>
+#include <vector>
+
 #include <itkRGBAPixel.h>
 #include <itkRGBPixel.h>
 #include <itkVector.h>
@@ -8,43 +40,50 @@
 namespace ITKDream3DHelper
 {
 
-template <class PixelType> QVector<size_t> GetComponentsDimensions_impl(PixelType*)
+template <class PixelType>
+std::vector<size_t> GetComponentsDimensions_impl(PixelType*)
 {
-  QVector<size_t> cDims(1, 1);
+  std::vector<size_t> cDims(1, 1);
   return cDims;
 }
 
-template <class PixelType> QVector<size_t> GetComponentsDimensions_impl(itk::Vector<PixelType, 36>*)
+template <class PixelType>
+std::vector<size_t> GetComponentsDimensions_impl(itk::Vector<PixelType, 36>*)
 {
-  QVector<size_t> cDims(36, 1);
+  std::vector<size_t> cDims(36, 1);
   return cDims;
 }
 
-template <class PixelType> QVector<size_t> GetComponentsDimensions_impl(itk::Vector<PixelType, 3>*)
+template <class PixelType>
+std::vector<size_t> GetComponentsDimensions_impl(itk::Vector<PixelType, 3>*)
 {
-  QVector<size_t> cDims(3, 1);
+  std::vector<size_t> cDims(3, 1);
   return cDims;
 }
 
-template <class PixelType> QVector<size_t> GetComponentsDimensions_impl(itk::Vector<PixelType, 2>*)
+template <class PixelType>
+std::vector<size_t> GetComponentsDimensions_impl(itk::Vector<PixelType, 2>*)
 {
-  QVector<size_t> cDims(2, 1);
+  std::vector<size_t> cDims(2, 1);
   return cDims;
 }
 
-template <class PixelType> QVector<size_t> GetComponentsDimensions_impl(itk::RGBPixel<PixelType>*)
+template <class PixelType>
+std::vector<size_t> GetComponentsDimensions_impl(itk::RGBPixel<PixelType>*)
 {
-  QVector<size_t> cDims(1, 3);
+  std::vector<size_t> cDims(1, 3);
   return cDims;
 }
 
-template <class PixelType> QVector<size_t> GetComponentsDimensions_impl(itk::RGBAPixel<PixelType>*)
+template <class PixelType>
+std::vector<size_t> GetComponentsDimensions_impl(itk::RGBAPixel<PixelType>*)
 {
-  QVector<size_t> cDims(1, 4);
+  std::vector<size_t> cDims(1, 4);
   return cDims;
 }
 
-template <class PixelType> QVector<size_t> GetComponentsDimensions()
+template <class PixelType>
+std::vector<size_t> GetComponentsDimensions()
 {
   return GetComponentsDimensions_impl(static_cast<PixelType*>(0));
 }

--- a/Source/SIMPLib/ITK/itkImageReaderHelper.cpp
+++ b/Source/SIMPLib/ITK/itkImageReaderHelper.cpp
@@ -266,8 +266,8 @@ ITK_IMAGE_READER_CLASS_NAME
   image->setSpacing(tspacing);
   container->setGeometry(image);
 
-  QVector<size_t> cDims = ITKDream3DHelper::GetComponentsDimensions<TPixel>();
-  QVector<size_t> qTdims = {tDims[0], tDims[1], tDims[2]};
+  std::vector<size_t> cDims = ITKDream3DHelper::GetComponentsDimensions<TPixel>();
+  std::vector<size_t> qTdims = {tDims[0], tDims[1], tDims[2]};
   AttributeMatrix::Pointer cellAttrMat = container->createNonPrereqAttributeMatrix(this, dataArrayPath.getAttributeMatrixName(), qTdims, AttributeMatrix::Type::Cell);
   if(getErrorCode() < 0)
   {

--- a/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.hxx
+++ b/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.hxx
@@ -73,7 +73,7 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   //float tol = 0.000001;
   QVector<float> torigin(3, 0);
   QVector<float> tspacing(3, 1);
-  QVector<size_t> tDims(3, 1);
+  std::vector<size_t> tDims(3, 1);
   // Get Input image properties
   ImagePointer inputPtr = dynamic_cast<ImageType*>(this->GetInput(0));
   typename ImageType::PointType origin = inputPtr->GetOrigin();
@@ -119,10 +119,10 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   DataContainer::Pointer dataContainer = outputPtr->Get();
   ImagePointer inputPtr = dynamic_cast<ImageType*>(this->GetInput(0));
   // Create data array
-  QVector<size_t> cDims = ITKDream3DHelper::GetComponentsDimensions<PixelType>();
+  std::vector<size_t> cDims = ITKDream3DHelper::GetComponentsDimensions<PixelType>();
   IGeometry::Pointer geom = dataContainer->getGeometry();
   ImageGeom::Pointer imageGeom = std::dynamic_pointer_cast<ImageGeom>(geom);
-  QVector<size_t> tDims = imageGeom->getDimensions().toContainer<QVector<size_t>>();
+  std::vector<size_t> tDims = imageGeom->getDimensions().toContainer<std::vector<size_t>>();
 
   AttributeMatrix::Pointer attrMat;
   if( dataContainer->doesAttributeMatrixExist(m_AttributeMatrixArrayName.c_str()))
@@ -135,7 +135,7 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
 	}
 	// Check that if size does not match, there are no other data array than the one we expect.
 	// That makes it possible to modify the attribute matrix without having to worry.
-	QVector<size_t> matDims = attrMat->getTupleDimensions();
+	std::vector<size_t> matDims = attrMat->getTupleDimensions();
 	if (matDims != tDims)
 	{
     if (! ((attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()) && attrMat->getNumAttributeArrays() == 1)

--- a/Source/SIMPLib/TestFilters/MakeDataContainer.cpp
+++ b/Source/SIMPLib/TestFilters/MakeDataContainer.cpp
@@ -113,7 +113,7 @@ void MakeDataContainer::dataCheck()
   {
     return;
   }
-  QVector<size_t> tDims(3, 64);
+  std::vector<size_t> tDims(3, 64);
   AttributeMatrix::Pointer cellAttrMat = m->createNonPrereqAttributeMatrix(this, getCellAttributeMatrixName(), tDims, AttributeMatrix::Type::Cell);
   if(getErrorCode() < 0)
   {
@@ -127,7 +127,7 @@ void MakeDataContainer::dataCheck()
   //    return;
   //  }
 
-  QVector<size_t> dims(1, 1);
+  std::vector<size_t> dims(1, 1);
   m_FeatureIdsPtr =
       cellAttrMat->createNonPrereqArray<DataArray<int32_t>, AbstractFilter, int32_t>(this, m_FeatureIdsArrayName, 0, dims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */
   if(nullptr != m_FeatureIdsPtr.lock()) /* Validate the Weak Pointer wraps a non-nullptr pointer to a DataArray<T> object */

--- a/Source/SIMPLib/Utilities/SIMPLH5DataReaderRequirements.cpp
+++ b/Source/SIMPLib/Utilities/SIMPLH5DataReaderRequirements.cpp
@@ -51,7 +51,7 @@ SIMPLH5DataReaderRequirements::SIMPLH5DataReaderRequirements(const QString &prim
   }
   if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
   {
-    m_ComponentDimensions = QVector<QVector<size_t> >(1, QVector<size_t>(1, allowedCompDim));
+    m_ComponentDimensions = std::vector<std::vector<size_t>>(1, std::vector<size_t>(1, allowedCompDim));
   }
   if(AttributeMatrix::Type::Any != attributeMatrixType)
   {

--- a/Source/SIMPLib/Utilities/SIMPLH5DataReaderRequirements.h
+++ b/Source/SIMPLib/Utilities/SIMPLH5DataReaderRequirements.h
@@ -32,6 +32,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "SIMPLib/SIMPLib.h"
 
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
@@ -52,7 +54,7 @@ class SIMPLib_EXPORT SIMPLH5DataReaderRequirements
     
     virtual ~SIMPLH5DataReaderRequirements();
 
-    using QVectorSizeT = QVector<QVector<size_t>> ;
+    using QVectorSizeT = std::vector<std::vector<size_t>>;
 
     SIMPL_INSTANCE_PROPERTY(IGeometry::Types, DCGeometryTypes)
     SIMPL_INSTANCE_PROPERTY(AttributeMatrix::Types, AMTypes)

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FilterParameterWidgetUtils.hpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FilterParameterWidgetUtils.hpp
@@ -220,14 +220,8 @@ class FilterParameterWidgetUtils
     template <typename T>
     static bool VectorContains(const std::vector<std::vector<T>>& container, const std::vector<T>& comparison)
     {
-      for(const auto& value : container)
-      {
-        if(value == comparison)
-        {
-          return true;
-        }
-      }
-      return false;
+      typename std::vector<T>::iterator pos = std::find(container.begin(), container.end(), comparison);
+      return (pos != container.end());
     }
     /**
      * @brief PopulateAttributeArrayList This method populates a QListWidget with

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FilterParameterWidgetUtils.hpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FilterParameterWidgetUtils.hpp
@@ -169,7 +169,7 @@ class FilterParameterWidgetUtils
       DataContainerArrayProxy::StorageType& dcMap = dcaProxy.getDataContainers();
 
       QVector<QString> daTypes = fp->getDefaultAttributeArrayTypes();
-      QVector< QVector<size_t> > cDims = fp->getDefaultComponentDimensions();
+      std::vector<std::vector<size_t>> cDims = fp->getDefaultComponentDimensions();
       for(auto& dc : dcMap)
       {
         if(dc.getName() == currentDCName)
@@ -191,7 +191,7 @@ class FilterParameterWidgetUtils
                 IDataArray::Pointer da = dca->getPrereqIDataArrayFromPath<IDataArray, AbstractFilter>(nullptr, DataArrayPath(dc.getName(), amProxy.getName(), daName));
                 aaCombo->addItem(daName);
 
-                if(nullptr != da.get() && ((!daTypes.isEmpty() && !daTypes.contains(da->getTypeAsString())) || (!cDims.isEmpty() && !cDims.contains(da->getComponentDimensions()))))
+                if(nullptr != da.get() && ((!daTypes.isEmpty() && !daTypes.contains(da->getTypeAsString())) || (!cDims.empty() && !VectorContains<size_t>(cDims, da->getComponentDimensions()))))
                 {
                   QStandardItemModel* model = qobject_cast<QStandardItemModel*>(aaCombo->model());
                   if (nullptr != model)
@@ -216,7 +216,19 @@ class FilterParameterWidgetUtils
       }
     }
 
-
+    // -----------------------------------------------------------------------------
+    template <typename T>
+    static bool VectorContains(const std::vector<std::vector<T>>& container, const std::vector<T>& comparison)
+    {
+      for(const auto& value : container)
+      {
+        if(value == comparison)
+        {
+          return true;
+        }
+      }
+      return false;
+    }
     /**
      * @brief PopulateAttributeArrayList This method populates a QListWidget with
      * items representing AttributeArrays
@@ -249,7 +261,7 @@ class FilterParameterWidgetUtils
       DataContainerArrayProxy::StorageType& dcMap = dcaProxy.getDataContainers();
 
       QVector<QString> daTypes = fp->getDefaultAttributeArrayTypes();
-      QVector< QVector<size_t> > cDims = fp->getDefaultComponentDimensions();
+      QVector< std::vector<size_t> > cDims = fp->getDefaultComponentDimensions();
       for(auto& dc : dcMap)
       {
         if(dc.getName() == currentDCName)

--- a/Source/SVWidgetsLib/FilterParameterWidgets/FilterParameterWidgetUtils.hpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/FilterParameterWidgetUtils.hpp
@@ -220,7 +220,14 @@ class FilterParameterWidgetUtils
     template <typename T>
     static bool VectorContains(const std::vector<std::vector<T>>& container, const std::vector<T>& comparison)
     {
-      typename std::vector<T>::iterator pos = std::find(container.begin(), container.end(), comparison);
+      auto pos = std::find(container.begin(), container.end(), comparison);
+      return (pos != container.end());
+    }
+    // -----------------------------------------------------------------------------
+    template <typename T>
+    static bool VectorContains(std::vector<std::vector<T>>& container, const std::vector<T>& comparison)
+    {
+      auto pos = std::find(container.begin(), container.end(), comparison);
       return (pos != container.end());
     }
     /**

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.cpp
@@ -966,7 +966,7 @@ std::tuple<herr_t, QString> ImportHDF5DatasetWidget::bestGuessCDims(const QStrin
   AttributeMatrix::Pointer am = m_Filter->getDataContainerArray()->getAttributeMatrix(amPath);
   if(am != nullptr)
   {
-    QVector<size_t> amTupleDims = am->getTupleDimensions();
+    std::vector<size_t> amTupleDims = am->getTupleDimensions();
     int fileDimsSize = fileDims.size();
 
     //      // Calculate the prime factors of the attribute matrix tuple dimensions

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ReadASCIIDataWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ReadASCIIDataWidget.cpp
@@ -121,7 +121,7 @@ void ReadASCIIDataWidget::setupGui()
 
     m_LineCounter = new LineCounterObject(m_FilePath, m_Filter->getWizardData().numberOfLines);
 
-    QVector<size_t> tupleDimsArray = m_Filter->getWizardData().tupleDims;
+    std::vector<size_t> tupleDimsArray = m_Filter->getWizardData().tupleDims;
 
     if(!tupleDimsArray.empty())
     {
@@ -177,7 +177,7 @@ void ReadASCIIDataWidget::on_editImportSettings_clicked()
       int beginIndex = m_ImportWizard->getBeginningLineNum();
       int numOfDataLines = numOfLines - beginIndex + 1;
       tupleCount->setText(QString::number(numOfDataLines));
-      QVector<size_t> dims = m_ImportWizard->getTupleDims();
+      std::vector<size_t> dims = m_ImportWizard->getTupleDims();
 
       QString tupleDimsStr = "";
       for(int i = 0; i < dims.size(); i++)
@@ -403,7 +403,7 @@ void ReadASCIIDataWidget::lineCountDidFinish()
     int beginIndex = m_ImportWizard->getBeginningLineNum();
     int numOfDataLines = numOfLines - beginIndex + 1;
     tupleCount->setText(QString::number(numOfDataLines));
-    QVector<size_t> dims = m_ImportWizard->getTupleDims();
+    std::vector<size_t> dims = m_ImportWizard->getTupleDims();
 
     QString tupleDimsStr = "";
     for(int i = 0; i < dims.size(); i++)

--- a/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.cpp
@@ -273,6 +273,19 @@ bool DataArrayPathSelectionWidget::CheckPathRequirements(AbstractFilter* filter,
 }
 
 // -----------------------------------------------------------------------------
+template <typename T>
+bool vectorContains(const std::vector<std::vector<T>>& container, const std::vector<T>& comparison)
+{
+  for(const auto& value : container)
+  {
+    if(value == comparison)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+// -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
 bool DataArrayPathSelectionWidget::CheckPathRequirements(AbstractFilter* filter, const DataArrayPath& path, const DataArraySelectionFilterParameter::RequirementType& reqs)
@@ -342,12 +355,8 @@ bool DataArrayPathSelectionWidget::CheckPathRequirements(AbstractFilter* filter,
     return false;
   }
 
-  if(!reqs.componentDimensions.empty() && !FilterParameterWidgetUtils::VectorContains<size_t>(reqs.componentDimensions, da->getComponentDimensions()))
-  {
-    return false;
-  }
-
-  return true;
+  bool b = !FilterParameterWidgetUtils::VectorContains<size_t>(reqs.componentDimensions, da->getComponentDimensions());
+  return !(!reqs.componentDimensions.empty() && !b);
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.cpp
@@ -42,6 +42,7 @@
 #include <QtWidgets/QApplication>
 
 #include "SVWidgetsLib/FilterParameterWidgets/FilterParameterWidget.h"
+#include "SVWidgetsLib/FilterParameterWidgets/FilterParameterWidgetUtils.hpp"
 #include "SVWidgetsLib/QtSupport/QtSSettings.h"
 #include "SVWidgetsLib/Widgets/SVStyle.h"
 
@@ -271,19 +272,6 @@ bool DataArrayPathSelectionWidget::CheckPathRequirements(AbstractFilter* filter,
   return true;
 }
 
-template <typename T>
-bool vectorContains(const std::vector<std::vector<T>>& container, const std::vector<T>& comparison)
-{
-  for(const auto& value : container)
-  {
-    if(value == comparison)
-    {
-      return true;
-    }
-  }
-  return false;
-}
-
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -354,7 +342,7 @@ bool DataArrayPathSelectionWidget::CheckPathRequirements(AbstractFilter* filter,
     return false;
   }
 
-  if(!reqs.componentDimensions.empty() && !vectorContains<size_t>(reqs.componentDimensions, da->getComponentDimensions()))
+  if(!reqs.componentDimensions.empty() && !FilterParameterWidgetUtils::VectorContains<size_t>(reqs.componentDimensions, da->getComponentDimensions()))
   {
     return false;
   }

--- a/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.cpp
@@ -271,6 +271,19 @@ bool DataArrayPathSelectionWidget::CheckPathRequirements(AbstractFilter* filter,
   return true;
 }
 
+template <typename T>
+bool vectorContains(const std::vector<std::vector<T>>& container, const std::vector<T>& comparison)
+{
+  for(const auto& value : container)
+  {
+    if(value == comparison)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -341,7 +354,7 @@ bool DataArrayPathSelectionWidget::CheckPathRequirements(AbstractFilter* filter,
     return false;
   }
 
-  if(!reqs.componentDimensions.empty() && !reqs.componentDimensions.contains(da->getComponentDimensions()))
+  if(!reqs.componentDimensions.empty() && !vectorContains<size_t>(reqs.componentDimensions, da->getComponentDimensions()))
   {
     return false;
   }
@@ -601,7 +614,7 @@ QString DataArrayPathSelectionWidget::createDataArrayTypeString(QVector<QString>
   }
   else
   {
-    for(QString type : daTypes)
+    for(const QString& type : daTypes)
     {
       reqStr += "<td>" + type + "</td>";
     }
@@ -614,7 +627,7 @@ QString DataArrayPathSelectionWidget::createDataArrayTypeString(QVector<QString>
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QString DataArrayPathSelectionWidget::createComponentReqString(QVector<QVector<size_t>> comps) const
+QString DataArrayPathSelectionWidget::createComponentReqString(std::vector<std::vector<size_t>> comps) const
 {
   QString reqStr = "<tr><td><i>Required Component Size:</i></td>";
   if(comps.empty())
@@ -623,7 +636,7 @@ QString DataArrayPathSelectionWidget::createComponentReqString(QVector<QVector<s
   }
   else
   {
-    for(QVector<size_t> comp : comps)
+    for(const std::vector<size_t>& comp : comps)
     {
       reqStr += "<td>[";
 

--- a/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.h
+++ b/Source/SVWidgetsLib/Widgets/DataArrayPathSelectionWidget.h
@@ -387,7 +387,7 @@ protected:
   * @param compDims
   * @return
   */
-  QString createComponentReqString(QVector<QVector<size_t>> compDims) const;
+  QString createComponentReqString(std::vector<std::vector<size_t>> compDims) const;
 
   /**
   * @brief mouseMoveEvent

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.cpp
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.cpp
@@ -83,7 +83,7 @@ void DataFormatPage::setupGui()
   dataView->setModel(m_ASCIIDataModel.data());
 
   connect(dataView->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this, SLOT(updateSelection(const QItemSelection&, const QItemSelection&)));
-  connect(tupleDimsTable, SIGNAL(tupleDimsChanged(QVector<size_t>)), this, SLOT(checkTupleDimensions(QVector<size_t>)));
+  connect(tupleDimsTable, SIGNAL(tupleDimsChanged(std::vector<size_t>)), this, SLOT(checkTupleDimensions(std::vector<size_t>)));
   connect(amName, SIGNAL(textEdited(const QString&)), this, SLOT(widgetChanged(const QString&)));
 
   headersIndexLineEdit->setValidator(new QRegularExpressionValidator(QRegularExpression("[1-9][0-9]*"), headersIndexLineEdit));
@@ -115,7 +115,7 @@ void DataFormatPage::setupGui()
 //  amTuplesLabel->setText(QString::number(numOfDataLines));
 
   tupleDimsTable->blockSignals(true);
-  tupleDimsTable->addTupleDimensions(QVector<size_t>(1, numOfDataLines));
+  tupleDimsTable->addTupleDimensions(std::vector<size_t>(1, numOfDataLines));
   tupleDimsTable->blockSignals(false);
 
   selectedDCBtn->setStyleSheet(SVStyle::Instance()->QToolSelectionButtonStyle(false));
@@ -452,7 +452,7 @@ void DataFormatPage::createAMSelectionMenu()
   // Loop over the data containers until we find the proper data container
   DataContainerArray::Container containers = dca->getDataContainers();
   QVector<QString> daTypes;// = m_FilterParameter->getDefaultAttributeArrayTypes();
-  QVector<QVector<size_t>> cDims;// = m_FilterParameter->getDefaultComponentDimensions();
+  QVector<std::vector<size_t>> cDims;// = m_FilterParameter->getDefaultComponentDimensions();
   QVector<AttributeMatrix::Type> amTypes;// = m_FilterParameter->getDefaultAttributeMatrixTypes();
   IGeometry::Types geomTypes;// = m_FilterParameter->getDefaultGeometryTypes();
 
@@ -709,7 +709,7 @@ void DataFormatPage::on_startRowSpin_valueChanged(int value)
   if(!tupleDimsTable->didUseEdit())
   {
     tupleDimsTable->clearTupleDimensions();
-    tupleDimsTable->addTupleDimensions(QVector<size_t>(1, numOfDataLines));
+    tupleDimsTable->addTupleDimensions(std::vector<size_t>(1, numOfDataLines));
   }
   checkTupleDimensions(getTupleTable()->getData());
 
@@ -956,7 +956,7 @@ void DataFormatPage::updateSelection(const QItemSelection& selected, const QItem
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-bool DataFormatPage::checkTupleDimensions(QVector<size_t> tupleDims)
+bool DataFormatPage::checkTupleDimensions(std::vector<size_t> tupleDims)
 {
   if(!validateTupleDimensions(tupleDims))
   {
@@ -977,7 +977,7 @@ bool DataFormatPage::checkTupleDimensions(QVector<size_t> tupleDims)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-bool DataFormatPage::validateTupleDimensions(QVector<size_t> tupleDims)
+bool DataFormatPage::validateTupleDimensions(std::vector<size_t> tupleDims)
 {
   size_t tupleTotal = 1;
 

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/DataFormatPage.h
@@ -265,7 +265,7 @@ class DataFormatPage : public AbstractWizardPage, private Ui::DataFormatPage
     void on_amName_returnPressed();
 
     void updateSelection(const QItemSelection &selected, const QItemSelection &deselected);
-    bool checkTupleDimensions(QVector<size_t> tupleDims);
+    bool checkTupleDimensions(std::vector<size_t> tupleDims);
 
     void on_createAMRadio_toggled(bool b);
     void on_useAMRadio_toggled(bool b);
@@ -291,7 +291,7 @@ class DataFormatPage : public AbstractWizardPage, private Ui::DataFormatPage
     bool                                            m_HeadersHasErrors = false;
 
     bool validateHeaders(QVector<QString> headers);
-    bool validateTupleDimensions(QVector<size_t> tupleDims);
+    bool validateTupleDimensions(std::vector<size_t> tupleDims);
   
   public:
     DataFormatPage(const DataFormatPage&) = delete; // Copy Constructor Not Implemented

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ImportASCIIDataWizard.cpp
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ImportASCIIDataWizard.cpp
@@ -454,7 +454,7 @@ QString ImportASCIIDataWizard::getInputFilePath()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<size_t> ImportASCIIDataWizard::getTupleDims()
+std::vector<size_t> ImportASCIIDataWizard::getTupleDims()
 {
   DataFormatPage* dfPage = dynamic_cast<DataFormatPage*>(page(DataFormat));
   if(nullptr != dfPage)
@@ -462,7 +462,7 @@ QVector<size_t> ImportASCIIDataWizard::getTupleDims()
     return dfPage->getTupleTable()->getData();
   }
 
-  return QVector<size_t>();
+  return std::vector<size_t>();
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ImportASCIIDataWizard.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/ImportASCIIDataWizard.h
@@ -136,7 +136,7 @@ class ImportASCIIDataWizard : public QWizard
     QStringList getDataTypes();
     int getBeginningLineNum();
     QString getInputFilePath();
-    QVector<size_t> getTupleDims();
+    std::vector<size_t> getTupleDims();
     bool getAutomaticAM();
     DataArrayPath getSelectedPath();
     int getAttributeMatrixType();

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/TupleTableWidget.cpp
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/TupleTableWidget.cpp
@@ -78,17 +78,17 @@ void TupleTableWidget::setupGui()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<size_t> TupleTableWidget::getData()
+std::vector<size_t> TupleTableWidget::getData()
 {
   int cCount = tupleTable->columnCount();
-  QVector<size_t> data(cCount, 0);
+  std::vector<size_t> data(cCount, 0);
 
   for(int col = 0; col < cCount; col++)
   {
     QTableWidgetItem* item = tupleTable->item(0, col);
     if(nullptr == item)
     {
-      return QVector<size_t>();
+      return std::vector<size_t>();
     }
     data[col] = item->data(Qt::DisplayRole).toInt();
   }
@@ -99,7 +99,7 @@ QVector<size_t> TupleTableWidget::getData()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void TupleTableWidget::addTupleDimensions(QVector<size_t> tupleDims)
+void TupleTableWidget::addTupleDimensions(std::vector<size_t> tupleDims)
 {
   if(!m_UserEdited)
   {

--- a/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/TupleTableWidget.h
+++ b/Source/SVWidgetsLib/Widgets/ImportASCIIDataWizard/TupleTableWidget.h
@@ -65,9 +65,9 @@ class TupleTableWidget : public QWidget, private Ui::TupleTableWidget
     */
     void setupGui();
 
-    QVector<size_t> getData();
+    std::vector<size_t> getData();
 
-    void addTupleDimensions(QVector<size_t> tupleDims);
+    void addTupleDimensions(std::vector<size_t> tupleDims);
     void clearTupleDimensions();
 
     bool didUseEdit();
@@ -83,7 +83,7 @@ class TupleTableWidget : public QWidget, private Ui::TupleTableWidget
     void on_tupleTable_itemChanged(QTableWidgetItem* item);
 
   signals:
-    void tupleDimsChanged(QVector<size_t> tupleDims);
+    void tupleDimsChanged(std::vector<size_t> tupleDims);
 
   private:
     void updateDynamicButtons();

--- a/Wrapping/Python/Pybind11/Templates/Pybind11CustomTypeCasts.in.h
+++ b/Wrapping/Python/Pybind11/Templates/Pybind11CustomTypeCasts.in.h
@@ -186,7 +186,7 @@ public:
       }
       value.dataHeaders = dataHeaders;
       value.attrMatType = py::cast<int>(awdDict["attrMatType"]);
-      QVector<size_t> tupleDims;
+      std::vector<size_t> tupleDims;
       for(auto tupleDim : awdDict["tupleDimensions"])
       {
         tupleDims.push_back(py::cast<size_t>(tupleDim));

--- a/Wrapping/Python/Pybind11/Templates/SIMPLModuleCodeTemplate.in.cpp
+++ b/Wrapping/Python/Pybind11/Templates/SIMPLModuleCodeTemplate.in.cpp
@@ -78,9 +78,9 @@ template <typename T> using PySharedPtrClass = py::class_<T, std::shared_ptr<T>>
   {                                                                                                                                                                                                    \
     using DataArrayType = DataArray<T>;                                                                                                                                                                \
     PySharedPtrClass<DataArrayType> instance(m, #NAME, parent, py::buffer_protocol());                                                                                                                 \
-    instance.def(py::init([](size_t numElements, QString name, bool allocate) { return DataArrayType::CreateArray(numElements, name, allocate); }))                                                    \
+    instance.def(py::init([](size_t numElements, QString name, T initValue) { return DataArrayType::CreateArray(numElements, name, initValue); }))                                                    \
         .def(py::init([](T* ptr, size_t numElements, std::vector<size_t> cDims, QString name, bool ownsData) {                                                                                         \
-          return DataArrayType::WrapPointer(ptr, numElements, std::vector<size_t>::fromStdVector(cDims), name, ownsData);                                                                                  \
+          return DataArrayType::WrapPointer(ptr, numElements, cDims, name, ownsData);                                                                                  \
         }))                                                                                                                                                                                            \
         .def(py::init([](py::array_t<T, py::array::c_style> b, std::vector<size_t> cDims, QString name, bool ownsData) {                                                                               \
           ssize_t numElements = 1;                                                                                                                                                                     \
@@ -90,7 +90,7 @@ template <typename T> using PySharedPtrClass = py::class_<T, std::shared_ptr<T>>
             numElements *= b.shape(e);                                                                                                                                                                 \
           }                                                                                                                                                                                            \
           numElements /= cDims[0];                                                                                                                                                                     \
-          return DataArrayType::WrapPointer(reinterpret_cast<T*>(b.mutable_data(0)), static_cast<size_t>(numElements), std::vector<size_t>::fromStdVector(cDims), name, ownsData);                         \
+          return DataArrayType::WrapPointer(reinterpret_cast<T*>(b.mutable_data(0)), static_cast<size_t>(numElements), cDims, name, ownsData);                         \
         })) /* Class instance method setValue */                                                                                                                                                       \
         .def("setValue", &DataArrayType::setValue, py::arg("index"), py::arg("value"))                                                                                                                 \
         .def("getValue", &DataArrayType::getValue, py::arg("index"))                                                                                                                                   \

--- a/Wrapping/Python/Pybind11/Templates/SIMPLModuleCodeTemplate.in.cpp
+++ b/Wrapping/Python/Pybind11/Templates/SIMPLModuleCodeTemplate.in.cpp
@@ -80,7 +80,7 @@ template <typename T> using PySharedPtrClass = py::class_<T, std::shared_ptr<T>>
     PySharedPtrClass<DataArrayType> instance(m, #NAME, parent, py::buffer_protocol());                                                                                                                 \
     instance.def(py::init([](size_t numElements, QString name, bool allocate) { return DataArrayType::CreateArray(numElements, name, allocate); }))                                                    \
         .def(py::init([](T* ptr, size_t numElements, std::vector<size_t> cDims, QString name, bool ownsData) {                                                                                         \
-          return DataArrayType::WrapPointer(ptr, numElements, QVector<size_t>::fromStdVector(cDims), name, ownsData);                                                                                  \
+          return DataArrayType::WrapPointer(ptr, numElements, std::vector<size_t>::fromStdVector(cDims), name, ownsData);                                                                                  \
         }))                                                                                                                                                                                            \
         .def(py::init([](py::array_t<T, py::array::c_style> b, std::vector<size_t> cDims, QString name, bool ownsData) {                                                                               \
           ssize_t numElements = 1;                                                                                                                                                                     \
@@ -90,7 +90,7 @@ template <typename T> using PySharedPtrClass = py::class_<T, std::shared_ptr<T>>
             numElements *= b.shape(e);                                                                                                                                                                 \
           }                                                                                                                                                                                            \
           numElements /= cDims[0];                                                                                                                                                                     \
-          return DataArrayType::WrapPointer(reinterpret_cast<T*>(b.mutable_data(0)), static_cast<size_t>(numElements), QVector<size_t>::fromStdVector(cDims), name, ownsData);                         \
+          return DataArrayType::WrapPointer(reinterpret_cast<T*>(b.mutable_data(0)), static_cast<size_t>(numElements), std::vector<size_t>::fromStdVector(cDims), name, ownsData);                         \
         })) /* Class instance method setValue */                                                                                                                                                       \
         .def("setValue", &DataArrayType::setValue, py::arg("index"), py::arg("value"))                                                                                                                 \
         .def("getValue", &DataArrayType::getValue, py::arg("index"))                                                                                                                                   \
@@ -264,16 +264,16 @@ PYBIND11_MODULE(dream3d, m)
   ;
 
   // Handle QVector of size_t
-  py::class_<QVector<size_t>>(mod, "Dims")
+  py::class_<std::vector<size_t>>(mod, "Dims")
 	  .def(py::init<>([](py::list dimensions) {
-	  QVector<size_t> dims = QVector<size_t>();
+	  std::vector<size_t> dims = std::vector<size_t>();
 	  for (auto dimension : dimensions)
 	  {
 		  dims.push_back(py::cast<size_t>(dimension));
 	  }
 	  return dims;
       }))
-	  .def("__repr__", [](const QVector<size_t> &dims) {
+	  .def("__repr__", [](const std::vector<size_t> &dims) {
 		  py::list dimensions;
 		  for (size_t dim : dims)
 		  {
@@ -281,7 +281,7 @@ PYBIND11_MODULE(dream3d, m)
 		  }
 		  return dimensions;
 	  })
-	  .def("__str__", [](const QVector<size_t> &dims) {
+	  .def("__str__", [](const std::vector<size_t> &dims) {
 		  py::list dimensions;
 		  for (size_t dim : dims)
 		  {
@@ -289,7 +289,7 @@ PYBIND11_MODULE(dream3d, m)
 		  }
       return py::str(dimensions);
 	  })
-	  .def("__getitem__", [](const QVector<size_t> &dims, int key) {
+	  .def("__getitem__", [](const std::vector<size_t> &dims, int key) {
 		  return dims[key];
 	  })
   ;

--- a/Wrapping/Python/SIMPL/simpl_helpers.py
+++ b/Wrapping/Python/SIMPL/simpl_helpers.py
@@ -38,7 +38,7 @@ def CreateAttributeMatrix(dims, name, type):
     name -- The name of the AttributeMatrix
     type -- the type of the AttributeMatrix
     """
-    am = simpl.AttributeMatrix.Create(dims, name, type)
+    am = simpl.AttributeMatrix.New(dims, name, type)
     return am
 
 
@@ -132,7 +132,7 @@ def ConvertToDataArray(name, array, componentDimensions = 1):
     # Get shape
     shape = array.shape
     # Determine cDims
-    cDims = simpl.VectorSizeT([componentDimensions])  # Default is 1
+    cDims = simpl.Dims([componentDimensions])  # Default is 1
 
     # Determine type
     type = array.dtype

--- a/Wrapping/Python/Testing/AttributeMatrixTest.py
+++ b/Wrapping/Python/Testing/AttributeMatrixTest.py
@@ -9,7 +9,7 @@ from dream3d import simpl_test_dirs as sd
 def AttributeMatrixTest():
     # Create an AttributeMatrix
     amType = simpl.AttributeMatrix.Type.Cell
-    tupleDims = simpl.VectorSizeT([5, 4, 3])
+    tupleDims = simpl.Dims([5, 4, 3])
     amName = "CellAttributeMatrix"
     am = sc.CreateAttributeMatrix(tupleDims, amName, amType)
 

--- a/Wrapping/Python/Testing/Convert_Attribute_Array_Data_Type.py
+++ b/Wrapping/Python/Testing/Convert_Attribute_Array_Data_Type.py
@@ -18,7 +18,7 @@ def convert_data_test():
     dc = sc.CreateDataContainer("ImageDataContainer")
     dca.addOrReplaceDataContainer(dc)
  
-    shape = simpl.VectorSizeT([4, 5, 2])
+    shape = simpl.Dims([4, 5, 2])
     cellAm = sc.CreateAttributeMatrix(shape, "CellAttributeMatrix", simpl.AttributeMatrix.Type.Cell)
     dc.addOrReplaceAttributeMatrix(cellAm)   
     

--- a/Wrapping/Python/Testing/DataArrayTest.py
+++ b/Wrapping/Python/Testing/DataArrayTest.py
@@ -24,12 +24,12 @@ def DataArrayTest():
     dc = sc.CreateDataContainer("ImageDataContainer")
     dca.addOrReplaceDataContainer(dc)
 
-    shape = simpl.VectorSizeT([4, 5, 2])
+    shape = simpl.Dims([4, 5, 2])
     cellAm = sc.CreateAttributeMatrix(shape, "CellAttributeMatrix", simpl.AttributeMatrix.Type.Cell)
     dc.addOrReplaceAttributeMatrix(cellAm)
-
+    shape = [4,5,2]
     # Create the Component Dimensions for the Array, 1 Component in this case
-    cDims = simpl.VectorSizeT([1])
+    cDims = simpl.Dims([1])
 
     arrayTypes = [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64, np.float32, np.double]
     # We store each return numpy array in order to keep it in scope. If we let it

--- a/Wrapping/Python/Testing/DataContainerArrayTest.py
+++ b/Wrapping/Python/Testing/DataContainerArrayTest.py
@@ -32,8 +32,8 @@ def AttributeMatrixAccessTest():
     dca.addOrReplaceDataContainer(dc)
     
     amType = simpl.AttributeMatrix.Type.Cell
-    tupleDims = simpl.VectorSizeT([5,4,3])
-    am = simpl.AttributeMatrix.Create(tupleDims, "CellAttributeMatrix", amType)
+    tupleDims = simpl.Dims([5,4,3])
+    am = simpl.AttributeMatrix.New(tupleDims, "CellAttributeMatrix", amType)
     dc.addOrReplaceAttributeMatrix(am)
 
     # See if we can get the AttributeMatrix based on a DataArrayPath object

--- a/Wrapping/Python/Testing/DataContainerTest.py
+++ b/Wrapping/Python/Testing/DataContainerTest.py
@@ -29,7 +29,7 @@ def DataContainerTest() :
   assert dc.Name == "ImageDataContainer"
   
   amType = simpl.AttributeMatrix.Type.Cell
-  tupleDims = simpl.VectorSizeT([5,4,3])
+  tupleDims = simpl.Dims([5,4,3])
   amName = "CellAttributeMatrix"
   am = sc.CreateAttributeMatrix(tupleDims, amName, amType)
 

--- a/Wrapping/Python/Testing/ImageReadTest.py
+++ b/Wrapping/Python/Testing/ImageReadTest.py
@@ -45,12 +45,12 @@ def ImageReadTest():
     dca.addOrReplaceDataContainer(dc)
 
     # Create an AttributeMatrix and add it to the DataContainer
-    amShape = simpl.VectorSizeT([shape[1], shape[0], 1])
+    amShape = simpl.Dims([shape[1], shape[0], 1])
     cellAm = sc.CreateAttributeMatrix(amShape, "CellAttributeMatrix", simpl.AttributeMatrix.Type.Cell)
     dc.addOrReplaceAttributeMatrix(cellAm)
 
     # Create an AttributeArray from the image data and add it to the AttributeMatrix
-    cDims = simpl.VectorSizeT([1])
+    cDims = simpl.Dims([1])
     name = "slice_11.tiff"
     array = simpl.UInt8ArrayType(z_flat, cDims, name, False)
     cellAm.addOrReplaceAttributeArray(array)


### PR DESCRIPTION
* Predominant change is to use std::vector<size_t> for the component dimensions argument.
* Other minor clang-tidy warning cleanup if deemed appropriate.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>