### PR TITLE
Fix crash when reading prior .dream3d files with mesh based geometry

### DIFF
--- a/Source/SIMPLib/Geometry/EdgeGeom.cpp
+++ b/Source/SIMPLib/Geometry/EdgeGeom.cpp
@@ -582,13 +582,9 @@ int EdgeGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 {
   herr_t err = 0;
   SharedVertexList::Pointer vertices = GeometryHelpers::GeomIO::ReadListFromHDF5<SharedVertexList>(SIMPL::Geometry::SharedVertexList, parentId, preflight, err);
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  DataArray<uint64_t>::Pointer tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::SharedEdgeList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedEdgeList::Pointer edges =
-      SharedEdgeList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
+
+  SharedEdgeList::Pointer edges = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::SharedEdgeList, parentId, preflight, err);
+
   if(edges.get() == nullptr || vertices.get() == nullptr)
   {
     return -1;

--- a/Source/SIMPLib/Geometry/GeometryHelpers.cpp
+++ b/Source/SIMPLib/Geometry/GeometryHelpers.cpp
@@ -34,5 +34,67 @@
 namespace GeometryHelpers
 {
 
+// -----------------------------------------------------------------------------
+MeshIndexArrayType::Pointer GeomIO::ReadMeshIndexListFromHDF5(const QString& listName, hid_t parentId, bool preflight, herr_t& err)
+{
+  MeshIndexArrayType::Pointer meshIndex = MeshIndexArrayType::NullPointer();
 
+  // In versions of DREAM3D before 6.6, the index list was stored as a Int64_t type, versions starting with 6.6 now store
+  // the list as a size_t (UInt64_t). So we need to try each type:
+  Int64ArrayType::Pointer tempInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<Int64ArrayType>(listName, parentId, preflight, err);
+  if(tempInt64.get() != nullptr)
+  {
+    meshIndex = SharedEdgeList::WrapPointer(reinterpret_cast<MeshIndexType*>(tempInt64->data()), tempInt64->getNumberOfTuples(), tempInt64->getComponentDimensions(), tempInt64->getName(), true);
+    // Release the ownership of the memory from TempTris and essentially pass it to tris.
+    tempInt64->releaseOwnership();
+  }
+  else // Reading as a Int64 didn't work which means the data _should_ be a UInt64_t (size_t)
+  {
+    MeshIndexArrayType::Pointer tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<MeshIndexArrayType>(listName, parentId, preflight, err);
+    if(tempUInt64.get() != nullptr)
+    {
+      meshIndex = SharedEdgeList::WrapPointer(reinterpret_cast<MeshIndexType*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
+      // Release the ownership of the memory from TempTris and essentially pass it to tris.
+      tempUInt64->releaseOwnership();
+    }
+  }
+
+  return meshIndex;
 }
+
+// -----------------------------------------------------------------------------
+int GeomIO::ReadMetaDataFromHDF5(hid_t parentId, const IGeometry::Pointer& geometry)
+{
+  herr_t err = 0;
+  unsigned int spatialDims = 0;
+  QString geomName = "";
+  err = QH5Lite::readScalarAttribute(parentId, SIMPL::Geometry::Geometry, SIMPL::Geometry::SpatialDimensionality, spatialDims);
+  if(err < 0)
+  {
+    return err;
+  }
+  err = QH5Lite::readStringAttribute(parentId, SIMPL::Geometry::Geometry, SIMPL::Geometry::GeometryName, geomName);
+  if(err < 0)
+  {
+    return err;
+  }
+  geometry->setSpatialDimensionality(spatialDims);
+  geometry->setName(geomName);
+
+  return 1;
+}
+
+// -----------------------------------------------------------------------------
+int GeomIO::WriteListToHDF5(hid_t parentId, const IDataArray::Pointer& list)
+{
+  herr_t err = 0;
+  if(list->getNumberOfTuples() == 0)
+  {
+    return err;
+  }
+  QVector<size_t> tDims(1, list->getNumberOfTuples());
+  err = list->writeH5Data(parentId, tDims);
+  return err;
+}
+
+} // namespace GeometryHelpers

--- a/Source/SIMPLib/Geometry/GeometryHelpers.h
+++ b/Source/SIMPLib/Geometry/GeometryHelpers.h
@@ -64,12 +64,14 @@ public:
 
   /**
    * @brief ReadMeshFromHDF5
-   * @param listName
-   * @param parentId
-   * @param preflight
+   * @param listName The name of the DataSet
+   * @param parentId The HDF5
+   * @param preflight Are we in preflight mode. If TRUE then the underlying memory for the array will *not* be allocated
+   * @param err Any error that occured.
    * @return
    */
-  template <typename ListType> static typename ListType::Pointer ReadListFromHDF5(const QString& listName, hid_t parentId, bool preflight, herr_t& err)
+  template <typename ListType>
+  static typename ListType::Pointer ReadListFromHDF5(const QString& listName, hid_t parentId, bool preflight, herr_t& err)
   {
     QVector<hsize_t> dims;
     H5T_class_t type_class;
@@ -92,31 +94,22 @@ public:
   }
 
   /**
+   * @brief ReadIndexListFromHDF5
+   * @param listName The name of the DataSet
+   * @param parentId The HDF5
+   * @param preflight Are we in preflight mode. If TRUE then the underlying memory for the array will *not* be allocated
+   * @param err Any error that occured.
+   * @return
+   */
+  static MeshIndexArrayType::Pointer ReadMeshIndexListFromHDF5(const QString& listName, hid_t parentId, bool preflight, herr_t& err);
+
+  /**
    * @brief ReadMetaDataFromHDF5
    * @param parentId
    * @param geometry
    * @return
    */
-  static int ReadMetaDataFromHDF5(hid_t parentId, IGeometry::Pointer geometry)
-  {
-    herr_t err = 0;
-    unsigned int spatialDims = 0;
-    QString geomName = "";
-    err = QH5Lite::readScalarAttribute(parentId, SIMPL::Geometry::Geometry, SIMPL::Geometry::SpatialDimensionality, spatialDims);
-    if(err < 0)
-    {
-      return err;
-    }
-    err = QH5Lite::readStringAttribute(parentId, SIMPL::Geometry::Geometry, SIMPL::Geometry::GeometryName, geomName);
-    if(err < 0)
-    {
-      return err;
-    }
-    geometry->setSpatialDimensionality(spatialDims);
-    geometry->setName(geomName);
-
-    return 1;
-  }
+  static int ReadMetaDataFromHDF5(hid_t parentId, const IGeometry::Pointer& geometry);
 
   /**
    * @brief WriteListToHDF5
@@ -124,17 +117,7 @@ public:
    * @param list
    * @return
    */
-  static int WriteListToHDF5(hid_t parentId, IDataArray::Pointer list)
-  {
-    herr_t err = 0;
-    if(list->getNumberOfTuples() == 0)
-    {
-      return err;
-    }
-    QVector<size_t> tDims(1, list->getNumberOfTuples());
-    err = list->writeH5Data(parentId, tDims);
-    return err;
-  }
+  static int WriteListToHDF5(hid_t parentId, const IDataArray::Pointer& list);
 
   /**
    * @brief ReadDynamicListFromHDF5
@@ -187,7 +170,8 @@ public:
    * @param name
    * @return
    */
-  template <typename T, typename K> static int WriteDynamicListToHDF5(hid_t parentId, typename DynamicListArray<T, K>::Pointer dynamicList, size_t numElems, const QString& name)
+  template <typename T, typename K>
+  static int WriteDynamicListToHDF5(hid_t parentId, typename DynamicListArray<T, K>::Pointer dynamicList, size_t numElems, const QString& name)
   {
     herr_t err = 0;
     if(numElems == 0)

--- a/Source/SIMPLib/Geometry/HexahedralGeom.cpp
+++ b/Source/SIMPLib/Geometry/HexahedralGeom.cpp
@@ -742,60 +742,35 @@ int HexahedralGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 {
   herr_t err = 0;
   SharedVertexList::Pointer vertices = GeometryHelpers::GeomIO::ReadListFromHDF5<SharedVertexList>(SIMPL::Geometry::SharedVertexList, parentId, preflight, err);
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  DataArray<uint64_t>::Pointer tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::SharedHexList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedHexList::Pointer hexas =
-      SharedHexList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
+
+  MeshIndexArrayType::Pointer hexas = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::SharedHexList, parentId, preflight, err);
   if(hexas.get() == nullptr || vertices.get() == nullptr)
   {
     return -1;
   }
+
   size_t numHexas = hexas->getNumberOfTuples();
   size_t numVerts = vertices->getNumberOfTuples();
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::SharedQuadList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedQuadList::Pointer quads =
-      SharedQuadList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
-  if(err < 0 && err != -2)
-  {
-    return -1;
-  }
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::UnsharedFaceList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedQuadList::Pointer bQuads =
-      SharedQuadList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
-  if(err < 0 && err != -2)
-  {
-    return -1;
-  }
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::SharedEdgeList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedEdgeList::Pointer edges =
-      SharedEdgeList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
+
+  MeshIndexArrayType::Pointer quads = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::SharedQuadList, parentId, preflight, err);
   if(err < 0 && err != -2)
   {
     return -1;
   }
 
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::UnsharedEdgeList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedEdgeList::Pointer bEdges =
-      SharedEdgeList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
+  MeshIndexArrayType::Pointer bQuads = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::UnsharedFaceList, parentId, preflight, err);
+  if(err < 0 && err != -2)
+  {
+    return -1;
+  }
+
+  MeshIndexArrayType::Pointer edges = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::SharedEdgeList, parentId, preflight, err);
+  if(err < 0 && err != -2)
+  {
+    return -1;
+  }
+
+  MeshIndexArrayType::Pointer bEdges = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::UnsharedEdgeList, parentId, preflight, err);
   if(err < 0 && err != -2)
   {
     return -1;

--- a/Source/SIMPLib/Geometry/IGeometry.h
+++ b/Source/SIMPLib/Geometry/IGeometry.h
@@ -55,12 +55,12 @@ class QTextStream;
 using MeshIndexType = size_t;
 using MeshIndexArrayType = DataArray<MeshIndexType>;
 using SharedVertexList = FloatArrayType;
-using SharedEdgeList = DataArray<MeshIndexType>;
-using SharedTriList = DataArray<MeshIndexType>;
-using SharedQuadList = DataArray<MeshIndexType>;
-using SharedTetList = DataArray<MeshIndexType>;
-using SharedHexList = DataArray<MeshIndexType>;
-using SharedFaceList = DataArray<MeshIndexType>;
+using SharedEdgeList = MeshIndexArrayType;
+using SharedTriList = MeshIndexArrayType;
+using SharedQuadList = MeshIndexArrayType;
+using SharedTetList = MeshIndexArrayType;
+using SharedHexList = MeshIndexArrayType;
+using SharedFaceList = MeshIndexArrayType;
 using ElementDynamicList = DynamicListArray<uint16_t, MeshIndexType>;
 
 /**

--- a/Source/SIMPLib/Geometry/QuadGeom.cpp
+++ b/Source/SIMPLib/Geometry/QuadGeom.cpp
@@ -667,13 +667,8 @@ int QuadGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 {
   herr_t err = 0;
   SharedVertexList::Pointer vertices = GeometryHelpers::GeomIO::ReadListFromHDF5<SharedVertexList>(SIMPL::Geometry::SharedVertexList, parentId, preflight, err);
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  DataArray<uint64_t>::Pointer tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::SharedQuadList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedQuadList::Pointer quads =
-      SharedTriList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
+
+  MeshIndexArrayType::Pointer quads = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::SharedQuadList, parentId, preflight, err);
   if(quads.get() == nullptr || vertices.get() == nullptr)
   {
     return -1;
@@ -681,25 +676,13 @@ int QuadGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
   size_t numQuads = quads->getNumberOfTuples();
   size_t numVerts = vertices->getNumberOfTuples();
 
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::SharedEdgeList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedEdgeList::Pointer edges =
-      SharedEdgeList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
+  MeshIndexArrayType::Pointer edges = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::SharedEdgeList, parentId, preflight, err);
   if(err < 0 && err != -2)
   {
     return -1;
   }
 
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::UnsharedEdgeList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedEdgeList::Pointer bEdges =
-      SharedEdgeList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
+  MeshIndexArrayType::Pointer bEdges = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::UnsharedEdgeList, parentId, preflight, err);
   if(err < 0 && err != -2)
   {
     return -1;

--- a/Source/SIMPLib/Geometry/TetrahedralGeom.cpp
+++ b/Source/SIMPLib/Geometry/TetrahedralGeom.cpp
@@ -759,61 +759,33 @@ int TetrahedralGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
   herr_t err = 0;
   SharedVertexList::Pointer vertices = GeometryHelpers::GeomIO::ReadListFromHDF5<SharedVertexList>(SIMPL::Geometry::SharedVertexList, parentId, preflight, err);
 
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  DataArray<uint64_t>::Pointer tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::SharedTetList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedTetList::Pointer tets =
-      SharedTetList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
+  MeshIndexArrayType::Pointer tets = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::SharedTetList, parentId, preflight, err);
   if(tets.get() == nullptr || vertices.get() == nullptr)
   {
     return -1;
   }
   size_t numTets = tets->getNumberOfTuples();
   size_t numVerts = vertices->getNumberOfTuples();
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::SharedTriList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedTriList::Pointer tris =
-      SharedTriList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
-  if(err < 0 && err != -2)
-  {
-    return -1;
-  }
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::UnsharedFaceList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedTriList::Pointer bTris =
-      SharedTriList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
+
+  MeshIndexArrayType::Pointer tris = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::SharedTriList, parentId, preflight, err);
   if(err < 0 && err != -2)
   {
     return -1;
   }
 
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::SharedEdgeList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedEdgeList::Pointer edges =
-      SharedEdgeList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
+  MeshIndexArrayType::Pointer bTris = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::UnsharedFaceList, parentId, preflight, err);
   if(err < 0 && err != -2)
   {
     return -1;
   }
 
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::UnsharedEdgeList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedEdgeList::Pointer bEdges =
-      SharedEdgeList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
+  MeshIndexArrayType::Pointer edges = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::SharedEdgeList, parentId, preflight, err);
+  if(err < 0 && err != -2)
+  {
+    return -1;
+  }
+
+  MeshIndexArrayType::Pointer bEdges = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::UnsharedEdgeList, parentId, preflight, err);
   if(err < 0 && err != -2)
   {
     return -1;

--- a/Source/SIMPLib/Geometry/TriangleGeom.cpp
+++ b/Source/SIMPLib/Geometry/TriangleGeom.cpp
@@ -664,26 +664,22 @@ int TriangleGeom::readGeometryFromHDF5(hid_t parentId, bool preflight)
 {
   herr_t err = 0;
   SharedVertexList::Pointer vertices = GeometryHelpers::GeomIO::ReadListFromHDF5<SharedVertexList>(SIMPL::Geometry::SharedVertexList, parentId, preflight, err);
-  // The cast from the method is going to fail so create a temp DataArray<uint64_t>
-  DataArray<uint64_t>::Pointer tempUInt64 = GeometryHelpers::GeomIO::ReadListFromHDF5<DataArray<uint64_t>>(SIMPL::Geometry::SharedTriList, parentId, preflight, err);
-  // Now create the correct type and pass in the pointer to tempTris.
-  SharedTriList::Pointer tris =
-      SharedTriList::WrapPointer(reinterpret_cast<size_t*>(tempUInt64->data()), tempUInt64->getNumberOfTuples(), tempUInt64->getComponentDimensions(), tempUInt64->getName(), true);
-  // Release the ownership of the memory from TempTris and essentially pass it to tris.
-  tempUInt64->releaseOwnership();
 
+  MeshIndexArrayType::Pointer tris = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::SharedTriList, parentId, preflight, err);
   if(tris.get() == nullptr || vertices.get() == nullptr)
   {
     return -1;
   }
   size_t numTris = tris->getNumberOfTuples();
   size_t numVerts = vertices->getNumberOfTuples();
-  SharedEdgeList::Pointer edges = GeometryHelpers::GeomIO::ReadListFromHDF5<SharedEdgeList>(SIMPL::Geometry::SharedEdgeList, parentId, preflight, err);
+
+  MeshIndexArrayType::Pointer edges = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::SharedEdgeList, parentId, preflight, err);
   if(err < 0 && err != -2)
   {
     return -1;
   }
-  SharedEdgeList::Pointer bEdges = GeometryHelpers::GeomIO::ReadListFromHDF5<SharedEdgeList>(SIMPL::Geometry::UnsharedEdgeList, parentId, preflight, err);
+
+  MeshIndexArrayType::Pointer bEdges = GeometryHelpers::GeomIO::ReadMeshIndexListFromHDF5(SIMPL::Geometry::UnsharedEdgeList, parentId, preflight, err);
   if(err < 0 && err != -2)
   {
     return -1;


### PR DESCRIPTION
The crash is due to a bad cast from Int64 array to size_t array.
We now try to first read as the Int64 array and reinterpret cast to size_t. If that fails
then we read as a size_t (unsigned long long int) and return the result of that
operation.

fixes #363. closes #363

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>