### PR TITLE
Fixed braces around initialization of subobjects

### DIFF
--- a/Source/SIMPLib/Common/SIMPLRange.cpp
+++ b/Source/SIMPLib/Common/SIMPLRange.cpp
@@ -37,7 +37,7 @@
 //
 // -----------------------------------------------------------------------------
 SIMPLRange::SIMPLRange()
-: m_Range({0, 0})
+: m_Range({{0, 0}})
 {
 }
 
@@ -45,7 +45,7 @@ SIMPLRange::SIMPLRange()
 //
 // -----------------------------------------------------------------------------
 SIMPLRange::SIMPLRange(size_t begin, size_t end)
-: m_Range({begin, end})
+: m_Range({{begin, end}})
 {
 }
 
@@ -54,7 +54,7 @@ SIMPLRange::SIMPLRange(size_t begin, size_t end)
 //
 // -----------------------------------------------------------------------------
 SIMPLRange::SIMPLRange(const tbb::blocked_range<size_t>& r)
-: m_Range({r.begin(), r.end()})
+: m_Range({{r.begin(), r.end()}})
 {
 }
 #endif

--- a/Source/SIMPLib/Common/SIMPLRange2D.cpp
+++ b/Source/SIMPLib/Common/SIMPLRange2D.cpp
@@ -37,7 +37,7 @@
 //
 // -----------------------------------------------------------------------------
 SIMPLRange2D::SIMPLRange2D()
-: m_Range({0, 0, 0, 0})
+: m_Range({{0, 0, 0, 0}})
 {
 }
 
@@ -45,7 +45,7 @@ SIMPLRange2D::SIMPLRange2D()
 //
 // -----------------------------------------------------------------------------
 SIMPLRange2D::SIMPLRange2D(size_t initRow, size_t initCol, size_t endRow, size_t endCol)
-: m_Range({initRow, initCol, endRow, endCol})
+: m_Range({{initRow, initCol, endRow, endCol}})
 {
 }
 
@@ -54,7 +54,7 @@ SIMPLRange2D::SIMPLRange2D(size_t initRow, size_t initCol, size_t endRow, size_t
 //
 // -----------------------------------------------------------------------------
 SIMPLRange2D::SIMPLRange2D(const tbb::blocked_range2d<size_t, size_t>& r)
-: m_Range({r.rows().begin(), r.cols().begin(), r.rows().end(), r.cols().end()})
+: m_Range({{r.rows().begin(), r.cols().begin(), r.rows().end(), r.cols().end()}})
 {
 }
 #endif

--- a/Source/SIMPLib/Common/SIMPLRange3D.cpp
+++ b/Source/SIMPLib/Common/SIMPLRange3D.cpp
@@ -37,7 +37,7 @@
 //
 // -----------------------------------------------------------------------------
 SIMPLRange3D::SIMPLRange3D()
-: m_Range({0, 0, 0, 0, 0, 0})
+: m_Range({{0, 0, 0, 0, 0, 0}})
 {
 }
 
@@ -45,7 +45,7 @@ SIMPLRange3D::SIMPLRange3D()
 //
 // -----------------------------------------------------------------------------
 SIMPLRange3D::SIMPLRange3D(size_t x, size_t y, size_t z)
-: m_Range({0, x, 0, y, 0, z})
+: m_Range({{0, x, 0, y, 0, z}})
 {
 }
 
@@ -53,7 +53,7 @@ SIMPLRange3D::SIMPLRange3D(size_t x, size_t y, size_t z)
 //
 // -----------------------------------------------------------------------------
 SIMPLRange3D::SIMPLRange3D(size_t xMin, size_t xMax, size_t yMin, size_t yMax, size_t zMin, size_t zMax)
-: m_Range({xMin, xMax, yMin, yMax, zMin, zMax})
+: m_Range({{xMin, xMax, yMin, yMax, zMin, zMax}})
 {
 }
 
@@ -62,7 +62,7 @@ SIMPLRange3D::SIMPLRange3D(size_t xMin, size_t xMax, size_t yMin, size_t yMax, s
 //
 // -----------------------------------------------------------------------------
 SIMPLRange3D::SIMPLRange3D(const tbb::blocked_range3d<size_t>& r)
-: m_Range({r.pages().begin(), r.pages().end(), r.rows().begin(), r.rows().end(), r.cols().begin(), r.cols().end()})
+: m_Range({{r.pages().begin(), r.pages().end(), r.rows().begin(), r.rows().end(), r.cols().begin(), r.cols().end()}})
 {
 }
 #endif
@@ -80,7 +80,7 @@ SIMPLRange3D::RangeType SIMPLRange3D::getRange() const
 // -----------------------------------------------------------------------------
 SIMPLRange3D::DimensionRange SIMPLRange3D::getXRange() const
 {
-  return {m_Range[0], m_Range[1]};
+  return {{m_Range[0], m_Range[1]}};
 }
 
 // -----------------------------------------------------------------------------
@@ -88,7 +88,7 @@ SIMPLRange3D::DimensionRange SIMPLRange3D::getXRange() const
 // -----------------------------------------------------------------------------
 SIMPLRange3D::DimensionRange SIMPLRange3D::getYRange() const
 {
-  return {m_Range[2], m_Range[3]};
+  return {{m_Range[2], m_Range[3]}};
 }
 
 // -----------------------------------------------------------------------------
@@ -96,7 +96,7 @@ SIMPLRange3D::DimensionRange SIMPLRange3D::getYRange() const
 // -----------------------------------------------------------------------------
 SIMPLRange3D::DimensionRange SIMPLRange3D::getZRange() const
 {
-  return {m_Range[4], m_Range[5]};
+  return {{m_Range[4], m_Range[5]}};
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
* Added an extra set of braces around the various SIMPLRange array initialization points to silence warnings for MacOS.
* This has been tested to ensure this does not add additional warnings for Windows.
* This affects SIMPLRange, SIMPLRange2D, and SIMPLRange3D.