### PR TITLE
Override CopyInformation in Dream3DImage

### DIFF
--- a/Source/SIMPLib/ITK/itkDream3DImage.h
+++ b/Source/SIMPLib/ITK/itkDream3DImage.h
@@ -264,6 +264,9 @@ public:
     return NeighborhoodAccessorFunctorType();
   }
 
+  /** Work around casting issue. */
+  void CopyInformation(const DataObject *data) override;
+
 protected:
   Dream3DImage();
   void PrintSelf(std::ostream& os, Indent indent) const override;

--- a/Source/SIMPLib/ITK/itkDream3DImage.hxx
+++ b/Source/SIMPLib/ITK/itkDream3DImage.hxx
@@ -141,5 +141,24 @@ Dream3DImage<TPixel, VImageDimension>
   // m_Origin and m_Spacing are printed in the Superclass
 }
 
+
+template <typename TPixel, unsigned int VImageDimension>
+void
+Dream3DImage<TPixel, VImageDimension>
+::CopyInformation(const DataObject *data)
+{
+  if ( data )
+    {
+    const auto * const imgData = static_cast< const ImageBase< VImageDimension > * >( data );
+
+    // Copy the meta data for this data type
+    this->SetLargestPossibleRegion( imgData->GetLargestPossibleRegion() );
+    this->SetSpacing( imgData->GetSpacing() );
+    this->SetOrigin( imgData->GetOrigin() );
+    this->SetDirection( imgData->GetDirection() );
+    this->SetNumberOfComponentsPerPixel(
+    }
+}
+
 } // end namespace itk
 


### PR DESCRIPTION
This is a workaround for a failed dynamic_cast to imgData
occuring on macOS in itk::ImageBase.