### PR TITLE
Add DataArraySelectionFilterParameter::CreateRequirement for vector of strings

### DIFF
--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
@@ -161,6 +161,39 @@ DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParam
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParameter::CreateRequirement(const QVector<QString>& primitiveTypes, size_t allowedCompDim,
+                                                                                                        AttributeMatrix::Type attributeMatrixType, IGeometry::Type geometryType)
+{
+  using SizeTVectorType = std::vector<size_t>;
+  DataArraySelectionFilterParameter::RequirementType req;
+
+  for(const auto& type : primitiveTypes)
+  {
+    if(type.compare(SIMPL::Defaults::AnyPrimitive) != 0)
+    {
+      req.daTypes.push_back(type);
+    }
+  }
+
+  if(SIMPL::Defaults::AnyComponentSize != allowedCompDim)
+  {
+    req.componentDimensions = std::vector<SizeTVectorType>(1, SizeTVectorType(1, allowedCompDim));
+  }
+  if(AttributeMatrix::Type::Any != attributeMatrixType)
+  {
+    QVector<AttributeMatrix::Type> amTypes(1, attributeMatrixType);
+    req.amTypes = amTypes;
+  }
+  if(IGeometry::Type::Any != geometryType)
+  {
+    req.dcGeometryTypes = IGeometry::Types(1, geometryType);
+  }
+  return req;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void DataArraySelectionFilterParameter::readJson(const QJsonObject& json)
 {
   QJsonValue jsonValue = json[getPropertyName()];

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.cpp
@@ -148,7 +148,7 @@ DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParam
   }
   if(AttributeMatrix::Type::Any != attributeMatrixType)
   {
-    QVector<AttributeMatrix::Type> amTypes(1, attributeMatrixType);
+    AttributeMatrix::Types amTypes(1, attributeMatrixType);
     req.amTypes = amTypes;
   }
   if(IGeometry::Type::Any != geometryType)
@@ -181,7 +181,7 @@ DataArraySelectionFilterParameter::RequirementType DataArraySelectionFilterParam
   }
   if(AttributeMatrix::Type::Any != attributeMatrixType)
   {
-    QVector<AttributeMatrix::Type> amTypes(1, attributeMatrixType);
+    AttributeMatrix::Types amTypes(1, attributeMatrixType);
     req.amTypes = amTypes;
   }
   if(IGeometry::Type::Any != geometryType)
@@ -292,13 +292,13 @@ IGeometry::Types DataArraySelectionFilterParameter::getDefaultGeometryTypes() co
 }
 
 // -----------------------------------------------------------------------------
-void DataArraySelectionFilterParameter::setDefaultAttributeMatrixTypes(const QVector<AttributeMatrix::Type>& value)
+void DataArraySelectionFilterParameter::setDefaultAttributeMatrixTypes(const AttributeMatrix::Types& value)
 {
   m_DefaultAttributeMatrixTypes = value;
 }
 
 // -----------------------------------------------------------------------------
-QVector<AttributeMatrix::Type> DataArraySelectionFilterParameter::getDefaultAttributeMatrixTypes() const
+AttributeMatrix::Types DataArraySelectionFilterParameter::getDefaultAttributeMatrixTypes() const
 {
   return m_DefaultAttributeMatrixTypes;
 }

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
@@ -207,12 +207,12 @@ class SIMPLib_EXPORT DataArraySelectionFilterParameter : public FilterParameter
     /**
      * @brief Setter property for DefaultAttributeMatrixTypes
      */
-    void setDefaultAttributeMatrixTypes(const QVector<AttributeMatrix::Type>& value);
+    void setDefaultAttributeMatrixTypes(const AttributeMatrix::Types& value);
     /**
      * @brief Getter property for DefaultAttributeMatrixTypes
      * @return Value of DefaultAttributeMatrixTypes
      */
-    QVector<AttributeMatrix::Type> getDefaultAttributeMatrixTypes() const;
+    AttributeMatrix::Types getDefaultAttributeMatrixTypes() const;
 
     /**
     * @param DefaultAttributeArrayTypes Default attribute array types required for Attribute Array selections
@@ -292,7 +292,7 @@ class SIMPLib_EXPORT DataArraySelectionFilterParameter : public FilterParameter
 
   private:
     IGeometry::Types m_DefaultGeometryTypes = {};
-    QVector<AttributeMatrix::Type> m_DefaultAttributeMatrixTypes = {};
+    AttributeMatrix::Types m_DefaultAttributeMatrixTypes = {};
     QVector<QString> m_DefaultAttributeArrayTypes = {};
     std::vector<std::vector<size_t>> m_DefaultComponentDimensions = {};
     DataArraySelectionFilterParameter::SetterCallbackType m_SetterCallback = {};

--- a/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h
@@ -151,6 +151,15 @@ class SIMPLib_EXPORT DataArraySelectionFilterParameter : public FilterParameter
                                              AttributeMatrix::Type attributeMatrixType,
                                              IGeometry::Type geometryType);
 
+    /**
+     * @brief CreateRequirement
+     * @param primitiveTypes
+     * @param allowedCompDim
+     * @param attributeMatrixType
+     * @param geometryType
+     * @return
+     */
+    static RequirementType CreateRequirement(const QVector<QString>& primitiveTypes, size_t allowedCompDim, AttributeMatrix::Type attributeMatrixType, IGeometry::Type geometryType);
 
     /**
     * @brief getWidgetType Returns the type of widget that displays and controls


### PR DESCRIPTION
* Can now use a static creation function to allow multiple types in DataArraySelectionFilterParameter instead of having to specify it in a separate statement