### PR TITLE
Filling in IntVec2 widget values from the filter when preflight ends.

### DIFF
--- a/Source/SVWidgetsLib/FilterParameterWidgets/IntVec2Widget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/IntVec2Widget.cpp
@@ -129,4 +129,10 @@ void IntVec2Widget::beforePreflight()
 // -----------------------------------------------------------------------------
 void IntVec2Widget::afterPreflight()
 {
+  if(getFilterParameter() != nullptr)
+  {
+    IntVec2Type data = getFilter()->property(PROPERTY_NAME_AS_CHAR).value<IntVec2Type>();
+    xData->setText(QString::number(data[0]));
+    yData->setText(QString::number(data[1]));
+  }
 }


### PR DESCRIPTION
This allows filters to set recommended IntVec2 values during preflight.

Signed-off-by: Joey Kleingers <joey.kleingers@bluequartz.net>