### PR TITLE
Add export specification to Dream3DImage

### DIFF
--- a/Source/SIMPLib/ITK/itkDream3DImage.h
+++ b/Source/SIMPLib/ITK/itkDream3DImage.h
@@ -81,7 +81,7 @@ namespace itk
  * \wikiexample{SimpleOperations/SetPixels,Set specified pixels to specified values}
  * \endwiki
  */
-template <typename TPixel, unsigned int VImageDimension = 2> class Dream3DImage : public Image<TPixel, VImageDimension>
+template <typename TPixel, unsigned int VImageDimension = 2> class ITK_TEMPLATE_EXPORT Dream3DImage : public Image<TPixel, VImageDimension>
 {
 public:
   /** Standard class typedefs */


### PR DESCRIPTION
Required on macOS to resolve symbols correctly.

Intended to address:

  libc++abi.dylib: terminating with uncaught exception of type itk::ExceptionObject: /Users/Shared/IMF_SDK/superbuild/ITK/Source/ITK/Modules/Core/Common/include/itkImageBase.hxx:333:

  itk::ERROR: Dream3DImage(0x7fc7ad7dc250): itk::ImageBase::CopyInformation() cannot cast PKN3itk10DataObjectE to PKN3itk9ImageBaseILj2EEE