### PR TITLE
Copying a DataContainerReader filter only copies that filter

### DIFF
--- a/Source/SIMPLib/FilterParameters/JsonFilterParametersWriter.cpp
+++ b/Source/SIMPLib/FilterParameters/JsonFilterParametersWriter.cpp
@@ -47,11 +47,9 @@
 //
 // -----------------------------------------------------------------------------
 JsonFilterParametersWriter::JsonFilterParametersWriter()
-:
- m_ExpandReaderFilters(true)
+: m_ExpandReaderFilters(true)
 , m_MaxFilterIndex(-1)
 , m_CurrentIndex(0)
-
 {
 }
 
@@ -59,7 +57,8 @@ JsonFilterParametersWriter::JsonFilterParametersWriter()
 //
 // -----------------------------------------------------------------------------
 JsonFilterParametersWriter::JsonFilterParametersWriter(QString& fileName, QString& pipelineName, int& numFilters)
-: m_MaxFilterIndex(-1)
+: m_ExpandReaderFilters(true)
+, m_MaxFilterIndex(-1)
 , m_CurrentIndex(0)
 {
   m_FileName = fileName;

--- a/Source/SVWidgetsLib/Widgets/SVPipelineView.cpp
+++ b/Source/SVWidgetsLib/Widgets/SVPipelineView.cpp
@@ -714,6 +714,7 @@ void SVPipelineView::copySelectedFilters()
   }
 
   JsonFilterParametersWriter::Pointer jsonWriter = JsonFilterParametersWriter::New();
+  jsonWriter->setExpandReaderFilters(false);
   QString jsonString = jsonWriter->writePipelineToString(pipeline, "Pipeline");
 
   QClipboard* clipboard = QApplication::clipboard();


### PR DESCRIPTION
* Copying a DataContainerReader filter to the clipboard in SVPipelineView no longer copies the entire pipeline that was written instead.  This is done by taking advantage of JsonFilterParametersWriter::setExpandReaderFilters(bool) to avoid modifying behavior used to write DREAM.3D files.