### PR TITLE
Feature/move rotate filter

### DIFF
--- a/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.cpp
+++ b/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.cpp
@@ -1,0 +1,820 @@
+/* ============================================================================
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "RotateSampleRefFrame.h"
+
+#include <cmath>
+#include <memory>
+
+#ifdef SIMPL_USE_PARALLEL_ALGORITHMS
+#include <tbb/blocked_range3d.h>
+#include <tbb/parallel_for.h>
+#include <tbb/partitioner.h>
+#include <tbb/task_scheduler_init.h>
+#endif
+
+#include <QtCore/QTextStream>
+
+#include <Eigen/Dense>
+
+#include "SIMPLib/Common/Constants.h"
+
+#include "SIMPLib/DataContainers/DataContainerArray.h"
+#include "SIMPLib/DataContainers/DataContainer.h"
+#include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
+#include "SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.h"
+#include "SIMPLib/FilterParameters/DynamicTableFilterParameter.h"
+#include "SIMPLib/FilterParameters/FloatFilterParameter.h"
+#include "SIMPLib/FilterParameters/FloatVec3FilterParameter.h"
+#include "SIMPLib/FilterParameters/LinkedChoicesFilterParameter.h"
+#include "SIMPLib/FilterParameters/SeparatorFilterParameter.h"
+#include "SIMPLib/Geometry/ImageGeom.h"
+#include "SIMPLib/Math/MatrixMath.h"
+#include "SIMPLib/SIMPLibVersion.h"
+
+namespace
+{
+struct RotateArgs
+{
+  int64_t xp = 0;
+  int64_t yp = 0;
+  int64_t zp = 0;
+  float xRes = 0.0f;
+  float yRes = 0.0f;
+  float zRes = 0.0f;
+  int64_t xpNew = 0;
+  int64_t ypNew = 0;
+  int64_t zpNew = 0;
+  float xResNew = 0.0f;
+  float yResNew = 0.0f;
+  float zResNew = 0.0f;
+  float xMinNew = 0.0f;
+  float yMinNew = 0.0f;
+  float zMinNew = 0.0f;
+};
+
+using Matrix3fR = Eigen::Matrix<float, 3, 3, Eigen::RowMajor>;
+
+constexpr float k_Threshold = 0.0001f;
+
+const Eigen::Vector3f k_XAxis = Eigen::Vector3f::UnitX();
+const Eigen::Vector3f k_YAxis = Eigen::Vector3f::UnitY();
+const Eigen::Vector3f k_ZAxis = Eigen::Vector3f::UnitZ();
+
+// Requires table to be 3 x 3
+Matrix3fR tableToMatrix(const std::vector<std::vector<double>>& table)
+{
+  Matrix3fR matrix;
+
+  for(size_t i = 0; i < table.size(); i++)
+  {
+    const auto& row = table[i];
+    for(size_t j = 0; j < row.size(); j++)
+    {
+      matrix(i, j) = row[j];
+    }
+  }
+
+  return matrix;
+}
+
+void determineMinMax(const Matrix3fR& rotationMatrix, const FloatVec3Type& spacing, size_t col, size_t row, size_t plane, float& xMin, float& xMax, float& yMin, float& yMax, float& zMin, float& zMax)
+{
+  Eigen::Vector3f coords(static_cast<float>(col) * spacing[0], static_cast<float>(row) * spacing[1], static_cast<float>(plane) * spacing[2]);
+
+  Eigen::Vector3f newCoords = rotationMatrix * coords;
+
+  xMin = std::min(newCoords[0], xMin);
+  xMax = std::max(newCoords[0], xMax);
+
+  yMin = std::min(newCoords[1], yMin);
+  yMax = std::max(newCoords[1], yMax);
+
+  zMin = std::min(newCoords[2], zMin);
+  zMax = std::max(newCoords[2], zMax);
+}
+
+float cosBetweenVectors(const Eigen::Vector3f& a, const Eigen::Vector3f& b)
+{
+  float normA = a.norm();
+  float normB = b.norm();
+
+  if(normA == 0.0f || normB == 0.0f)
+  {
+    return 1.0f;
+  }
+
+  return a.dot(b) / (normA * normB);
+}
+
+float determineSpacing(const FloatVec3Type& spacing, const Eigen::Vector3f& axisNew)
+{
+  float xAngle = std::abs(cosBetweenVectors(k_XAxis, axisNew));
+  float yAngle = std::abs(cosBetweenVectors(k_YAxis, axisNew));
+  float zAngle = std::abs(cosBetweenVectors(k_ZAxis, axisNew));
+
+  std::array<float, 3> axes = {xAngle, yAngle, zAngle};
+
+  auto iter = std::max_element(axes.cbegin(), axes.cend());
+
+  size_t index = std::distance(axes.cbegin(), iter);
+
+  return spacing[index];
+}
+
+RotateArgs createRotateParams(const ImageGeom& imageGeom, const Matrix3fR& rotationMatrix)
+{
+  const SizeVec3Type origDims = imageGeom.getDimensions();
+  const FloatVec3Type spacing = imageGeom.getSpacing();
+  const FloatVec3Type origin = imageGeom.getOrigin();
+
+  float xMin = std::numeric_limits<float>::max();
+  float xMax = std::numeric_limits<float>::min();
+  float yMin = std::numeric_limits<float>::max();
+  float yMax = std::numeric_limits<float>::min();
+  float zMin = std::numeric_limits<float>::max();
+  float zMax = std::numeric_limits<float>::min();
+
+  const std::vector<std::vector<size_t>> coords{{0, 0, 0},
+                                                {origDims[0] - 1, 0, 0},
+                                                {0, origDims[1] - 1, 0},
+                                                {origDims[0] - 1, origDims[1] - 1, 0},
+                                                {0, 0, origDims[2] - 1},
+                                                {origDims[0] - 1, 0, origDims[2] - 1},
+                                                {0, origDims[1] - 1, origDims[2] - 1},
+                                                {origDims[0] - 1, origDims[1] - 1, origDims[2] - 1}};
+
+  for(const auto& item : coords)
+  {
+    determineMinMax(rotationMatrix, spacing, item[0], item[1], item[2], xMin, xMax, yMin, yMax, zMin, zMax);
+  }
+
+  Eigen::Vector3f xAxisNew = rotationMatrix * k_XAxis;
+  Eigen::Vector3f yAxisNew = rotationMatrix * k_YAxis;
+  Eigen::Vector3f zAxisNew = rotationMatrix * k_ZAxis;
+
+  float xResNew = determineSpacing(spacing, xAxisNew);
+  float yResNew = determineSpacing(spacing, yAxisNew);
+  float zResNew = determineSpacing(spacing, zAxisNew);
+
+  MeshIndexType xpNew = static_cast<int64_t>(std::nearbyint((xMax - xMin) / xResNew) + 1);
+  MeshIndexType ypNew = static_cast<int64_t>(std::nearbyint((yMax - yMin) / yResNew) + 1);
+  MeshIndexType zpNew = static_cast<int64_t>(std::nearbyint((zMax - zMin) / zResNew) + 1);
+
+  RotateArgs params;
+
+  params.xp = origDims[0];
+  params.xRes = spacing[0];
+  params.yp = origDims[1];
+  params.yRes = spacing[1];
+  params.zp = origDims[2];
+  params.zRes = spacing[2];
+
+  params.xpNew = xpNew;
+  params.xResNew = xResNew;
+  params.xMinNew = xMin;
+  params.ypNew = ypNew;
+  params.yResNew = yResNew;
+  params.yMinNew = yMin;
+  params.zpNew = zpNew;
+  params.zResNew = zResNew;
+  params.zMinNew = zMin;
+
+  return params;
+}
+
+void updateGeometry(ImageGeom& imageGeom, const RotateArgs& params)
+{
+  FloatVec3Type origin = imageGeom.getOrigin();
+
+  imageGeom.setSpacing(params.xResNew, params.yResNew, params.zResNew);
+  imageGeom.setDimensions(params.xpNew, params.ypNew, params.zpNew);
+  origin[0] += params.xMinNew;
+  origin[1] += params.yMinNew;
+  origin[2] += params.zMinNew;
+  imageGeom.setOrigin(origin);
+}
+
+/**
+ * @brief The RotateSampleRefFrameImpl class implements a threaded algorithm to do the
+ * actual computation of the rotation by applying the rotation to each Euler angle
+ */
+class SampleRefFrameRotator
+{
+  DataArray<int64_t>::Pointer m_NewIndicesPtr;
+  float m_RotMatrixInv[3][3] = {{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}};
+  bool m_SliceBySlice = false;
+  RotateArgs m_Params;
+
+public:
+  SampleRefFrameRotator(DataArray<int64_t>::Pointer newindices, const RotateArgs& args, const Matrix3fR& rotationMatrix, bool sliceBySlice)
+  : m_NewIndicesPtr(newindices)
+  , m_SliceBySlice(sliceBySlice)
+  , m_Params(args)
+  {
+    // We have to inline the 3x3 Maxtrix transpose here because of the "const" nature of the 'convert' function
+    Matrix3fR transpose = rotationMatrix.transpose();
+    // Need to use row based Eigen matrix so that the values get mapped to the right place in the raw array
+    // Raw array is faster than Eigen
+    Eigen::Map<Matrix3fR>(&m_RotMatrixInv[0][0], transpose.rows(), transpose.cols()) = transpose;
+  }
+
+  ~SampleRefFrameRotator() = default;
+
+  void convert(int64_t zStart, int64_t zEnd, int64_t yStart, int64_t yEnd, int64_t xStart, int64_t xEnd) const
+  {
+    int64_t* newindicies = m_NewIndicesPtr->getPointer(0);
+
+    for(int64_t k = zStart; k < zEnd; k++)
+    {
+      int64_t ktot = (m_Params.xpNew * m_Params.ypNew) * k;
+      for(int64_t j = yStart; j < yEnd; j++)
+      {
+        int64_t jtot = (m_Params.xpNew) * j;
+        for(int64_t i = xStart; i < xEnd; i++)
+        {
+          int64_t index = ktot + jtot + i;
+          newindicies[index] = -1;
+
+          float coords[3] = {0.0f, 0.0f, 0.0f};
+          float coordsNew[3] = {0.0f, 0.0f, 0.0f};
+
+          coords[0] = (static_cast<float>(i) * m_Params.xResNew) + m_Params.xMinNew;
+          coords[1] = (static_cast<float>(j) * m_Params.yResNew) + m_Params.yMinNew;
+          coords[2] = (static_cast<float>(k) * m_Params.zResNew) + m_Params.zMinNew;
+
+          MatrixMath::Multiply3x3with3x1(m_RotMatrixInv, coords, coordsNew);
+
+          int64_t colOld = static_cast<int64_t>(std::nearbyint(coordsNew[0] / m_Params.xRes));
+          int64_t rowOld = static_cast<int64_t>(std::nearbyint(coordsNew[1] / m_Params.yRes));
+          int64_t planeOld = static_cast<int64_t>(std::nearbyint(coordsNew[2] / m_Params.zRes));
+
+          if(m_SliceBySlice)
+          {
+            planeOld = k;
+          }
+
+          if(colOld >= 0 && colOld < m_Params.xp && rowOld >= 0 && rowOld < m_Params.yp && planeOld >= 0 && planeOld < m_Params.zp)
+          {
+            newindicies[index] = (m_Params.xp * m_Params.yp * planeOld) + (m_Params.xp * rowOld) + colOld;
+          }
+        }
+      }
+    }
+  }
+
+#ifdef SIMPL_USE_PARALLEL_ALGORITHMS
+  void operator()(const tbb::blocked_range3d<int64_t, int64_t, int64_t>& r) const
+  {
+    convert(r.pages().begin(), r.pages().end(), r.rows().begin(), r.rows().end(), r.cols().begin(), r.cols().end());
+  }
+#endif
+};
+
+} // namespace
+
+struct RotateSampleRefFrame::Impl
+{
+  Matrix3fR m_RotationMatrix = Matrix3fR::Zero();
+  RotateArgs m_Params;
+
+  void reset()
+  {
+    m_RotationMatrix.setZero();
+
+    m_Params = RotateArgs();
+  }
+};
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+RotateSampleRefFrame::RotateSampleRefFrame()
+: m_CellAttributeMatrixPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, "")
+, p_Impl(std::make_unique<Impl>())
+{
+  std::vector<std::vector<double>> defaultTable{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}};
+  m_RotationTable.setTableData(defaultTable);
+  m_RotationTable.setDynamicRows(false);
+  m_RotationTable.setDynamicCols(false);
+  m_RotationTable.setDefaultColCount(3);
+  m_RotationTable.setDefaultRowCount(3);
+  m_RotationTable.setMinCols(3);
+  m_RotationTable.setMinRows(3);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+RotateSampleRefFrame::~RotateSampleRefFrame() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::setupFilterParameters()
+{
+  FilterParameterVectorType parameters;
+
+  {
+    LinkedChoicesFilterParameter::Pointer parameter = LinkedChoicesFilterParameter::New();
+    parameter->setHumanLabel("Rotation Representation");
+    parameter->setPropertyName("RotationRepresentation");
+    parameter->setSetterCallback(SIMPL_BIND_SETTER(RotateSampleRefFrame, this, RotationRepresentation));
+    parameter->setGetterCallback(SIMPL_BIND_GETTER(RotateSampleRefFrame, this, RotationRepresentation));
+    QVector<QString> choices{"Axis Angle", "Rotation Matrix"};
+    parameter->setChoices(choices);
+    QStringList linkedProps{"RotationAngle", "RotationAxis", "RotationTable"};
+    parameter->setLinkedProperties(linkedProps);
+    parameter->setEditable(false);
+    parameter->setCategory(FilterParameter::Category::Parameter);
+    parameters.push_back(parameter);
+  }
+
+  // Axis Angle Parameters
+
+  parameters.push_back(SIMPL_NEW_FLOAT_FP("Rotation Angle (Degrees)", RotationAngle, FilterParameter::Parameter, RotateSampleRefFrame, 0));
+  parameters.push_back(SIMPL_NEW_FLOAT_VEC3_FP("Rotation Axis (ijk)", RotationAxis, FilterParameter::Parameter, RotateSampleRefFrame, 0));
+
+  // Rotation Matrix Parameters
+
+  parameters.push_back(SIMPL_NEW_DYN_TABLE_FP("Rotation Matrix", RotationTable, FilterParameter::Parameter, RotateSampleRefFrame, 1));
+
+  // Required Arrays
+
+  parameters.push_back(SeparatorFilterParameter::New("Cell Data", FilterParameter::RequiredArray));
+  {
+    AttributeMatrixSelectionFilterParameter::RequirementType req = AttributeMatrixSelectionFilterParameter::CreateRequirement(AttributeMatrix::Type::Cell, IGeometry::Type::Image);
+    parameters.push_back(SIMPL_NEW_AM_SELECTION_FP("Cell Attribute Matrix", CellAttributeMatrixPath, FilterParameter::RequiredArray, RotateSampleRefFrame, req));
+  }
+
+  setFilterParameters(parameters);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::readFilterParameters(AbstractFilterParametersReader* reader, int index)
+{
+  reader->openFilterGroup(this, index);
+  setCellAttributeMatrixPath(reader->readDataArrayPath("CellAttributeMatrixPath", getCellAttributeMatrixPath()));
+  setRotationAxis(reader->readFloatVec3("RotationAxis", getRotationAxis()));
+  setRotationAngle(reader->readValue("RotationAngle", getRotationAngle()));
+  reader->closeFilterGroup();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::initialize()
+{
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::dataCheck()
+{
+  clearErrorCode();
+  clearWarningCode();
+
+  p_Impl->reset();
+
+  if(getErrorCode() < 0)
+  {
+    return;
+  }
+
+  if(!isRotationRepresentationValid(m_RotationRepresentation))
+  {
+    QString ss = QObject::tr("Invalid rotation representation");
+    setErrorCondition(-45001, ss);
+    return;
+  }
+
+  getDataContainerArray()->getPrereqGeometryFromDataContainer<ImageGeom, AbstractFilter>(this, getCellAttributeMatrixPath().getDataContainerName());
+  getDataContainerArray()->getPrereqAttributeMatrixFromPath<AbstractFilter>(this, getCellAttributeMatrixPath(), -301);
+  if(getErrorCode() < 0)
+  {
+    return;
+  }
+
+  DataContainer::Pointer m = getDataContainerArray()->getDataContainer(getCellAttributeMatrixPath().getDataContainerName());
+
+  if(m == nullptr)
+  {
+    QString ss = QObject::tr("Failed to get DataContainer '%1'").arg(getCellAttributeMatrixPath().getDataContainerName());
+    setErrorCondition(-45002, ss);
+    return;
+  }
+
+  ImageGeom::Pointer imageGeom = m->getGeometryAs<ImageGeom>();
+
+  if(imageGeom == nullptr)
+  {
+    QString ss = QObject::tr("Failed to get Image Geometry from '%1'").arg(getCellAttributeMatrixPath().getDataContainerName());
+    setErrorCondition(-45002, ss);
+    return;
+  }
+
+  const RotationRepresentation representation = getRotationRepresentationEnum();
+
+  switch(representation)
+  {
+  case RotationRepresentation::AxisAngle:
+  {
+    const Eigen::Vector3f rotationAxis(m_RotationAxis.data());
+    float norm = rotationAxis.norm();
+    if(!SIMPLibMath::closeEnough(rotationAxis.norm(), 1.0f, k_Threshold))
+    {
+      QString ss = QObject::tr("Axis angle is not normalized (norm is %1). Filter will automatically normalize the value.").arg(norm);
+      setWarningCondition(-45003, ss);
+    }
+
+    float rotationAngleRadians = m_RotationAngle * SIMPLib::Constants::k_DegToRad;
+
+    Eigen::AngleAxisf axisAngle(rotationAngleRadians, rotationAxis.normalized());
+
+    p_Impl->m_RotationMatrix = axisAngle.toRotationMatrix();
+  }
+  break;
+  case RotationRepresentation::RotationMatrix:
+  {
+    auto rotationMatrixTable = m_RotationTable.getTableData();
+
+    if(rotationMatrixTable.size() != 3)
+    {
+      QString ss = QObject::tr("Rotation Matrix must be 3 x 3");
+      setErrorCondition(-45004, ss);
+      return;
+    }
+
+    for(const auto& row : rotationMatrixTable)
+    {
+      if(row.size() != 3)
+      {
+        QString ss = QObject::tr("Rotation Matrix must be 3 x 3");
+        setErrorCondition(-45005, ss);
+        return;
+      }
+    }
+
+    Matrix3fR rotationMatrix = tableToMatrix(rotationMatrixTable);
+
+    float determinant = rotationMatrix.determinant();
+
+    if(!SIMPLibMath::closeEnough(determinant, 1.0f, k_Threshold))
+    {
+      QString ss = QObject::tr("Rotation Matrix must have a determinant of 1 (is %1)").arg(determinant);
+      setErrorCondition(-45006, ss);
+      return;
+    }
+
+    Matrix3fR transpose = rotationMatrix.transpose();
+    Matrix3fR inverse = rotationMatrix.inverse();
+
+    if(!transpose.isApprox(inverse, k_Threshold))
+    {
+      QString ss = QObject::tr("Rotation Matrix's inverse and transpose must be equal");
+      setErrorCondition(-45007, ss);
+      return;
+    }
+
+    p_Impl->m_RotationMatrix = rotationMatrix;
+  }
+  break;
+  default:
+  {
+    QString ss = QObject::tr("Invalid rotation representation");
+    setErrorCondition(-45008, ss);
+    return;
+  }
+  }
+
+  p_Impl->m_Params = createRotateParams(*imageGeom, p_Impl->m_RotationMatrix);
+
+  updateGeometry(*imageGeom, p_Impl->m_Params);
+
+  // Resize attribute matrix
+
+  std::vector<size_t> tDims(3);
+  tDims[0] = p_Impl->m_Params.xpNew;
+  tDims[1] = p_Impl->m_Params.ypNew;
+  tDims[2] = p_Impl->m_Params.zpNew;
+  QString attrMatName = getCellAttributeMatrixPath().getAttributeMatrixName();
+  m->getAttributeMatrix(attrMatName)->resizeAttributeArrays(tDims);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::preflight()
+{
+  // These are the REQUIRED lines of CODE to make sure the filter behaves correctly
+  setInPreflight(true);              // Set the fact that we are preflighting.
+  emit preflightAboutToExecute();    // Emit this signal so that other widgets can do one file update
+  emit updateFilterParameters(this); // Emit this signal to have the widgets push their values down to the filter
+  dataCheck();                       // Run our DataCheck to make sure everthing is setup correctly
+  emit preflightExecuted();          // We are done preflighting this filter
+  setInPreflight(false);             // Inform the system this filter is NOT in preflight mode anymore.
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::execute()
+{
+  clearErrorCode();
+  clearWarningCode();
+  dataCheck();
+  if(getErrorCode() < 0)
+  {
+    return;
+  }
+
+  DataContainer::Pointer m = getDataContainerArray()->getDataContainer(getCellAttributeMatrixPath().getDataContainerName());
+
+  if(m == nullptr)
+  {
+    QString ss = QObject::tr("Failed to get DataContainer '%1'").arg(getCellAttributeMatrixPath().getDataContainerName());
+    setErrorCondition(-45101, ss);
+    return;
+  }
+
+  int64_t newNumCellTuples = p_Impl->m_Params.xpNew * p_Impl->m_Params.ypNew * p_Impl->m_Params.zpNew;
+
+  DataArray<int64_t>::Pointer newIndiciesPtr = DataArray<int64_t>::CreateArray(newNumCellTuples, "_INTERNAL_USE_ONLY_RotateSampleRef_NewIndicies", true);
+  newIndiciesPtr->initializeWithValue(-1);
+  int64_t* newindicies = newIndiciesPtr->getPointer(0);
+
+#ifdef SIMPL_USE_PARALLEL_ALGORITHMS
+  tbb::parallel_for(tbb::blocked_range3d<int64_t, int64_t, int64_t>(0, p_Impl->m_Params.zpNew, 0, p_Impl->m_Params.ypNew, 0, p_Impl->m_Params.xpNew),
+                    SampleRefFrameRotator(newIndiciesPtr, p_Impl->m_Params, p_Impl->m_RotationMatrix, m_SliceBySlice), tbb::auto_partitioner());
+#else
+  {
+    SampleRefFrameRotator serial(newIndiciesPtr, p_Impl->m_Params, p_Impl->m_RotationMatrix, m_SliceBySlice);
+    serial.convert(0, p_Impl->m_Params.zpNew, 0, p_Impl->m_Params.ypNew, 0, p_Impl->m_Params.xpNew);
+  }
+#endif
+
+  // This could technically be parallelized also where each thread takes an array to adjust. Except
+  // that the DataContainer is NOT thread safe or re-entrant so that would actually be a BAD idea.
+
+  QString attrMatName = getCellAttributeMatrixPath().getAttributeMatrixName();
+  QList<QString> voxelArrayNames = m->getAttributeMatrix(attrMatName)->getAttributeArrayNames();
+
+  for(const auto& attrArrayName : voxelArrayNames)
+  {
+    IDataArray::Pointer p = m->getAttributeMatrix(attrMatName)->getAttributeArray(attrArrayName);
+
+    // Make a copy of the 'p' array that has the same name. When placed into
+    // the data container this will over write the current array with
+    // the same name.
+
+    IDataArray::Pointer data = p->createNewArray(newNumCellTuples, p->getComponentDimensions(), p->getName());
+    int64_t newIndicies_I = 0;
+    for(size_t i = 0; i < static_cast<size_t>(newNumCellTuples); i++)
+    {
+      newIndicies_I = newindicies[i];
+      if(newIndicies_I >= 0)
+      {
+        if(!data->copyFromArray(i, p, newIndicies_I, 1))
+        {
+          QString ss = QObject::tr("copyFromArray Failed: ");
+          QTextStream out(&ss);
+          out << "Source Array Name: " << p->getName() << " Source Tuple Index: " << newIndicies_I << "\n";
+          out << "Dest Array Name: " << data->getName() << "  Dest. Tuple Index: " << i << "\n";
+          setErrorCondition(-45102, ss);
+          return;
+        }
+      }
+      else
+      {
+        int var = 0;
+        data->initializeTuple(i, &var);
+      }
+    }
+    m->getAttributeMatrix(attrMatName)->insertOrAssign(data);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+AbstractFilter::Pointer RotateSampleRefFrame::newFilterInstance(bool copyFilterParameters) const
+{
+  RotateSampleRefFrame::Pointer filter = RotateSampleRefFrame::New();
+  if(copyFilterParameters)
+  {
+    copyFilterParameterInstanceVariables(filter.get());
+  }
+  return filter;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString RotateSampleRefFrame::getCompiledLibraryName() const
+{
+  return Core::CoreBaseName;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString RotateSampleRefFrame::getBrandingString() const
+{
+  return "SIMPLib Core Filter";
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString RotateSampleRefFrame::getFilterVersion() const
+{
+  QString version;
+  QTextStream vStream(&version);
+  vStream << SIMPLib::Version::Major() << "." << SIMPLib::Version::Minor() << "." << SIMPLib::Version::Patch();
+  return version;
+}
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString RotateSampleRefFrame::getGroupName() const
+{
+  return SIMPL::FilterGroups::SamplingFilters;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QUuid RotateSampleRefFrame::getUuid() const
+{
+  return QUuid("{e25d9b4c-2b37-578c-b1de-cf7032b5ef19}");
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString RotateSampleRefFrame::getSubGroupName() const
+{
+  return SIMPL::FilterSubGroups::RotationTransformationFilters;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString RotateSampleRefFrame::getHumanLabel() const
+{
+  return "Rotate Sample Reference Frame";
+}
+
+// -----------------------------------------------------------------------------
+RotateSampleRefFrame::Pointer RotateSampleRefFrame::NullPointer()
+{
+  return Pointer(static_cast<Self*>(nullptr));
+}
+
+// -----------------------------------------------------------------------------
+std::shared_ptr<RotateSampleRefFrame> RotateSampleRefFrame::New()
+{
+  struct make_shared_enabler : public RotateSampleRefFrame
+  {
+  };
+  std::shared_ptr<make_shared_enabler> val = std::make_shared<make_shared_enabler>();
+  val->setupFilterParameters();
+  return val;
+}
+
+// -----------------------------------------------------------------------------
+QString RotateSampleRefFrame::getNameOfClass() const
+{
+  return QString("RotateSampleRefFrame");
+}
+
+// -----------------------------------------------------------------------------
+QString RotateSampleRefFrame::ClassName()
+{
+  return QString("RotateSampleRefFrame");
+}
+
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::setCellAttributeMatrixPath(const DataArrayPath& value)
+{
+  m_CellAttributeMatrixPath = value;
+}
+
+// -----------------------------------------------------------------------------
+DataArrayPath RotateSampleRefFrame::getCellAttributeMatrixPath() const
+{
+  return m_CellAttributeMatrixPath;
+}
+
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::setRotationAxis(const FloatVec3Type& value)
+{
+  m_RotationAxis = value;
+}
+
+// -----------------------------------------------------------------------------
+FloatVec3Type RotateSampleRefFrame::getRotationAxis() const
+{
+  return m_RotationAxis;
+}
+
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::setRotationAngle(float value)
+{
+  m_RotationAngle = value;
+}
+
+// -----------------------------------------------------------------------------
+float RotateSampleRefFrame::getRotationAngle() const
+{
+  return m_RotationAngle;
+}
+
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::setSliceBySlice(bool value)
+{
+  m_SliceBySlice = value;
+}
+
+// -----------------------------------------------------------------------------
+bool RotateSampleRefFrame::getSliceBySlice() const
+{
+  return m_SliceBySlice;
+}
+
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::setRotationTable(const DynamicTableData& value)
+{
+  m_RotationTable = value;
+}
+
+// -----------------------------------------------------------------------------
+DynamicTableData RotateSampleRefFrame::getRotationTable() const
+{
+  return m_RotationTable;
+}
+
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::setRotationRepresentation(int value)
+{
+  m_RotationRepresentation = value;
+}
+
+// -----------------------------------------------------------------------------
+int RotateSampleRefFrame::getRotationRepresentation() const
+{
+  return m_RotationRepresentation;
+}
+
+// -----------------------------------------------------------------------------
+RotateSampleRefFrame::RotationRepresentation RotateSampleRefFrame::getRotationRepresentationEnum() const
+{
+  return static_cast<RotationRepresentation>(m_RotationRepresentation);
+}
+
+// -----------------------------------------------------------------------------
+void RotateSampleRefFrame::setRotationRepresentationEnum(RotationRepresentation value)
+{
+  m_RotationRepresentation = static_cast<int>(value);
+}
+
+// -----------------------------------------------------------------------------
+bool RotateSampleRefFrame::isRotationRepresentationValid(int value)
+{
+  return (value >= 0) && (value <= 1);
+}

--- a/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.cpp
+++ b/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.cpp
@@ -351,8 +351,8 @@ void RotateSampleRefFrame::setupFilterParameters()
     LinkedChoicesFilterParameter::Pointer parameter = LinkedChoicesFilterParameter::New();
     parameter->setHumanLabel("Rotation Representation");
     parameter->setPropertyName("RotationRepresentation");
-    parameter->setSetterCallback(SIMPL_BIND_SETTER(RotateSampleRefFrame, this, RotationRepresentation));
-    parameter->setGetterCallback(SIMPL_BIND_GETTER(RotateSampleRefFrame, this, RotationRepresentation));
+    parameter->setSetterCallback(SIMPL_BIND_SETTER(RotateSampleRefFrame, this, RotationRepresentationChoice));
+    parameter->setGetterCallback(SIMPL_BIND_GETTER(RotateSampleRefFrame, this, RotationRepresentationChoice));
     QVector<QString> choices{"Axis Angle", "Rotation Matrix"};
     parameter->setChoices(choices);
     QStringList linkedProps{"RotationAngle", "RotationAxis", "RotationTable"};
@@ -416,7 +416,7 @@ void RotateSampleRefFrame::dataCheck()
     return;
   }
 
-  if(!isRotationRepresentationValid(m_RotationRepresentation))
+  if(!isRotationRepresentationValid(m_RotationRepresentationChoice))
   {
     QString ss = QObject::tr("Invalid rotation representation");
     setErrorCondition(-45001, ss);
@@ -448,7 +448,7 @@ void RotateSampleRefFrame::dataCheck()
     return;
   }
 
-  const RotationRepresentation representation = getRotationRepresentationEnum();
+  const RotationRepresentation representation = getRotationRepresentation();
 
   switch(representation)
   {
@@ -790,31 +790,31 @@ DynamicTableData RotateSampleRefFrame::getRotationTable() const
 }
 
 // -----------------------------------------------------------------------------
-void RotateSampleRefFrame::setRotationRepresentation(int value)
+void RotateSampleRefFrame::setRotationRepresentationChoice(int value)
 {
-  m_RotationRepresentation = value;
+  m_RotationRepresentationChoice = value;
 }
 
 // -----------------------------------------------------------------------------
-int RotateSampleRefFrame::getRotationRepresentation() const
+int RotateSampleRefFrame::getRotationRepresentationChoice() const
 {
-  return m_RotationRepresentation;
+  return m_RotationRepresentationChoice;
 }
 
 // -----------------------------------------------------------------------------
-RotateSampleRefFrame::RotationRepresentation RotateSampleRefFrame::getRotationRepresentationEnum() const
+RotateSampleRefFrame::RotationRepresentation RotateSampleRefFrame::getRotationRepresentation() const
 {
-  return static_cast<RotationRepresentation>(m_RotationRepresentation);
+  return static_cast<RotationRepresentation>(m_RotationRepresentationChoice);
 }
 
 // -----------------------------------------------------------------------------
-void RotateSampleRefFrame::setRotationRepresentationEnum(RotationRepresentation value)
+void RotateSampleRefFrame::setRotationRepresentation(RotationRepresentation value)
 {
-  m_RotationRepresentation = static_cast<int>(value);
+  m_RotationRepresentationChoice = static_cast<int>(value);
 }
 
 // -----------------------------------------------------------------------------
-bool RotateSampleRefFrame::isRotationRepresentationValid(int value)
+bool RotateSampleRefFrame::isRotationRepresentationValid(int value) const
 {
   return (value >= 0) && (value <= 1);
 }

--- a/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.cpp
+++ b/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.cpp
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ * Copyright (c) 2009-2019 BlueQuartz Software, LLC
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -29,6 +29,7 @@
  * The code contained herein was partially funded by the followig contracts:
  *    United States Air Force Prime Contract FA8650-07-D-5800
  *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Air Force Prime Contract FA8650-15-D-5231
  *    United States Prime Contract Navy N00173-07-C-2068
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */

--- a/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.h
+++ b/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.h
@@ -63,9 +63,9 @@ class SIMPLib_EXPORT RotateSampleRefFrame : public AbstractFilter
   PYB11_PROPERTY(float RotationAngle READ getRotationAngle WRITE setRotationAngle)
   PYB11_PROPERTY(bool SliceBySlice READ getSliceBySlice WRITE setSliceBySlice)
   PYB11_PROPERTY(DynamicTableData RotationTable READ getRotationTable WRITE setRotationTable)
-  PYB11_PROPERTY(int RotationRepresentation READ getRotationRepresentation WRITE setRotationRepresentation)
-  PYB11_METHOD(RotationRepresentation getRotationRepresentationEnum)
-  PYB11_METHOD(void setRotationRepresentationEnum ARGS value)
+  PYB11_PROPERTY(int RotationRepresentationChoice READ getRotationRepresentationChoice WRITE setRotationRepresentationChoice)
+  PYB11_METHOD(RotationRepresentation getRotationRepresentation)
+  PYB11_METHOD(void setRotationRepresentation ARGS value)
   PYB11_METHOD(bool isRotationRepresentationValid ARGS value)
 #endif
 
@@ -110,20 +110,20 @@ public:
    * @brief Returns the current rotation representation in enum form.
    * @return
    */
-  RotationRepresentation getRotationRepresentationEnum() const;
+  RotationRepresentation getRotationRepresentation() const;
 
   /**
    * @brief Sets the rotation representation value to the given enum value
    * @param value
    */
-  void setRotationRepresentationEnum(RotationRepresentation value);
+  void setRotationRepresentation(RotationRepresentation value);
 
   /**
    * @brief Returns true if the selected index for the rotation representation choice widget is a valid enum value.
    * @param value
    * @return
    */
-  static bool isRotationRepresentationValid(int value);
+  bool isRotationRepresentationValid(int value) const;
 
   /**
    * @brief Setter property for CellAttributeMatrixPath
@@ -185,18 +185,18 @@ public:
   void setRotationTable(const DynamicTableData& value);
 
   /**
-   * @brief Setter property for RotationRepresentation
+   * @brief Setter property for RotationRepresentationChoice
    * @param value
    */
-  void setRotationRepresentation(int value);
+  void setRotationRepresentationChoice(int value);
 
   /**
-   * @brief Getter property for RotationRepresentation
+   * @brief Getter property for RotationRepresentationChoice
    * @return
    */
-  int getRotationRepresentation() const;
+  int getRotationRepresentationChoice() const;
 
-  Q_PROPERTY(int RotationRepresentation READ getRotationRepresentation WRITE setRotationRepresentation)
+  Q_PROPERTY(int RotationRepresentationChoice READ getRotationRepresentationChoice WRITE setRotationRepresentationChoice)
 
   /**
    * @brief Getter property for RotationTable
@@ -322,5 +322,5 @@ private:
   float m_RotationAngle = 0.0f;
   bool m_SliceBySlice = false;
   DynamicTableData m_RotationTable;
-  int m_RotationRepresentation = 0;
+  int m_RotationRepresentationChoice = 0;
 };

--- a/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.h
+++ b/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.h
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ * Copyright (c) 2009-2019 BlueQuartz Software, LLC
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -29,6 +29,7 @@
  * The code contained herein was partially funded by the followig contracts:
  *    United States Air Force Prime Contract FA8650-07-D-5800
  *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Air Force Prime Contract FA8650-15-D-5231
  *    United States Prime Contract Navy N00173-07-C-2068
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */

--- a/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.h
+++ b/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.h
@@ -1,0 +1,326 @@
+/* ============================================================================
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <memory>
+
+#include "SIMPLib/SIMPLib.h"
+#include "SIMPLib/FilterParameters/DynamicTableData.h"
+#include "SIMPLib/FilterParameters/FloatVec3FilterParameter.h"
+#include "SIMPLib/Filtering/AbstractFilter.h"
+
+/**
+ * @brief The RotateSampleRefFrame class. See [Filter documentation](@ref rotatesamplerefframe) for details.
+ */
+class SIMPLib_EXPORT RotateSampleRefFrame : public AbstractFilter
+{
+  Q_OBJECT
+
+#ifdef SIMPL_ENABLE_PYTHON
+  PYB11_CREATE_BINDINGS(RotateSampleRefFrame SUPERCLASS AbstractFilter)
+  PYB11_SHARED_POINTERS(RotateSampleRefFrame)
+  PYB11_FILTER_NEW_MACRO(RotateSampleRefFrame)
+  PYB11_ENUMERATION(RotationRepresentation)
+  PYB11_FILTER_PARAMETER(DataArrayPath, CellAttributeMatrixPath)
+  PYB11_FILTER_PARAMETER(FloatVec3Type, RotationAxis)
+  PYB11_FILTER_PARAMETER(float, RotationAngle)
+  PYB11_FILTER_PARAMETER(bool, SliceBySlice)
+  PYB11_PROPERTY(DataArrayPath CellAttributeMatrixPath READ getCellAttributeMatrixPath WRITE setCellAttributeMatrixPath)
+  PYB11_PROPERTY(FloatVec3Type RotationAxis READ getRotationAxis WRITE setRotationAxis)
+  PYB11_PROPERTY(float RotationAngle READ getRotationAngle WRITE setRotationAngle)
+  PYB11_PROPERTY(bool SliceBySlice READ getSliceBySlice WRITE setSliceBySlice)
+  PYB11_PROPERTY(DynamicTableData RotationTable READ getRotationTable WRITE setRotationTable)
+  PYB11_PROPERTY(int RotationRepresentation READ getRotationRepresentation WRITE setRotationRepresentation)
+  PYB11_METHOD(RotationRepresentation getRotationRepresentationEnum)
+  PYB11_METHOD(void setRotationRepresentationEnum ARGS value)
+  PYB11_METHOD(bool isRotationRepresentationValid ARGS value)
+#endif
+
+public:
+  using Self = RotateSampleRefFrame;
+  using Pointer = std::shared_ptr<Self>;
+  using ConstPointer = std::shared_ptr<const Self>;
+  using WeakPointer = std::weak_ptr<Self>;
+  using ConstWeakPointer = std::weak_ptr<const Self>;
+
+  /**
+   * @brief Returns a NullPointer wrapped by a shared_ptr<>
+   * @return
+   */
+  static Pointer NullPointer();
+
+  /**
+   * @brief Creates a new object wrapped in a shared_ptr<>
+   * @return
+   */
+  static Pointer New();
+
+  /**
+   * @brief Returns the name of the class for RotateSampleRefFrame
+   */
+  QString getNameOfClass() const override;
+
+  /**
+   * @brief Returns the name of the class for RotateSampleRefFrame
+   */
+  static QString ClassName();
+
+  ~RotateSampleRefFrame() override;
+
+  enum class RotationRepresentation : int
+  {
+    AxisAngle = 0,
+    RotationMatrix = 1
+  };
+
+  /**
+   * @brief Returns the current rotation representation in enum form.
+   * @return
+   */
+  RotationRepresentation getRotationRepresentationEnum() const;
+
+  /**
+   * @brief Sets the rotation representation value to the given enum value
+   * @param value
+   */
+  void setRotationRepresentationEnum(RotationRepresentation value);
+
+  /**
+   * @brief Returns true if the selected index for the rotation representation choice widget is a valid enum value.
+   * @param value
+   * @return
+   */
+  static bool isRotationRepresentationValid(int value);
+
+  /**
+   * @brief Setter property for CellAttributeMatrixPath
+   */
+  void setCellAttributeMatrixPath(const DataArrayPath& value);
+
+  /**
+   * @brief Getter property for CellAttributeMatrixPath
+   * @return Value of CellAttributeMatrixPath
+   */
+  DataArrayPath getCellAttributeMatrixPath() const;
+
+  Q_PROPERTY(DataArrayPath CellAttributeMatrixPath READ getCellAttributeMatrixPath WRITE setCellAttributeMatrixPath)
+
+  /**
+   * @brief Setter property for RotationAxis
+   */
+  void setRotationAxis(const FloatVec3Type& value);
+
+  /**
+   * @brief Getter property for RotationAxis
+   * @return Value of RotationAxis
+   */
+  FloatVec3Type getRotationAxis() const;
+
+  Q_PROPERTY(FloatVec3Type RotationAxis READ getRotationAxis WRITE setRotationAxis)
+
+  /**
+   * @brief Setter property for RotationAngle
+   */
+  void setRotationAngle(float value);
+
+  /**
+   * @brief Getter property for RotationAngle
+   * @return Value of RotationAngle
+   */
+  float getRotationAngle() const;
+
+  Q_PROPERTY(float RotationAngle READ getRotationAngle WRITE setRotationAngle)
+
+  // This is getting exposed because other filters that are calling this filter needs to set this value
+  /**
+   * @brief Setter property for SliceBySlice
+   */
+  void setSliceBySlice(bool value);
+
+  /**
+   * @brief Getter property for SliceBySlice
+   * @return Value of SliceBySlice
+   */
+  bool getSliceBySlice() const;
+
+  Q_PROPERTY(bool SliceBySlice READ getSliceBySlice WRITE setSliceBySlice)
+
+  /**
+   * @brief Setter property for RotationTable
+   * @param value
+   */
+  void setRotationTable(const DynamicTableData& value);
+
+  /**
+   * @brief Setter property for RotationRepresentation
+   * @param value
+   */
+  void setRotationRepresentation(int value);
+
+  /**
+   * @brief Getter property for RotationRepresentation
+   * @return
+   */
+  int getRotationRepresentation() const;
+
+  Q_PROPERTY(int RotationRepresentation READ getRotationRepresentation WRITE setRotationRepresentation)
+
+  /**
+   * @brief Getter property for RotationTable
+   * @return
+   */
+  DynamicTableData getRotationTable() const;
+
+  Q_PROPERTY(DynamicTableData RotationTable READ getRotationTable WRITE setRotationTable)
+
+  /**
+   * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
+   */
+  QString getCompiledLibraryName() const override;
+
+  /**
+   * @brief getBrandingString Returns the branding string for the filter, which is a tag
+   * used to denote the filter's association with specific plugins
+   * @return Branding string
+   */
+  QString getBrandingString() const override;
+
+  /**
+   * @brief getFilterVersion Returns a version string for this filter. Default
+   * value is an empty string.
+   * @return
+   */
+  QString getFilterVersion() const override;
+
+  /**
+   * @brief newFilterInstance Reimplemented from @see AbstractFilter class
+   */
+  AbstractFilter::Pointer newFilterInstance(bool copyFilterParameters) const override;
+
+  /**
+   * @brief getGroupName Reimplemented from @see AbstractFilter class
+   */
+  QString getGroupName() const override;
+
+  /**
+   * @brief getSubGroupName Reimplemented from @see AbstractFilter class
+   */
+  QString getSubGroupName() const override;
+
+  /**
+   * @brief getUuid Return the unique identifier for this filter.
+   * @return A QUuid object.
+   */
+  QUuid getUuid() const override;
+
+  /**
+   * @brief getHumanLabel Reimplemented from @see AbstractFilter class
+   */
+  QString getHumanLabel() const override;
+
+  /**
+   * @brief setupFilterParameters Reimplemented from @see AbstractFilter class
+   */
+  void setupFilterParameters() override;
+
+  /**
+   * @brief readFilterParameters Reimplemented from @see AbstractFilter class
+   */
+  void readFilterParameters(AbstractFilterParametersReader* reader, int index) override;
+
+  /**
+   * @brief execute Reimplemented from @see AbstractFilter class
+   */
+  void execute() override;
+
+  /**
+   * @brief preflight Reimplemented from @see AbstractFilter class
+   */
+  void preflight() override;
+
+signals:
+  /**
+   * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters
+   * be pushed from a user-facing control (such as a widget)
+   * @param filter Filter instance pointer
+   */
+  void updateFilterParameters(AbstractFilter* filter);
+
+  /**
+   * @brief parametersChanged Emitted when any Filter parameter is changed internally
+   */
+  void parametersChanged();
+
+  /**
+   * @brief preflightAboutToExecute Emitted just before calling dataCheck()
+   */
+  void preflightAboutToExecute();
+
+  /**
+   * @brief preflightExecuted Emitted just after calling dataCheck()
+   */
+  void preflightExecuted();
+
+protected:
+  RotateSampleRefFrame();
+
+  /**
+   * @brief dataCheck Checks for the appropriate parameter values and availability of arrays
+   */
+  void dataCheck();
+
+  /**
+   * @brief Initializes all the private instance variables.
+   */
+  void initialize();
+
+public:
+  RotateSampleRefFrame(const RotateSampleRefFrame&) = delete;            // Copy Constructor Not Implemented
+  RotateSampleRefFrame(RotateSampleRefFrame&&) = delete;                 // Move Constructor Not Implemented
+  RotateSampleRefFrame& operator=(const RotateSampleRefFrame&) = delete; // Copy Assignment Not Implemented
+  RotateSampleRefFrame& operator=(RotateSampleRefFrame&&) = delete;      // Move Assignment Not Implemented
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> p_Impl;
+
+  DataArrayPath m_CellAttributeMatrixPath = {};
+  FloatVec3Type m_RotationAxis = {0.0f, 0.0f, 1.0f};
+  float m_RotationAngle = 0.0f;
+  bool m_SliceBySlice = false;
+  DynamicTableData m_RotationTable;
+  int m_RotationRepresentation = 0;
+};

--- a/Source/SIMPLib/CoreFilters/SourceList.cmake
+++ b/Source/SIMPLib/CoreFilters/SourceList.cmake
@@ -71,6 +71,7 @@ set(_PublicFilters
   RenameDataContainer
   ReplaceValueInArray
   RequiredZThickness
+  RotateSampleRefFrame
   ScaleVolume
   SetOriginResolutionImageGeom
   SplitAttributeArray

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
@@ -63,8 +63,8 @@ private:
   const QString k_RotationTableName = "RotationTable";
   const QString k_RotationRepresentationName = "RotationRepresentation";
   const QString k_CellAttributeMatrixPathName = "CellAttributeMatrixPath";
-  static constexpr int k_AxisAngle = 0;
-  static constexpr int k_RotationMatrix = 1;
+  const int k_AxisAngle = 0;
+  const int k_RotationMatrix = 1;
 
   template <class T>
   static bool dataArrayEqual(const DataArray<T>& a, const DataArray<T>& b)

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
@@ -61,7 +61,7 @@ private:
   const QString k_RotationAngleName = "RotationAngle";
   const QString k_RotationAxisName = "RotationAxis";
   const QString k_RotationTableName = "RotationTable";
-  const QString k_RotationRepresentationName = "RotationRepresentation";
+  const QString k_RotationRepresentationChoiceName = "RotationRepresentationChoice";
   const QString k_CellAttributeMatrixPathName = "CellAttributeMatrixPath";
   const int k_AxisAngle = 0;
   const int k_RotationMatrix = 1;
@@ -231,7 +231,7 @@ public:
     rotateFilter->setDataContainerArray(dca);
 
     setProperty(rotateFilter, k_CellAttributeMatrixPathName, path);
-    setProperty(rotateFilter, k_RotationRepresentationName, k_AxisAngle);
+    setProperty(rotateFilter, k_RotationRepresentationChoiceName, k_AxisAngle);
 
     // Correct axis angle inputs
 
@@ -256,7 +256,7 @@ public:
 
     // Correct rotation matrix inputs
 
-    setProperty(rotateFilter, k_RotationRepresentationName, k_RotationMatrix);
+    setProperty(rotateFilter, k_RotationRepresentationChoiceName, k_RotationMatrix);
 
     //  0 0 1
     //  0 1 0
@@ -377,7 +377,7 @@ public:
 
       {
         // Set to axis angle representation
-        setProperty(rotateFilter, k_RotationRepresentationName, k_AxisAngle);
+        setProperty(rotateFilter, k_RotationRepresentationChoiceName, k_AxisAngle);
 
         // Copy original data for rotation
 
@@ -408,7 +408,7 @@ public:
 
       {
         // Set to rotation matrix representation
-        setProperty(rotateFilter, k_RotationRepresentationName, k_RotationMatrix);
+        setProperty(rotateFilter, k_RotationRepresentationChoiceName, k_RotationMatrix);
 
         // Copy original data for rotation
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
@@ -46,7 +46,7 @@
 #include "SIMPLib/Plugin/ISIMPLibPlugin.h"
 #include "SIMPLib/Plugin/SIMPLibPluginLoader.h"
 #include "SIMPLib/SIMPLib.h"
-#include "UnitTestSupport.hpp"
+#include "SIMPLib/Testing/UnitTestSupport.hpp"
 
 #include "SIMPLib/Testing/SIMPLTestFileLocations.h"
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
@@ -27,9 +27,7 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * The code contained herein was partially funded by the followig contracts:
- *    United States Air Force Prime Contract FA8650-07-D-5800
- *    United States Air Force Prime Contract FA8650-10-D-5210
- *    United States Prime Contract Navy N00173-07-C-2068
+ *    United States Air Force Prime Contract FA8650-15-D-5231
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
@@ -35,6 +35,7 @@
 
 #include <Eigen/Dense>
 
+#include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/CoreFilters/DataContainerReader.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 #include "SIMPLib/Filtering/FilterFactory.hpp"
@@ -43,14 +44,14 @@
 #include "SIMPLib/Filtering/QMetaObjectUtilities.h"
 #include "SIMPLib/Plugin/ISIMPLibPlugin.h"
 #include "SIMPLib/Plugin/SIMPLibPluginLoader.h"
-#include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/Testing/UnitTestSupport.hpp"
-
-#include "SIMPLib/Testing/SIMPLTestFileLocations.h"
-
+#include "SIMPLib/Geometry/ImageGeom.h"
+#include "SIMPLib/DataContainers/DataContainerArray.h"
 #include "SIMPLib/FilterParameters/DynamicTableData.h"
 #include "SIMPLib/FilterParameters/FloatVec3FilterParameter.h"
 #include "SIMPLib/Math/SIMPLibMath.h"
+
+#include "SIMPLib/Testing/SIMPLTestFileLocations.h"
 
 class RotateSampleRefFrameTest
 {
@@ -86,9 +87,9 @@ private:
     FloatVec3Type originA = a.getOrigin();
     FloatVec3Type spacingA = a.getSpacing();
 
-    SizeVec3Type dimsB = a.getDimensions();
-    FloatVec3Type originB = a.getOrigin();
-    FloatVec3Type spacingB = a.getSpacing();
+    SizeVec3Type dimsB = b.getDimensions();
+    FloatVec3Type originB = b.getOrigin();
+    FloatVec3Type spacingB = b.getSpacing();
 
     return (dimsA == dimsB) && (originA == originB) && (spacingA == spacingB);
   }
@@ -260,7 +261,7 @@ public:
     //  0 1 0
     // -1 0 0
 
-    std::vector<std::vector<double>> table = {{0.0f, 0.0f, 1.0f}, {0.0f, 1.0f, 0.0f}, {-1.0f, 0.0f, 0.0f}};
+    std::vector<std::vector<double>> table = {{0.0, 0.0, 1.0}, {0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}};
 
     DynamicTableData tableData(table);
 
@@ -278,7 +279,7 @@ public:
     // 0 1 0
     // 0 0 1
 
-    table = {{1.0f, 0.0f, 1.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}};
+    table = {{1.0, 0.0, 1.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}};
 
     tableData.setTableData(table);
 
@@ -296,7 +297,7 @@ public:
     // 0 1 0
     // 1 0 1
 
-    table = {{1.0f, 0.0f, 1.0f}, {0.0f, 1.0f, 0.0f}, {1.0f, 0.0f, 1.0f}};
+    table = {{1.0, 0.0, 1.0}, {0.0, 1.0, 0.0}, {1.0, 0.0, 1.0}};
 
     tableData.setTableData(table);
 
@@ -422,7 +423,7 @@ public:
         // Set properties
 
         Eigen::Vector3f axis(x, y, z);
-        float angleRadians = angle * SIMPLib::Constants::k_DegToRad;
+        float angleRadians = angle * static_cast<float>(SIMPLib::Constants::k_DegToRad);
         Eigen::AngleAxisf axisAngle(angleRadians, axis);
 
         Eigen::Matrix3f rotationMatrix = axisAngle.toRotationMatrix();
@@ -434,7 +435,7 @@ public:
           std::vector<double> row;
           for(int j = 0; j < rotationMatrix.cols(); j++)
           {
-            row.push_back(rotationMatrix(i, j));
+            row.push_back(static_cast<double>(rotationMatrix(i, j)));
           }
           data.push_back(row);
         }
@@ -466,7 +467,7 @@ public:
     std::cout << "----Start RotateSampleRefFrameTest----\n";
 
     int err = EXIT_SUCCESS;
-    DREAM3D_REGISTER_TEST(TestFilterAvailability());
+    DREAM3D_REGISTER_TEST(TestFilterAvailability())
 
     DREAM3D_REGISTER_TEST(TestFilterParameters())
     DREAM3D_REGISTER_TEST(TestRotateSampleRefFrameTest())

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/RotateSampleRefFrameTest.cpp
@@ -1,0 +1,480 @@
+/* ============================================================================
+ * Copyright (c) 2019-2019 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include <QtCore/QFile>
+
+#include <Eigen/Dense>
+
+#include "SIMPLib/CoreFilters/DataContainerReader.h"
+#include "SIMPLib/DataArrays/DataArray.hpp"
+#include "SIMPLib/Filtering/FilterFactory.hpp"
+#include "SIMPLib/Filtering/FilterManager.h"
+#include "SIMPLib/Filtering/FilterPipeline.h"
+#include "SIMPLib/Filtering/QMetaObjectUtilities.h"
+#include "SIMPLib/Plugin/ISIMPLibPlugin.h"
+#include "SIMPLib/Plugin/SIMPLibPluginLoader.h"
+#include "SIMPLib/SIMPLib.h"
+#include "UnitTestSupport.hpp"
+
+#include "SIMPLib/Testing/SIMPLTestFileLocations.h"
+
+#include "SIMPLib/FilterParameters/DynamicTableData.h"
+#include "SIMPLib/FilterParameters/FloatVec3FilterParameter.h"
+#include "SIMPLib/Math/SIMPLibMath.h"
+
+class RotateSampleRefFrameTest
+{
+private:
+  const QString k_FilterName = "RotateSampleRefFrame";
+  const QString k_RotationAngleName = "RotationAngle";
+  const QString k_RotationAxisName = "RotationAxis";
+  const QString k_RotationTableName = "RotationTable";
+  const QString k_RotationRepresentationName = "RotationRepresentation";
+  const QString k_CellAttributeMatrixPathName = "CellAttributeMatrixPath";
+  static constexpr int k_AxisAngle = 0;
+  static constexpr int k_RotationMatrix = 1;
+
+  template <class T>
+  static bool dataArrayEqual(const DataArray<T>& a, const DataArray<T>& b)
+  {
+    if(a.getNumberOfComponents() != b.getNumberOfComponents())
+    {
+      return false;
+    }
+
+    if(a.getNumberOfTuples() != b.getNumberOfTuples())
+    {
+      return false;
+    }
+
+    return std::equal(a.begin(), a.end(), b.begin(), b.end());
+  }
+
+  static bool imageGeomEqual(const ImageGeom& a, const ImageGeom& b)
+  {
+    SizeVec3Type dimsA = a.getDimensions();
+    FloatVec3Type originA = a.getOrigin();
+    FloatVec3Type spacingA = a.getSpacing();
+
+    SizeVec3Type dimsB = a.getDimensions();
+    FloatVec3Type originB = a.getOrigin();
+    FloatVec3Type spacingB = a.getSpacing();
+
+    return (dimsA == dimsB) && (originA == originB) && (spacingA == spacingB);
+  }
+
+  static bool matrixEqual(const AttributeMatrix& a, const AttributeMatrix& b)
+  {
+    return a.getTupleDimensions() == b.getTupleDimensions();
+  }
+
+  static void dataContainerEqual(const DataContainerArray& dca, const DataArrayPath& testPath, const DataArrayPath& expectedPath)
+  {
+    // Get test
+
+    DataContainer::Pointer testContainer = dca.getDataContainer(testPath);
+    DREAM3D_REQUIRE_VALID_POINTER(testContainer)
+
+    ImageGeom::Pointer testGeom = testContainer->getGeometryAs<ImageGeom>();
+    DREAM3D_REQUIRE_VALID_POINTER(testGeom)
+
+    AttributeMatrix::Pointer testMatrix = testContainer->getAttributeMatrix(testPath);
+    DREAM3D_REQUIRE_VALID_POINTER(testMatrix)
+
+    UInt8ArrayType::Pointer testArray = testMatrix->getAttributeArrayAs<UInt8ArrayType>(testPath.getDataArrayName());
+    DREAM3D_REQUIRE_VALID_POINTER(testArray)
+
+    // Get expected
+
+    DataContainer::Pointer expectedContainer = dca.getDataContainer(expectedPath);
+    DREAM3D_REQUIRE_VALID_POINTER(expectedContainer)
+
+    ImageGeom::Pointer expectedGeom = expectedContainer->getGeometryAs<ImageGeom>();
+    DREAM3D_REQUIRE_VALID_POINTER(expectedGeom)
+
+    AttributeMatrix::Pointer expectedMatrix = expectedContainer->getAttributeMatrix(expectedPath);
+    DREAM3D_REQUIRE_VALID_POINTER(expectedMatrix)
+
+    UInt8ArrayType::Pointer expectedArray = testMatrix->getAttributeArrayAs<UInt8ArrayType>(expectedPath.getDataArrayName());
+    DREAM3D_REQUIRE_VALID_POINTER(expectedArray)
+
+    // Compare
+
+    bool geometryEqual = imageGeomEqual(*testGeom, *expectedGeom);
+    DREAM3D_REQUIRE(geometryEqual)
+
+    bool attributeMatrixEqual = matrixEqual(*testMatrix, *expectedMatrix);
+    DREAM3D_REQUIRE(attributeMatrixEqual)
+
+    bool arraysEqual = dataArrayEqual(*testArray, *expectedArray);
+    DREAM3D_REQUIRE(arraysEqual)
+  }
+
+  static void resetGeometry(AttributeMatrix::Pointer matrix, ImageGeom::Pointer imageGeom, const std::vector<size_t>& tDims)
+  {
+    matrix->resizeAttributeArrays(tDims);
+    imageGeom->setDimensions(tDims);
+    imageGeom->setOrigin(0.0f, 0.0f, 0.0f);
+    imageGeom->setSpacing(1.0f, 1.0f, 1.0f);
+  }
+
+  AbstractFilter::Pointer createFilter() const
+  {
+    FilterManager* fm = FilterManager::Instance();
+    IFilterFactory::Pointer filterFactory = fm->getFactoryFromClassName(k_FilterName);
+    DREAM3D_REQUIRE_VALID_POINTER(filterFactory)
+
+    AbstractFilter::Pointer rotateFilter = filterFactory->create();
+    DREAM3D_REQUIRE_VALID_POINTER(rotateFilter)
+
+    return rotateFilter;
+  }
+
+  template <class T>
+  static void setProperty(AbstractFilter::Pointer filter, const QString& property, const T& value)
+  {
+    QVariant variant;
+    variant.setValue(value);
+    bool propWasSet = filter->setProperty(property.toStdString().c_str(), variant);
+    DREAM3D_REQUIRE_EQUAL(propWasSet, true)
+  }
+
+public:
+  RotateSampleRefFrameTest() = default;
+  ~RotateSampleRefFrameTest() = default;
+  RotateSampleRefFrameTest(const RotateSampleRefFrameTest&) = delete;            // Copy Constructor Not Implemented
+  RotateSampleRefFrameTest(RotateSampleRefFrameTest&&) = delete;                 // Move Constructor Not Implemented
+  RotateSampleRefFrameTest& operator=(const RotateSampleRefFrameTest&) = delete; // Copy Assignment Not Implemented
+  RotateSampleRefFrameTest& operator=(RotateSampleRefFrameTest&&) = delete;      // Move Assignment Not Implemented
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void RemoveTestFiles()
+  {
+#if REMOVE_TEST_FILES
+#endif
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  int TestFilterAvailability()
+  {
+    // Now instantiate the SampleSurfaceMeshSpecifiedPointsTest Filter from the FilterManager
+    FilterManager* filterManager = FilterManager::Instance();
+    IFilterFactory::Pointer filterFactory = filterManager->getFactoryFromClassName(k_FilterName);
+    if(filterFactory == nullptr)
+    {
+      std::stringstream ss;
+      ss << "The RotateSampleRefFrameTest Requires the use of the " << k_FilterName.toStdString() << " filter which is found in the Sampling Plugin";
+      DREAM3D_TEST_THROW_EXCEPTION(ss.str())
+    }
+    return 0;
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void TestFilterParameters()
+  {
+    const std::vector<size_t> tDims{10, 20, 30};
+    const DataArrayPath path("DataContainer", "AttributeMatrix", "DataArray");
+
+    DataContainerArray::Pointer dca = DataContainerArray::New();
+
+    DataContainer::Pointer dc = DataContainer::New(path.getDataContainerName());
+
+    ImageGeom::Pointer imageGeom = ImageGeom::New();
+
+    imageGeom->setDimensions(tDims);
+
+    dc->setGeometry(imageGeom);
+
+    dca->addOrReplaceDataContainer(dc);
+
+    AttributeMatrix::Pointer matrix = dc->createNonPrereqAttributeMatrix(nullptr, path.getAttributeMatrixName(), tDims, AttributeMatrix::Type::Cell);
+
+    AbstractFilter::Pointer rotateFilter = createFilter();
+    rotateFilter->setDataContainerArray(dca);
+
+    setProperty(rotateFilter, k_CellAttributeMatrixPathName, path);
+    setProperty(rotateFilter, k_RotationRepresentationName, k_AxisAngle);
+
+    // Correct axis angle inputs
+
+    setProperty(rotateFilter, k_RotationAxisName, FloatVec3Type(0.0f, 1.0f, 0.0f));
+    setProperty(rotateFilter, k_RotationAngleName, 90.0f);
+
+    rotateFilter->preflight();
+    int error = rotateFilter->getErrorCode();
+    DREAM3D_REQUIRED(error, >=, 0)
+
+    resetGeometry(matrix, imageGeom, tDims);
+
+    // Non-normalized rotation axis should generate a warning
+
+    setProperty(rotateFilter, k_RotationAxisName, FloatVec3Type(1.0f, 1.0f, 0.0f));
+
+    rotateFilter->preflight();
+    int warning = rotateFilter->getWarningCode();
+    DREAM3D_REQUIRED(warning, <, 0)
+
+    resetGeometry(matrix, imageGeom, tDims);
+
+    // Correct rotation matrix inputs
+
+    setProperty(rotateFilter, k_RotationRepresentationName, k_RotationMatrix);
+
+    //  0 0 1
+    //  0 1 0
+    // -1 0 0
+
+    std::vector<std::vector<double>> table = {{0.0f, 0.0f, 1.0f}, {0.0f, 1.0f, 0.0f}, {-1.0f, 0.0f, 0.0f}};
+
+    DynamicTableData tableData(table);
+
+    setProperty(rotateFilter, k_RotationTableName, tableData);
+
+    rotateFilter->preflight();
+    error = rotateFilter->getErrorCode();
+    DREAM3D_REQUIRED(error, >=, 0)
+
+    resetGeometry(matrix, imageGeom, tDims);
+
+    // Inverse != Transpose error
+
+    // 1 0 1
+    // 0 1 0
+    // 0 0 1
+
+    table = {{1.0f, 0.0f, 1.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}};
+
+    tableData.setTableData(table);
+
+    setProperty(rotateFilter, k_RotationTableName, tableData);
+
+    rotateFilter->preflight();
+    error = rotateFilter->getErrorCode();
+    DREAM3D_REQUIRED(error, <, 0)
+
+    resetGeometry(matrix, imageGeom, tDims);
+
+    // Determinant != 1 error
+
+    // 1 0 1
+    // 0 1 0
+    // 1 0 1
+
+    table = {{1.0f, 0.0f, 1.0f}, {0.0f, 1.0f, 0.0f}, {1.0f, 0.0f, 1.0f}};
+
+    tableData.setTableData(table);
+
+    setProperty(rotateFilter, k_RotationTableName, tableData);
+
+    rotateFilter->preflight();
+    error = rotateFilter->getErrorCode();
+    DREAM3D_REQUIRED(error, <, 0)
+
+    resetGeometry(matrix, imageGeom, tDims);
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void TestRotateSampleRefFrameTest()
+  {
+    const DataArrayPath basePath("", "CellData", "Data");
+
+    // Read test file
+
+    DataContainerArray::Pointer dca = DataContainerArray::New();
+
+    DataContainerReader::Pointer dataContainerReader = DataContainerReader::New();
+    dataContainerReader->setDataContainerArray(dca);
+    dataContainerReader->setInputFile(UnitTest::RotateSampleRefFrameTest::TestFile1);
+    DataContainerArrayProxy proxy = dataContainerReader->readDataContainerArrayStructure(UnitTest::RotateSampleRefFrameTest::TestFile1);
+    dataContainerReader->setInputFileDataContainerArrayProxy(proxy);
+
+    dataContainerReader->execute();
+    int error = dataContainerReader->getErrorCode();
+    DREAM3D_REQUIRED(error, >=, 0)
+
+    QList<QString> dcNames = dca->getDataContainerNames();
+
+    bool hasOriginal = dcNames.contains("Original");
+
+    DREAM3D_REQUIRE(hasOriginal)
+
+    AbstractFilter::Pointer rotateFilter = createFilter();
+    rotateFilter->setDataContainerArray(dca);
+
+    DataArrayPath originalPath = basePath;
+    originalPath.setDataContainerName("Original");
+    DataContainer::Pointer dcOriginal = dca->getDataContainer(originalPath);
+    DREAM3D_REQUIRE_VALID_POINTER(dcOriginal)
+
+    bool foundRotated = false;
+
+    for(const auto& name : dcNames)
+    {
+      bool isRotated = name.startsWith("Rotate");
+      foundRotated = isRotated ? true : foundRotated;
+      if(!isRotated)
+      {
+        continue;
+      }
+
+      DataArrayPath expectedPath = basePath;
+      expectedPath.setDataContainerName(name);
+
+      QStringList parts = name.split("_");
+      int size = parts.size();
+      DREAM3D_REQUIRED(size, ==, 5)
+
+      bool conversionSuccess = false;
+
+      float x = parts[1].toFloat(&conversionSuccess);
+      DREAM3D_REQUIRE(conversionSuccess)
+      float y = parts[2].toFloat(&conversionSuccess);
+      DREAM3D_REQUIRE(conversionSuccess)
+      float z = parts[3].toFloat(&conversionSuccess);
+      DREAM3D_REQUIRE(conversionSuccess)
+      float angle = parts[4].toFloat(&conversionSuccess);
+      DREAM3D_REQUIRE(conversionSuccess)
+
+      {
+        // Set to axis angle representation
+        setProperty(rotateFilter, k_RotationRepresentationName, k_AxisAngle);
+
+        // Copy original data for rotation
+
+        DataContainer::Pointer dcCopy = dcOriginal->deepCopy();
+        dcCopy->setName(name + "_Copy");
+        dca->addOrReplaceDataContainer(dcCopy);
+
+        DataArrayPath testPath = basePath;
+        testPath.setDataContainerName(dcCopy->getName());
+
+        setProperty(rotateFilter, k_CellAttributeMatrixPathName, testPath);
+
+        // Set properties
+
+        setProperty(rotateFilter, k_RotationAngleName, angle);
+        setProperty(rotateFilter, k_RotationAxisName, FloatVec3Type(x, y, z));
+
+        // Execute
+
+        rotateFilter->execute();
+        int error = rotateFilter->getErrorCode();
+        DREAM3D_REQUIRED(error, >=, 0)
+
+        // Compare
+
+        dataContainerEqual(*dca, testPath, expectedPath);
+      }
+
+      {
+        // Set to rotation matrix representation
+        setProperty(rotateFilter, k_RotationRepresentationName, k_RotationMatrix);
+
+        // Copy original data for rotation
+
+        DataContainer::Pointer dcCopy = dcOriginal->deepCopy();
+        dcCopy->setName(name + "_Copy_Matrix");
+        dca->addOrReplaceDataContainer(dcCopy);
+
+        DataArrayPath testPath = basePath;
+        testPath.setDataContainerName(dcCopy->getName());
+
+        setProperty(rotateFilter, k_CellAttributeMatrixPathName, testPath);
+
+        // Set properties
+
+        Eigen::Vector3f axis(x, y, z);
+        float angleRadians = angle * SIMPLib::Constants::k_DegToRad;
+        Eigen::AngleAxisf axisAngle(angleRadians, axis);
+
+        Eigen::Matrix3f rotationMatrix = axisAngle.toRotationMatrix();
+
+        std::vector<std::vector<double>> data;
+
+        for(int i = 0; i < rotationMatrix.rows(); i++)
+        {
+          std::vector<double> row;
+          for(int j = 0; j < rotationMatrix.cols(); j++)
+          {
+            row.push_back(rotationMatrix(i, j));
+          }
+          data.push_back(row);
+        }
+
+        DynamicTableData tableData(data);
+
+        setProperty(rotateFilter, k_RotationTableName, tableData);
+
+        // Execute
+
+        rotateFilter->execute();
+        int error = rotateFilter->getErrorCode();
+        DREAM3D_REQUIRED(error, >=, 0)
+
+        // Compare
+
+        dataContainerEqual(*dca, testPath, expectedPath);
+      }
+    }
+
+    DREAM3D_REQUIRE(foundRotated)
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void operator()()
+  {
+    std::cout << "----Start RotateSampleRefFrameTest----\n";
+
+    int err = EXIT_SUCCESS;
+    DREAM3D_REGISTER_TEST(TestFilterAvailability());
+
+    DREAM3D_REGISTER_TEST(TestFilterParameters())
+    DREAM3D_REGISTER_TEST(TestRotateSampleRefFrameTest())
+
+    DREAM3D_REGISTER_TEST(RemoveTestFiles())
+
+    std::cout << "----End RotateSampleRefFrameTest----\n";
+  }
+};

--- a/Source/SIMPLib/CoreFilters/Testing/Cxx/SourceList.cmake
+++ b/Source/SIMPLib/CoreFilters/Testing/Cxx/SourceList.cmake
@@ -45,6 +45,7 @@ set(TEST_${SUBDIR_NAME}_NAMES
   # RenameTimingTest
   ReplaceValueTest
   RequiredZThicknessTest
+  RotateSampleRefFrameTest
   ScaleVolumeTest
   SetOriginResolutionImageGeomTest
   SplitAttributeArrayTest

--- a/Source/SIMPLib/Documentation/SIMPLibFilters/CoreFilters/RotateSampleRefFrame.md
+++ b/Source/SIMPLib/Documentation/SIMPLibFilters/CoreFilters/RotateSampleRefFrame.md
@@ -1,0 +1,57 @@
+# Rotate Sample Reference Frame  #
+
+## Group (Subgroup) ##
+
+Sampling (Rotating/Transforming)
+
+## Description ##
+
+This **Filter** will rotate the *spatial reference frame* around a user defined axis, by a user defined angle.  The **Filter** will modify the (X, Y, Z) positions of each **Cell** to correctly represent where the **Cell** sits in the newly defined reference frame. For example, if a user selected a *rotation angle* of 90<sup>o</sup> and a *rotation axis* of (001), then a **Cell** sitting at (10, 0, 0) would be transformed to (0, -10, 0), since the new *reference frame* would have x'=y and y'=-x.
+
+The equivalent rotation matrix for the above rotation would be the following:
+
+|   |   |   |
+| - | - | - |
+| 0 | -1 | 0 |
+| 1 | 0 | 0 |
+| 0 | 0 | 1 |
+
+## Parameters ##
+
+| Name | Type | Description |
+|------|------|-------------|
+| Rotation Representation | Enumeration | Which form used to represent rotation (**axis angle** or **rotation matrix)** |
+| Rotation Axis (ijk) | float (3x) | Axis in sample reference frame to rotate about (if **axis angle**) |
+| Rotation Angle (Degrees) | float | Magnitude of rotation (in degrees) about the rotation axis (if **axis angle**) |
+| Rotation Matrix | float (3x3) | Axis in sample reference frame to rotate about (if **rotation matrix**) |
+
+## Required Geometry ##
+
+Image
+
+## Required Objects ##
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|------|----------------------|-------------|
+| **Attribute Matrix** | CellData | Cell | N/A | **Cell Attribute Matrix** that holds the data to rotate |
+
+## Created Objects ##
+
+None
+
+## Example Pipelines ##
+
++ INL Export
++ Export Small IN100 ODF Data (StatsGenerator)
++ TxCopper_Exposed
++ TxCopper_Unexposed
++ Edax IPF Colors
++ Confidence Index Histogram
+
+## License & Copyright ##
+
+Please see the description file distributed with this **Plugin**
+
+## DREAM.3D Mailing Lists ##
+
+If you need more help with a **Filter**, please consider asking your question on the [DREAM.3D Users Google group!](https://groups.google.com/forum/?hl=en#!forum/dream3d-users)

--- a/Source/SIMPLib/Testing/TestFileLocations.h.in
+++ b/Source/SIMPLib/Testing/TestFileLocations.h.in
@@ -214,6 +214,11 @@ namespace UnitTest
    const QString OutputFile("@TEST_TEMP_DIR@/FeatureDataCSVOutputTestFile.txt");
   }
 
+  namespace RotateSampleRefFrameTest
+  {
+    const QString TestFile1("@DREAM3D_DATA_DIR@/Data/RotateSampleRefFrame/RotateSampleRefFrameTest.dream3d");
+  }
+
   namespace RestUnitTest
   {
     // Server Configuration File


### PR DESCRIPTION
* Moved RotateSampleRefFrame filter from DREAM3D to SIMPL

* RotateSampleRefFrame now allows the user to choose between axis angle and rotation matrix input

* Cleaned up code in RotateSampleRefFrame
  * Moved calculations from preflight() to datacheck()
  * Removed duplicate code
* Added input validation using Eigen
* Added test case for RotateSampleRefFrame

* Requires https://github.com/BlueQuartzSoftware/DREAM3D/pull/924 and https://github.com/dream3d/DREAM3D_Data/pull/14