### PR TITLE
Feature/generate tilt series fix

### DIFF
--- a/Source/SIMPLib/CoreFilters/GenerateTiltSeries.cpp
+++ b/Source/SIMPLib/CoreFilters/GenerateTiltSeries.cpp
@@ -581,7 +581,7 @@ std::pair<FloatArrayType::Pointer, ImageGeom::Pointer> GenerateTiltSeries::gener
   float jIncr = resampleSpacing[xAxis];
 
   axisLength = {bounds[2 * xAxis + 1] - bounds[2 * xAxis], bounds[2 * yAxis + 1] - bounds[2 * yAxis], bounds[2 * zAxis + 1] - bounds[2 * zAxis]};
-  diagonalDistance = std::sqrtf(axisLength[0] * axisLength[0] + axisLength[1] * axisLength[1]);
+  diagonalDistance = std::sqrt(axisLength[0] * axisLength[0] + axisLength[1] * axisLength[1]);
 
   newOrigin[xAxis] = center[xAxis] - diagonalDistance / 2.0f;
   newOrigin[yAxis] = center[yAxis];
@@ -675,7 +675,7 @@ std::pair<FloatArrayType::Pointer, ImageGeom::Pointer> GenerateTiltSeries::gener
   std::array<float, 3> newOrigin = {0.0f, 0.0f, 0.0f};
 
   axisLength = {bounds[2 * yAxis + 1] - bounds[2 * yAxis], bounds[2 * zAxis + 1] - bounds[2 * zAxis], bounds[2 * xAxis + 1] - bounds[2 * xAxis]};
-  diagonalDistance = std::sqrtf(axisLength[0] * axisLength[0] + axisLength[1] * axisLength[1]);
+  diagonalDistance = std::sqrt(axisLength[0] * axisLength[0] + axisLength[1] * axisLength[1]);
 
   newOrigin[xAxis] = center[xAxis];
   newOrigin[yAxis] = bounds[yAxis * 2];
@@ -770,7 +770,7 @@ std::pair<FloatArrayType::Pointer, ImageGeom::Pointer> GenerateTiltSeries::gener
   std::array<float, 3> newOrigin = {0.0f, 0.0f, 0.0f};
 
   axisLength = {bounds[2 * xAxis + 1] - bounds[2 * xAxis], bounds[2 * yAxis + 1] - bounds[2 * yAxis], bounds[2 * zAxis + 1] - bounds[2 * zAxis]};
-  diagonalDistance = std::sqrtf(axisLength[xAxis] * axisLength[xAxis] + axisLength[yAxis] * axisLength[yAxis]);
+  diagonalDistance = std::sqrt(axisLength[xAxis] * axisLength[xAxis] + axisLength[yAxis] * axisLength[yAxis]);
 
   newOrigin[xAxis] = bounds[xAxis]; // xMin
   newOrigin[yAxis] = center[yAxis] - diagonalDistance / 2.0f;

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/GenerateTiltSeriesTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/GenerateTiltSeriesTest.cpp
@@ -76,8 +76,8 @@ class GenerateTiltSeriesTest
   const QString k_RotationBaseString = QString("Rotation_%1_%2");
   const QString k_FeatureIdsName = QString("FeatureIds");
   const QString k_SliceDataName = QString("Slice Data");
-  static constexpr int k_NumRotations = 12;
-  static constexpr float k_Increment = 15.0f;
+  const int k_NumRotations = 12;
+  const float k_Increment = 15.0f;
 
 public:
   GenerateTiltSeriesTest() = default;


### PR DESCRIPTION
Fixed gcc compile errors
* sqrtf isn't in the std namespace
* static constexpr member variable considered "undefined"