### PR TITLE
Use explicit Instantiated Templates for DataArray<>

### DIFF
--- a/Resources/UnitTestSupport.hpp
+++ b/Resources/UnitTestSupport.hpp
@@ -428,8 +428,8 @@ bool AlmostEqualUlpsFinal(float* A, float* B, int maxUlps)
     QString buf;                                                                                                                                                                                       \
     QTextStream ss(&buf);                                                                                                                                                                              \
     ss << "Your test required the following\n            '";                                                                                                                                           \
-    ss << "AlmostEqualUlpsFinal(" << #L << ", " << #R << ", " << #Ulps << "'\n             but this condition was not met with MaxUlps=" << Ulps << "\n";                                              \
-    ss << "             " << L << "==" << R;                                                                                                                                                           \
+    ss << "AlmostEqualUlpsFinal(" << #L << ", " << #R << ", " << #Ulps << ")'\n             but this condition was not met with MaxUlps=" << Ulps << "\n";                                              \
+    ss << "             " << *L << "==" << *R;                                                                                                                                                           \
     DREAM3D_TEST_THROW_EXCEPTION(buf.toStdString())                                                                                                                                                    \
   }
 

--- a/Source/SIMPLib/CoreFilters/DataContainerReader.cpp
+++ b/Source/SIMPLib/CoreFilters/DataContainerReader.cpp
@@ -32,22 +32,19 @@
 *    United States Prime Contract Navy N00173-07-C-2068
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+#include "DataContainerReader.h"
 
 #include <memory>
 
-#include "DataContainerReader.h"
-
 #include <QtCore/QFileInfo>
+#include <QtCore/QTextStream>
+#include <QtCore/QDebug>
 
 #include "H5Support/H5ScopedSentinel.h"
 #include "H5Support/QH5Utilities.h"
-
-#include <QtCore/QTextStream>
-
-#include <QtCore/QDebug>
+#include "H5Support/QH5Lite.h"
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/DataContainers/DataContainer.h"
 #include "SIMPLib/DataContainers/DataContainerBundle.h"
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"

--- a/Source/SIMPLib/CoreFilters/DataContainerWriter.cpp
+++ b/Source/SIMPLib/CoreFilters/DataContainerWriter.cpp
@@ -32,23 +32,20 @@
 *    United States Prime Contract Navy N00173-07-C-2068
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+#include "DataContainerWriter.h"
 
 #include <memory>
 
-#include "DataContainerWriter.h"
-
+#include <QtCore/QTextStream>
+#include <QtCore/QDebug>
 #include <QtCore/QDir>
 
 #include "H5Support/H5Utilities.h"
 #include "H5Support/QH5Utilities.h"
 #include "H5Support/H5ScopedSentinel.h"
-
-#include <QtCore/QTextStream>
-
-#include <QtCore/QDebug>
+#include "H5Support/QH5Lite.h"
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/BooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/H5FilterParametersWriter.h"

--- a/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.cpp
+++ b/Source/SIMPLib/CoreFilters/ImportHDF5Dataset.cpp
@@ -41,6 +41,7 @@
 #include "H5Support/H5ScopedSentinel.h"
 #include "H5Support/H5Utilities.h"
 #include "H5Support/QH5Utilities.h"
+#include "H5Support/QH5Lite.h"
 
 #include "SIMPLib/Common/Constants.h"
 #include "SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.h"

--- a/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.cpp
+++ b/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.cpp
@@ -159,7 +159,7 @@ RotateArgs createRotateParams(const ImageGeom& imageGeom, const Matrix3fR& rotat
 {
   const SizeVec3Type origDims = imageGeom.getDimensions();
   const FloatVec3Type spacing = imageGeom.getSpacing();
-  const FloatVec3Type origin = imageGeom.getOrigin();
+  //const FloatVec3Type origin = imageGeom.getOrigin();
 
   float xMin = std::numeric_limits<float>::max();
   float xMax = std::numeric_limits<float>::min();
@@ -323,8 +323,8 @@ struct RotateSampleRefFrame::Impl
 //
 // -----------------------------------------------------------------------------
 RotateSampleRefFrame::RotateSampleRefFrame()
-: m_CellAttributeMatrixPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, "")
-, p_Impl(std::make_unique<Impl>())
+: p_Impl(std::make_unique<Impl>())
+, m_CellAttributeMatrixPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, "")
 {
   std::vector<std::vector<double>> defaultTable{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}};
   m_RotationTable.setTableData(defaultTable);

--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -1617,23 +1617,24 @@ T* DataArray<T>::resizeAndExtend(size_t size)
 //
 // -----------------------------------------------------------------------------
 
-template class DataArray<bool>;
+template class SIMPLib_EXPORT DataArray<bool>;
 
-template class DataArray<char>;
+template class SIMPLib_EXPORT DataArray<char>;
 
-template class DataArray<int8_t>;
-template class DataArray<uint8_t>;
+template class SIMPLib_EXPORT DataArray<int8_t>;
+template class SIMPLib_EXPORT DataArray<uint8_t>;
 
-template class DataArray<int16_t>;
-template class DataArray<uint16_t>;
+template class SIMPLib_EXPORT DataArray<int16_t>;
+template class SIMPLib_EXPORT DataArray<uint16_t>;
 
-template class DataArray<int32_t>;
-template class DataArray<uint32_t>;
+template class SIMPLib_EXPORT DataArray<int32_t>;
+template class SIMPLib_EXPORT DataArray<uint32_t>;
 
-template class DataArray<int64_t>;
-template class DataArray<uint64_t>;
+template class SIMPLib_EXPORT DataArray<int64_t>;
+template class SIMPLib_EXPORT DataArray<uint64_t>;
 
-template class DataArray<float>;
-template class DataArray<double>;
+template class SIMPLib_EXPORT DataArray<float>;
+template class SIMPLib_EXPORT DataArray<double>;
 
-template class DataArray<size_t>;
+template class SIMPLib_EXPORT DataArray<size_t>;
+

--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -1632,6 +1632,10 @@ T* DataArray<T>::resizeAndExtend(size_t size)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+#if !defined(__APPLE__) && !defined(_MSC_VER)
+#undef SIMPLib_EXPORT
+#define SIMPLib_EXPORT
+#endif
 
 template class SIMPLib_EXPORT DataArray<bool>;
 
@@ -1652,5 +1656,6 @@ template class SIMPLib_EXPORT DataArray<uint64_t>;
 template class SIMPLib_EXPORT DataArray<float>;
 template class SIMPLib_EXPORT DataArray<double>;
 
+#if defined(__APPLE__) || defined(_MSC_VER)
 template class SIMPLib_EXPORT DataArray<size_t>;
-
+#endif

--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -1,0 +1,1639 @@
+/* ============================================================================
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "DataArray.hpp"
+
+#include <string>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <numeric>
+
+#include "SIMPLib/HDF5/H5DataArrayReader.h"
+#include "SIMPLib/HDF5/H5DataArrayWriter.hpp"
+
+#define DA_BYTE_SWAP(s, d, t)                                                                                                                                                                          \
+  t[0] = ptr[s];                                                                                                                                                                                       \
+  ptr[s] = ptr[d];                                                                                                                                                                                     \
+  ptr[d] = t[0];
+
+template <typename T>
+typename DataArray<T>::Pointer DataArray<T>::NullPointer()
+{
+  return Pointer(static_cast<Self*>(nullptr));
+}
+
+template <typename T>
+QString DataArray<T>::getNameOfClass() const
+{
+  return QString("DataArray<T>");
+}
+
+template <typename T>
+QString DataArray<T>::ClassName()
+{
+  return QString("DataArray<T>");
+}
+
+template <typename T>
+int32_t DataArray<T>::getClassVersion() const
+{
+  return 2;
+}
+
+//========================================= Constructing DataArray Objects =================================
+template <typename T>
+DataArray<T>::DataArray() = default;
+
+/**
+ * @brief Constructor
+ * @param numTuples The number of Tuples in the DataArray
+ * @param name The name of the DataArray
+ * @param initValue The value to use when initializing each element of the array
+ */
+template <typename T>
+DataArray<T>::DataArray(size_t numTuples, const QString& name, T initValue)
+: IDataArray(name)
+, m_InitValue(initValue)
+{
+  resizeTuples(numTuples);
+}
+
+/**
+ * @brief DataArray
+ * @param numTuples The number of Tuples in the DataArray
+ * @param name The name of the DataArray
+ * @param compDims The number of elements in each axis dimension.
+ * @param initValue The value to use when initializing each element of the array
+ *
+ * For example if you have a 2D image dimensions of 80(w) x 60(h) then the "cdims" would be [80][60]
+ */
+template <typename T>
+DataArray<T>::DataArray(size_t numTuples, const QString& name, comp_dims_type compDims, T initValue)
+: IDataArray(name)
+, m_NumTuples(numTuples)
+, m_CompDims(std::move(compDims))
+{
+  m_NumComponents = std::accumulate(m_CompDims.begin(), m_CompDims.end(), static_cast<size_t>(1), std::multiplies<>());
+  m_InitValue = initValue;
+  m_Array = resizeAndExtend(m_NumTuples * m_NumComponents);
+}
+
+/**
+ * @brief Protected Constructor
+ * @param numTuples The number of Tuples in the DataArray
+ * @param name The name of the DataArray
+ * @param compDims The number of elements in each axis dimension.
+ * @param initValue The value to use when initializing each element of the array
+ * @param allocate Will all the memory be allocated at time of construction
+ */
+template <typename T>
+DataArray<T>::DataArray(size_t numTuples, const QString& name, comp_dims_type compDims, T initValue, bool allocate)
+: IDataArray(name)
+, m_NumTuples(numTuples)
+, m_CompDims(std::move(compDims))
+{
+  m_NumComponents = std::accumulate(m_CompDims.begin(), m_CompDims.end(), static_cast<size_t>(1), std::multiplies<>());
+  m_InitValue = initValue;
+  if(allocate)
+  {
+    resizeTuples(numTuples);
+  }
+  else
+  {
+    m_Size = m_NumTuples * m_NumComponents;
+    m_MaxId = (m_Size > 0) ? m_Size - 1 : m_Size;
+  }
+#if 0
+      MUD_FLAP_0 = MUD_FLAP_1 = MUD_FLAP_2 = MUD_FLAP_3 = MUD_FLAP_4 = MUD_FLAP_5 = 0xABABABABABABABABul;
+#endif
+}
+
+template <typename T>
+DataArray<T>::~DataArray()
+{
+  clear();
+}
+
+template <typename T>
+typename DataArray<T>::Pointer DataArray<T>::CreateArray(size_t numTuples, const QString& name, bool allocate)
+{
+  if(name.isEmpty())
+  {
+    return NullPointer();
+  }
+  comp_dims_type cDims = {1};
+  auto d = new DataArray<T>(numTuples, name, cDims, static_cast<T>(0), allocate);
+  if(allocate)
+  {
+    if(d->allocate() < 0)
+    {
+      // Could not allocate enough memory, reset the pointer to null and return
+      delete d;
+      return DataArray<T>::NullPointer();
+    }
+  }
+  Pointer ptr(d);
+  return ptr;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+typename DataArray<T>::Pointer DataArray<T>::CreateArray(size_t numTuples, int rank, const size_t* dims, const QString& name, bool allocate)
+{
+  if(name.isEmpty())
+  {
+    return NullPointer();
+  }
+  comp_dims_type cDims(static_cast<size_t>(rank));
+  for(size_t i = 0; i < static_cast<size_t>(rank); i++)
+  {
+    cDims[i] = dims[i];
+  }
+  auto d = new DataArray<T>(numTuples, name, cDims, static_cast<T>(0), allocate);
+  if(allocate)
+  {
+    if(d->allocate() < 0)
+    {
+      // Could not allocate enough memory, reset the pointer to null and return
+      delete d;
+      return DataArray<T>::NullPointer();
+    }
+  }
+  Pointer ptr(d);
+  return ptr;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+typename DataArray<T>::Pointer DataArray<T>::CreateArray(size_t numTuples, const comp_dims_type& compDims, const QString& name, bool allocate)
+{
+  if(name.isEmpty())
+  {
+    return NullPointer();
+  }
+  DataArray<T>* d = new DataArray<T>(numTuples, name, compDims, static_cast<T>(0), allocate);
+  if(allocate)
+  {
+    if(d->allocate() < 0)
+    {
+      // Could not allocate enough memory, reset the pointer to null and return
+      delete d;
+      return DataArray<T>::NullPointer();
+    }
+  }
+  Pointer ptr(d);
+  return ptr;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+typename DataArray<T>::Pointer DataArray<T>::CreateArray(const comp_dims_type& tupleDims, const comp_dims_type& compDims, const QString& name, bool allocate)
+{
+  if(name.isEmpty())
+  {
+    return NullPointer();
+  }
+
+  size_t numTuples = std::accumulate(tupleDims.begin(), tupleDims.end(), static_cast<size_t>(1), std::multiplies<>());
+
+  auto d = new DataArray<T>(numTuples, name, compDims, static_cast<T>(0), allocate);
+  if(allocate)
+  {
+    if(d->allocate() < 0)
+    {
+      // Could not allocate enough memory, reset the pointer to null and return
+      delete d;
+      return DataArray<T>::NullPointer();
+    }
+  }
+  Pointer ptr(d);
+  return ptr;
+}
+
+template <typename T>
+IDataArray::Pointer DataArray<T>::createNewArray(size_t numTuples, int rank, const size_t* compDims, const QString& name, bool allocate) const
+{
+  IDataArray::Pointer p = DataArray<T>::CreateArray(numTuples, rank, compDims, name, allocate);
+  return p;
+}
+
+template <typename T>
+IDataArray::Pointer DataArray<T>::createNewArray(size_t numTuples, const comp_dims_type& compDims, const QString& name, bool allocate) const
+{
+  IDataArray::Pointer p = DataArray<T>::CreateArray(numTuples, compDims, name, allocate);
+  return p;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+typename DataArray<T>::Pointer DataArray<T>::FromQVector(QVector<T>& vec, const QString& name)
+{
+
+  Pointer p = CreateArray(static_cast<size_t>(vec.size()), name, true);
+  if(nullptr != p.get())
+  {
+    std::memcpy(p->getPointer(0), vec.data(), static_cast<size_t>(vec.size()) * sizeof(T));
+  }
+  return p;
+}
+
+// -----------------------------------------------------------------------------
+template <>
+typename DataArray<bool>::Pointer DataArray<bool>::FromStdVector(std::vector<bool>& vec, const QString& name)
+{
+  comp_dims_type cDims = {1};
+  Pointer p = CreateArray(vec.size(), cDims, name, true);
+  if(nullptr != p.get())
+  {
+    size_t i = 0;
+    for(const auto value : vec)
+    {
+      p->setValue(i, value);
+      i++;
+    }
+  }
+  return p;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+typename DataArray<T>::Pointer DataArray<T>::FromStdVector(std::vector<T>& vec, const QString& name)
+{
+  comp_dims_type cDims = {1};
+  Pointer p = CreateArray(vec.size(), cDims, name, true);
+  if(nullptr != p.get())
+  {
+    std::memcpy(p->getPointer(0), &(vec.front()), vec.size() * sizeof(T));
+  }
+  return p;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+typename DataArray<T>::Pointer DataArray<T>::CopyFromPointer(T* data, size_t size, const QString& name)
+{
+  Pointer p = CreateArray(size, name, true);
+  if(nullptr != p.get())
+  {
+    std::memcpy(p->getPointer(0), data, size * sizeof(T));
+  }
+  return p;
+}
+
+/**
+ * @brief WrapPointer Creates a DataArray<T> object that references the pointer. The original caller can
+ * set if the memory should be "free()'ed" when the object goes away. The original memory MUST have been
+ * "alloc()'ed" and <b>NOT</b> new 'ed.
+ * @param data
+ * @param numTuples
+ * @param cDims
+ * @param name
+ * @param ownsData
+ * @return
+ */
+template <typename T>
+typename DataArray<T>::Pointer DataArray<T>::WrapPointer(T* data, size_t numTuples, const comp_dims_type& compDims, const QString& name, bool ownsData)
+{
+  // Allocate on the heap
+  auto d = new DataArray(numTuples, name, compDims, static_cast<T>(0), false);
+  // Wrap that heap pointer with a shared_pointer to make it reference counted
+  Pointer p(d);
+
+  p->m_Array = data;        // Now set the internal array to the raw pointer
+  p->m_OwnsData = ownsData; // Set who owns the data, i.e., who is going to "free" the memory
+  if(nullptr != data)
+  {
+    p->m_IsAllocated = true;
+  }
+
+  return p;
+}
+
+//========================================= Begin API =================================
+template <typename T>
+IDataArray::Pointer DataArray<T>::deepCopy(bool forceNoAllocate) const
+{
+  bool allocate = m_IsAllocated;
+  if(forceNoAllocate)
+  {
+    allocate = false;
+  }
+  IDataArray::Pointer daCopy = createNewArray(getNumberOfTuples(), getComponentDimensions(), getName(), allocate);
+  if(m_IsAllocated && !forceNoAllocate)
+  {
+    T* src = getPointer(0);
+    void* dest = daCopy->getVoidPointer(0);
+    size_t totalBytes = (getNumberOfTuples() * static_cast<size_t>(getNumberOfComponents()) * sizeof(T));
+    std::memcpy(dest, src, totalBytes);
+  }
+  return daCopy;
+}
+
+/**
+ * @brief GetTypeName Returns a string representation of the type of data that is stored by this class. This
+ * can be a primitive like char, float, int or the name of a class.
+ * @return
+ */
+template <typename T>
+SIMPL::NumericTypes::Type DataArray<T>::getType() const
+{
+  T value = static_cast<T>(0x00);
+  if(typeid(value) == typeid(int8_t))
+  {
+    return SIMPL::NumericTypes::Type::Int8;
+  }
+  if(typeid(value) == typeid(uint8_t))
+  {
+    return SIMPL::NumericTypes::Type::UInt8;
+  }
+
+  if(typeid(value) == typeid(int16_t))
+  {
+    return SIMPL::NumericTypes::Type::Int16;
+  }
+  if(typeid(value) == typeid(uint16_t))
+  {
+    return SIMPL::NumericTypes::Type::UInt16;
+  }
+
+  if(typeid(value) == typeid(int32_t))
+  {
+    return SIMPL::NumericTypes::Type::Int32;
+  }
+  if(typeid(value) == typeid(uint32_t))
+  {
+    return SIMPL::NumericTypes::Type::UInt32;
+  }
+
+  if(typeid(value) == typeid(int64_t))
+  {
+    return SIMPL::NumericTypes::Type::Int64;
+  }
+  if(typeid(value) == typeid(uint64_t))
+  {
+    return SIMPL::NumericTypes::Type::UInt64;
+  }
+
+  if(typeid(value) == typeid(float))
+  {
+    return SIMPL::NumericTypes::Type::Float;
+  }
+  if(typeid(value) == typeid(double))
+  {
+    return SIMPL::NumericTypes::Type::Double;
+  }
+
+  if(typeid(value) == typeid(bool))
+  {
+    return SIMPL::NumericTypes::Type::Bool;
+  }
+
+  return SIMPL::NumericTypes::Type::UnknownNumType;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::getXdmfTypeAndSize(QString& xdmfTypeName, int& precision) const
+{
+  T value = static_cast<T>(0x00);
+  xdmfTypeName = "UNKNOWN";
+  precision = 0;
+  if(typeid(value) == typeid(int8_t))
+  {
+    xdmfTypeName = "Char";
+    precision = 1;
+  }
+  if(typeid(value) == typeid(uint8_t))
+  {
+    xdmfTypeName = "UChar";
+    precision = 1;
+  }
+
+  if(typeid(value) == typeid(int16_t))
+  {
+    xdmfTypeName = "Int";
+    precision = 2;
+  }
+  if(typeid(value) == typeid(uint16_t))
+  {
+    xdmfTypeName = "UInt";
+    precision = 2;
+  }
+
+  if(typeid(value) == typeid(int32_t))
+  {
+    xdmfTypeName = "Int";
+    precision = 4;
+  }
+  if(typeid(value) == typeid(uint32_t))
+  {
+    xdmfTypeName = "UInt";
+    precision = 4;
+  }
+
+  if(typeid(value) == typeid(int64_t))
+  {
+    xdmfTypeName = "Int";
+    precision = 8;
+  }
+  if(typeid(value) == typeid(uint64_t))
+  {
+    xdmfTypeName = "UInt";
+    precision = 8;
+  }
+
+  if(typeid(value) == typeid(float))
+  {
+    xdmfTypeName = "Float";
+    precision = 4;
+  }
+  if(typeid(value) == typeid(double))
+  {
+    xdmfTypeName = "Float";
+    precision = 8;
+  }
+
+  if(typeid(value) == typeid(bool))
+  {
+    xdmfTypeName = "uchar";
+    precision = 1;
+  }
+}
+// This line must be here, because we are overloading the copyData pure  function in IDataArray.
+// This is required so that other classes can call this version of copyData from the subclasses.
+// using IDataArray::copyFromArray;
+
+// -----------------------------------------------------------------------------
+template <typename T>
+bool DataArray<T>::copyFromArray(size_t destTupleOffset, IDataArray::Pointer sourceArray, size_t srcTupleOffset, size_t totalSrcTuples)
+{
+  if(!m_IsAllocated)
+  {
+    return false;
+  }
+  if(nullptr == m_Array)
+  {
+    return false;
+  }
+  if(destTupleOffset > m_MaxId)
+  {
+    return false;
+  }
+  if(!sourceArray->isAllocated())
+  {
+    return false;
+  }
+  Self* source = dynamic_cast<Self*>(sourceArray.get());
+  if(nullptr == source->getPointer(0))
+  {
+    return false;
+  }
+
+  if(sourceArray->getNumberOfComponents() != getNumberOfComponents())
+  {
+    return false;
+  }
+
+  if(srcTupleOffset + totalSrcTuples > sourceArray->getNumberOfTuples())
+  {
+    return false;
+  }
+
+  if(totalSrcTuples * static_cast<size_t>(sourceArray->getNumberOfComponents()) + destTupleOffset * static_cast<size_t>(getNumberOfComponents()) > m_Size)
+  {
+    return false;
+  }
+
+  size_t elementStart = destTupleOffset * static_cast<size_t>(getNumberOfComponents());
+  size_t totalBytes = (totalSrcTuples * static_cast<size_t>(sourceArray->getNumberOfComponents())) * sizeof(T);
+  std::memcpy(m_Array + elementStart, source->getPointer(srcTupleOffset * static_cast<size_t>(sourceArray->getNumberOfComponents())), totalBytes);
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+bool DataArray<T>::copyIntoArray(Pointer dest) const
+{
+  if(m_IsAllocated && dest->isAllocated() && m_Array && dest->getPointer(0))
+  {
+    size_t totalBytes = m_Size * sizeof(T);
+    std::memcpy(dest->getPointer(0), m_Array, totalBytes);
+    return true;
+  }
+  return false;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+bool DataArray<T>::isAllocated() const
+{
+  return m_IsAllocated;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::setInitValue(T initValue)
+{
+  m_InitValue = initValue;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::takeOwnership()
+{
+  m_OwnsData = true;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::releaseOwnership()
+{
+  m_OwnsData = false;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+int32_t DataArray<T>::allocate()
+{
+  if((nullptr != m_Array) && (true == m_OwnsData))
+  {
+    deallocate();
+  }
+  m_Array = nullptr;
+  m_OwnsData = true;
+  m_IsAllocated = false;
+  if(m_Size == 0)
+  {
+    clear();
+    return 1;
+  }
+
+  size_t newSize = m_Size;
+  m_Array = new T[newSize]();
+  if(!m_Array)
+  {
+    qDebug() << "Unable to allocate " << newSize << " elements of size " << sizeof(T) << " bytes. ";
+    return -1;
+  }
+  m_Size = newSize;
+  m_IsAllocated = true;
+
+  return 1;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::initializeWithZeros()
+{
+  if(!m_IsAllocated || nullptr == m_Array)
+  {
+    return;
+  }
+  size_t typeSize = sizeof(T);
+  ::memset(m_Array, 0, m_Size * typeSize);
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::initializeWithValue(T initValue, size_t offset)
+{
+  if(!m_IsAllocated || nullptr == m_Array)
+  {
+    return;
+  }
+  for(size_t i = offset; i < m_Size; i++)
+  {
+    m_Array[i] = initValue;
+  }
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+int DataArray<T>::eraseTuples(comp_dims_type& idxs)
+{
+  int err = 0;
+
+  // If nothing is to be erased just return
+  if(idxs.empty())
+  {
+    return 0;
+  }
+  auto idxs_size = static_cast<size_t>(idxs.size());
+  if(idxs_size >= getNumberOfTuples())
+  {
+    resizeTuples(0);
+    return 0;
+  }
+
+  // Sanity Check the Indices in the vector to make sure we are not trying to remove any indices that are
+  // off the end of the array and return an error code.
+  for(size_t& idx : idxs)
+  {
+    if(idx * m_NumComponents > m_MaxId)
+    {
+      return -100;
+    }
+  }
+
+  // Calculate the new size of the array to copy into
+  size_t newSize = (getNumberOfTuples() - idxs.size()) * m_NumComponents;
+
+  // Create a new m_Array to copy into
+  T* newArray = new T[newSize]();
+
+  // Splat AB across the array so we know if we are copying the values or not
+  ::memset(newArray, 0xAB, newSize * sizeof(T));
+
+  // Keep the current Destination Pointer
+  T* currentDest = newArray;
+  size_t j = 0;
+  size_t k = 0;
+  // Find the first chunk to copy by walking the idxs array until we get an
+  // index that is NOT a continuous increment from the start
+  for(k = 0; k < idxs.size(); ++k)
+  {
+    if(j == idxs[k])
+    {
+      ++j;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  if(k == idxs.size()) // Only front elements are being dropped
+  {
+    T* currentSrc = m_Array + (j * m_NumComponents);
+    std::memcpy(currentDest, currentSrc, (getNumberOfTuples() - idxs.size()) * m_NumComponents * sizeof(T));
+    deallocate(); // We are done copying - delete the current m_Array
+    m_Size = newSize;
+    m_Array = newArray;
+    m_OwnsData = true;
+    m_MaxId = newSize - 1;
+    m_IsAllocated = true;
+    return 0;
+  }
+
+  comp_dims_type srcIdx(idxs.size() + 1);
+  comp_dims_type destIdx(idxs.size() + 1);
+  comp_dims_type copyElements(idxs.size() + 1);
+  srcIdx[0] = 0;
+  destIdx[0] = 0;
+  copyElements[0] = (idxs[0] - 0) * m_NumComponents;
+
+  for(size_t i = 1; i < srcIdx.size(); ++i)
+  {
+    srcIdx[i] = (idxs[i - 1] + 1) * m_NumComponents;
+
+    if(i < srcIdx.size() - 1)
+    {
+      copyElements[i] = (idxs[i] - idxs[i - 1] - 1) * m_NumComponents;
+    }
+    else
+    {
+      copyElements[i] = (getNumberOfTuples() - idxs[i - 1] - 1) * m_NumComponents;
+    }
+    destIdx[i] = copyElements[i - 1] + destIdx[i - 1];
+  }
+
+  // Copy the data
+  for(size_t i = 0; i < srcIdx.size(); ++i)
+  {
+    currentDest = newArray + destIdx[i];
+    T* currentSrc = m_Array + srcIdx[i];
+    size_t bytes = copyElements[i] * sizeof(T);
+    std::memcpy(currentDest, currentSrc, bytes);
+  }
+
+  // We are done copying - delete the current m_Array
+  deallocate();
+
+  // Allocation was successful.  Save it.
+  m_Size = newSize;
+  m_Array = newArray;
+  // This object has now allocated its memory and owns it.
+  m_OwnsData = true;
+  m_IsAllocated = true;
+  m_MaxId = newSize - 1;
+
+  return err;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+int DataArray<T>::copyTuple(size_t currentPos, size_t newPos)
+{
+  size_t max = ((m_MaxId + 1) / m_NumComponents);
+  if(currentPos >= max || newPos >= max)
+  {
+    return -1;
+  }
+  T* src = m_Array + (currentPos * m_NumComponents);
+  T* dest = m_Array + (newPos * m_NumComponents);
+  size_t bytes = sizeof(T) * m_NumComponents;
+  std::memcpy(dest, src, bytes);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+size_t DataArray<T>::getTypeSize() const
+{
+  return sizeof(T);
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+size_t DataArray<T>::getNumberOfTuples() const
+{
+  return m_NumTuples;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+size_t DataArray<T>::getSize() const
+{
+  return m_Size;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+typename DataArray<T>::comp_dims_type DataArray<T>::getComponentDimensions() const
+{
+  return m_CompDims;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+int32_t DataArray<T>::getNumberOfComponents() const
+{
+  return static_cast<int32_t>(m_NumComponents);
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void* DataArray<T>::getVoidPointer(size_t i)
+{
+  if(i >= m_Size)
+  {
+    return nullptr;
+  }
+
+  return reinterpret_cast<void*>(&(m_Array[i]));
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+std::list<T> DataArray<T>::getArray() const
+{
+  return std::list<T>(m_Array, m_Array + (m_Size * sizeof(T)) / sizeof(T));
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::setArray(std::list<T> newArray)
+{
+  if(newArray.size() != m_Size)
+  {
+    return;
+  }
+  int i = 0;
+  for(auto elem : newArray)
+  {
+    m_Array[i++] = elem;
+  }
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+T* DataArray<T>::getPointer(size_t i) const
+{
+#ifndef NDEBUG
+  if(m_Size > 0)
+  {
+    Q_ASSERT(i < m_Size);
+  }
+#endif
+  return m_Array + i;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+T DataArray<T>::getValue(size_t i) const
+{
+#ifndef NDEBUG
+  if(m_Size > 0)
+  {
+    Q_ASSERT(i < m_Size);
+  }
+#endif
+  return m_Array[i];
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::setValue(size_t i, T value)
+{
+#ifndef NDEBUG
+  if(m_Size > 0)
+  {
+    Q_ASSERT(i < m_Size);
+  }
+#endif
+  m_Array[i] = value;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+T DataArray<T>::getComponent(size_t i, int32_t j) const
+{
+#ifndef NDEBUG
+  if(m_Size > 0)
+  {
+    Q_ASSERT(i * m_NumComponents + static_cast<size_t>(j) < m_Size);
+  }
+#endif
+  return m_Array[i * m_NumComponents + static_cast<size_t>(j)];
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::setComponent(size_t i, int32_t j, T c)
+{
+#ifndef NDEBUG
+  if(m_Size > 0)
+  {
+    Q_ASSERT(i * m_NumComponents + static_cast<size_t>(j) < m_Size);
+  }
+#endif
+  m_Array[i * m_NumComponents + static_cast<size_t>(j)] = c;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::setTuple(size_t tupleIndex, T* data)
+{
+#ifndef NDEBUG
+  if(m_Size > 0)
+  {
+    Q_ASSERT(tupleIndex * m_NumComponents + (m_NumComponents - 1) < m_Size);
+  }
+#endif
+  std::memcpy(getTuplePointer(tupleIndex), data, m_NumComponents * sizeof(T));
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::setTuple(size_t tupleIndex, const std::vector<T>& data)
+{
+#ifndef NDEBUG
+  if(m_Size > 0)
+  {
+    Q_ASSERT(tupleIndex * m_NumComponents + (m_NumComponents - 1) < m_Size);
+  }
+#endif
+  std::memcpy(getTuplePointer(tupleIndex), data.data(), m_NumComponents * sizeof(T));
+}
+// -----------------------------------------------------------------------------
+template <>
+void DataArray<bool>::setTuple(size_t tupleIndex, const std::vector<bool>& data)
+{
+#ifndef NDEBUG
+  if(m_Size > 0)
+  {
+    Q_ASSERT(tupleIndex * m_NumComponents + (m_NumComponents - 1) < m_Size);
+  }
+#endif
+  bool* ptr = getTuplePointer(tupleIndex);
+  size_t i = 0;
+  for(const auto value : data)
+  {
+    ptr[i] = value;
+    i++;
+  }
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::initializeTuple(size_t i, void* p)
+{
+  if(!m_IsAllocated)
+  {
+    return;
+  }
+#ifndef NDEBUG
+  if(m_Size > 0)
+  {
+    Q_ASSERT(i * m_NumComponents < m_Size);
+  }
+#endif
+  if(nullptr == p)
+  {
+    return;
+  }
+  T* c = reinterpret_cast<T*>(p);
+  for(size_t j = 0; j < m_NumComponents; ++j)
+  {
+    m_Array[i * m_NumComponents + j] = *c;
+  }
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+T* DataArray<T>::getTuplePointer(size_t tupleIndex) const
+{
+#ifndef NDEBUG
+  if(m_Size > 0)
+  {
+    Q_ASSERT(tupleIndex * m_NumComponents < m_Size);
+  }
+#endif
+  return m_Array + (tupleIndex * m_NumComponents);
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::resizeTuples(size_t numTuples)
+{
+  T* ptr = resizeAndExtend(numTuples * m_NumComponents);
+  if(nullptr != ptr)
+  {
+    m_NumTuples = numTuples;
+  }
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::printTuple(QTextStream& out, size_t i, char delimiter) const
+{
+  int precision = out.realNumberPrecision();
+  T value = static_cast<T>(0x00);
+  if(typeid(value) == typeid(float))
+  {
+    out.setRealNumberPrecision(8);
+  }
+  if(typeid(value) == typeid(double))
+  {
+    out.setRealNumberPrecision(16);
+  }
+
+  for(size_t j = 0; j < m_NumComponents; ++j)
+  {
+    if(j != 0)
+    {
+      out << delimiter;
+    }
+    out << m_Array[i * m_NumComponents + j];
+  }
+  out.setRealNumberPrecision(precision);
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::printComponent(QTextStream& out, size_t i, int32_t j) const
+{
+  out << m_Array[i * m_NumComponents + static_cast<size_t>(j)];
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+QString DataArray<T>::getFullNameOfClass() const
+{
+  QString theType = getTypeAsString();
+  theType = "DataArray<" + theType + ">";
+  return theType;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+QString DataArray<T>::getTypeAsString() const
+{
+  T value = static_cast<T>(0);
+  if(typeid(value) == typeid(float))
+  {
+    return "float";
+  }
+  if(typeid(value) == typeid(double))
+  {
+    return "double";
+  }
+
+  if(typeid(value) == typeid(int8_t))
+  {
+    return "int8_t";
+  }
+  if(typeid(value) == typeid(uint8_t))
+  {
+    return "uint8_t";
+  }
+#if CMP_TYPE_CHAR_IS_SIGNED
+  if(typeid(value) == typeid(char))
+  {
+    return "int8_t";
+  }
+#else
+  if(typeid(value) == typeid(char))
+  {
+    return "int8_t";
+  }
+#endif
+  if(typeid(value) == typeid(signed char))
+  {
+    return "int8_t";
+  }
+  if(typeid(value) == typeid(unsigned char))
+  {
+    return "uint8_t";
+  }
+
+  if(typeid(value) == typeid(int16_t))
+  {
+    return "int16_t";
+  }
+  if(typeid(value) == typeid(short))
+  {
+    return "int16_t";
+  }
+  if(typeid(value) == typeid(signed short))
+  {
+    return "int16_t";
+  }
+  if(typeid(value) == typeid(uint16_t))
+  {
+    return "uint16_t";
+  }
+  if(typeid(value) == typeid(unsigned short))
+  {
+    return "uint16_t";
+  }
+
+  if(typeid(value) == typeid(int32_t))
+  {
+    return "int32_t";
+  }
+  if(typeid(value) == typeid(uint32_t))
+  {
+    return "uint32_t";
+  }
+#if(CMP_SIZEOF_INT == 4)
+  if(typeid(value) == typeid(int))
+  {
+    return "int32_t";
+  }
+  if(typeid(value) == typeid(signed int))
+  {
+    return "int32_t";
+  }
+  if(typeid(value) == typeid(unsigned int))
+  {
+    return "uint32_t";
+  }
+#endif
+
+  if(typeid(value) == typeid(int64_t))
+  {
+    return "int64_t";
+  }
+  if(typeid(value) == typeid(uint64_t))
+  {
+    return "uint64_t";
+  }
+
+#if(CMP_SIZEOF_LONG == 4)
+  if(typeid(value) == typeid(long int))
+  {
+    return "long int";
+  }
+  if(typeid(value) == typeid(signed long int))
+  {
+    return "signed long int";
+  }
+  if(typeid(value) == typeid(unsigned long int))
+  {
+    return "unsigned long int";
+  }
+#elif(CMP_SIZEOF_LONG == 8)
+  if(typeid(value) == typeid(long int))
+  {
+    return "int64_t";
+  }
+  if(typeid(value) == typeid(signed long int))
+  {
+    return "int64_t";
+  }
+  if(typeid(value) == typeid(unsigned long int))
+  {
+    return "uint64_t";
+  }
+#endif
+
+#if(CMP_SIZEOF_LONG_LONG == 8)
+  if(typeid(value) == typeid(long long int))
+  {
+    return "int64_t";
+  }
+  if(typeid(value) == typeid(signed long long int))
+  {
+    return "int64_t";
+  }
+  if(typeid(value) == typeid(unsigned long long int))
+  {
+    return "uint64_t";
+  }
+#endif
+
+  if(typeid(value) == typeid(bool))
+  {
+    return "bool";
+  }
+
+  // qDebug()  << "Error: HDFTypeForPrimitive - Unknown Type: " << (typeid(value).name()) ;
+  const char* name = typeid(value).name();
+  if(nullptr != name && name[0] == 'l')
+  {
+    qDebug() << "You are using 'long int' as a type which is not 32/64 bit safe. Suggest you use one of the H5SupportTypes defined in <Common/H5SupportTypes.h> such as int32_t or uint32_t.";
+  }
+  return "UnknownType";
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+int DataArray<T>::writeH5Data(hid_t parentId, comp_dims_type tDims) const
+{
+  if(m_Array == nullptr)
+  {
+    return -85648;
+  }
+  return H5DataArrayWriter::writeDataArray<Self>(parentId, this, tDims);
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+int DataArray<T>::writeXdmfAttribute(QTextStream& out, int64_t* volDims, const QString& hdfFileName, const QString& groupPath, const QString& label) const
+{
+  if(m_Array == nullptr)
+  {
+    return -85648;
+  }
+  QString dimStr;
+  int precision = 0;
+  QString xdmfTypeName;
+  getXdmfTypeAndSize(xdmfTypeName, precision);
+  if(0 == precision)
+  {
+    out << "<!-- " << getName() << " has unknown type or unsupported type or precision for XDMF to understand"
+        << " -->"
+        << "\n";
+    return -100;
+  }
+
+  int numComp = getNumberOfComponents();
+  out << "    <Attribute Name=\"" << getName() << label << "\" ";
+  if(numComp == 1)
+  {
+    out << "AttributeType=\"Scalar\" ";
+    dimStr = QString("%1 %2 %3 ").arg(volDims[2]).arg(volDims[1]).arg(volDims[0]);
+  }
+  else if(numComp == 6)
+  {
+    out << "AttributeType=\"Tensor6\" ";
+    dimStr = QString("%1 %2 %3 %4 ").arg(volDims[2]).arg(volDims[1]).arg(volDims[0]).arg(numComp);
+  }
+  else if(numComp == 9)
+  {
+    out << "AttributeType=\"Tensor\" ";
+    dimStr = QString("%1 %2 %3 %4 ").arg(volDims[2]).arg(volDims[1]).arg(volDims[0]).arg(numComp);
+  }
+  else
+  {
+    out << "AttributeType=\"Vector\" ";
+    dimStr = QString("%1 %2 %3 %4 ").arg(volDims[2]).arg(volDims[1]).arg(volDims[0]).arg(numComp);
+  }
+  out << "Center=\"Cell\">\n";
+  // Open the <DataItem> Tag
+  out << R"(      <DataItem Format="HDF" Dimensions=")" << dimStr << R"(" )";
+  out << "NumberType=\"" << xdmfTypeName << "\" "
+      << "Precision=\"" << precision << "\" >\n";
+
+  out << "        " << hdfFileName << groupPath << "/" << getName() << "\n";
+  out << "      </DataItem>"
+      << "\n";
+  out << "    </Attribute>"
+      << "\n";
+  return 1;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+QString DataArray<T>::getInfoString(SIMPL::InfoStringFormat format) const
+{
+
+  QLocale usa(QLocale::English, QLocale::UnitedStates);
+
+  QString info;
+  QTextStream ss(&info);
+  if(format == SIMPL::HtmlFormat)
+  {
+    ss << "<html><head></head>\n";
+    ss << "<body>\n";
+    ss << "<table cellpadding=\"4\" cellspacing=\"0\" border=\"0\">\n";
+    ss << "<tbody>\n";
+    ss << "<tr bgcolor=\"#FFFCEA\"><th colspan=2>Attribute Array Info</th></tr>";
+
+    ss << R"(<tr bgcolor="#E9E7D6"><th align="right">Name:</th><td>)" << getName() << "</td></tr>";
+
+    ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Type:</th><td> DataArray&lt;)" << getTypeAsString() << "&gt;</td></tr>";
+    QString numStr = usa.toString(static_cast<qlonglong>(getNumberOfTuples()));
+    ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Number of Tuples:</th><td>)" << numStr << "</td></tr>";
+
+    QString compDimStr = "(";
+    for(size_t i = 0; i < m_CompDims.size(); i++)
+    {
+      compDimStr = compDimStr + QString::number(m_CompDims[i]);
+      if(i < m_CompDims.size() - 1)
+      {
+        compDimStr = compDimStr + QString(", ");
+      }
+    }
+    compDimStr = compDimStr + ")";
+    ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Component Dimensions:</th><td>)" << compDimStr << "</td></tr>";
+    numStr = usa.toString(static_cast<qlonglong>(m_Size));
+    ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Total Elements:</th><td>)" << numStr << "</td></tr>";
+    numStr = usa.toString(static_cast<qlonglong>(m_Size * sizeof(T)));
+    ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Total Memory Required:</th><td>)" << numStr << "</td></tr>";
+    ss << "</tbody></table>\n";
+    ss << "</body></html>";
+  }
+  else
+  {
+  }
+  return info;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+int DataArray<T>::readH5Data(hid_t parentId)
+{
+  int err = 0;
+
+  resizeTuples(0);
+  IDataArray::Pointer p = H5DataArrayReader::ReadIDataArray(parentId, getName());
+  if(p.get() == nullptr)
+  {
+    return -1;
+  }
+  m_Array = reinterpret_cast<T*>(p->getVoidPointer(0));
+  m_Size = p->getSize();
+  m_OwnsData = true;
+  m_MaxId = (m_Size == 0) ? 0 : m_Size - 1;
+  m_IsAllocated = true;
+  setName(p->getName());
+  m_NumTuples = p->getNumberOfTuples();
+  m_CompDims = p->getComponentDimensions();
+  m_NumComponents = static_cast<size_t>(p->getNumberOfComponents());
+
+  // Tell the intermediate DataArray to release ownership of the data as we are going to be responsible
+  // for deleting the memory
+  p->releaseOwnership();
+  return err;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::byteSwapElements()
+{
+  char* ptr = reinterpret_cast<char*>(m_Array);
+  char t[8];
+  size_t size = getTypeSize();
+  for(uint64_t var = 0; var < m_Size; ++var)
+  {
+    if(sizeof(T) == 2)
+    {
+      DA_BYTE_SWAP(0, 1, t)
+    }
+    else if(sizeof(T) == 4)
+    {
+      DA_BYTE_SWAP(0, 3, t) DA_BYTE_SWAP(1, 2, t)
+    }
+    else if(sizeof(T) == 8)
+    {
+      DA_BYTE_SWAP(0, 7, t) DA_BYTE_SWAP(1, 6, t) DA_BYTE_SWAP(2, 5, t) DA_BYTE_SWAP(3, 4, t)
+    }
+    ptr += size; // increment the pointer
+  }
+}
+
+template <typename T>
+typename DataArray<T>::iterator DataArray<T>::begin()
+{
+  return iterator(m_Array);
+}
+
+template <typename T>
+typename DataArray<T>::iterator DataArray<T>::end()
+{
+  return iterator(m_Array + m_Size);
+}
+
+template <typename T>
+typename DataArray<T>::const_iterator DataArray<T>::begin() const
+{
+  return const_iterator(m_Array);
+}
+template <typename T>
+typename DataArray<T>::const_iterator DataArray<T>::end() const
+{
+  return const_iterator(m_Array + m_Size);
+}
+
+// rbegin
+// rend
+// cbegin
+// cend
+// crbegin
+// crend
+
+// ######### Capacity #########
+template <typename T>
+typename DataArray<T>::size_type DataArray<T>::size() const
+{
+  return m_Size;
+}
+template <typename T>
+typename DataArray<T>::size_type DataArray<T>::max_size() const
+{
+  return m_Size;
+}
+//  void resize(size_type n)
+//  {
+//    resizeAndExtend(n);
+//  }
+// void resize (size_type n, const value_type& val);
+template <typename T>
+typename DataArray<T>::size_type DataArray<T>::capacity() const noexcept
+{
+  return m_Size;
+}
+
+template <typename T>
+bool DataArray<T>::empty() const noexcept
+{
+  return (m_Size == 0);
+}
+// reserve()
+// shrink_to_fit()
+
+// ######### Element Access #########
+
+// ######### Modifiers #########
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::assign(size_type n, const value_type& val) // fill (2)
+{
+  resizeAndExtend(n);
+  for(size_t i = 0; i < n; i++)
+  {
+    m_Array[i] = val;
+  }
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::assign(std::initializer_list<value_type> il) //  initializer list (3)
+{
+  assign(il.begin(), il.end());
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::push_back(const value_type& val)
+{
+  resizeAndExtend(m_Size + 1);
+  m_Array[m_MaxId] = val;
+}
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::push_back(value_type&& val)
+{
+  resizeAndExtend(m_Size + 1);
+  m_Array[m_MaxId] = val;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::pop_back()
+{
+  resizeAndExtend(m_Size - 1);
+}
+// insert
+// iterator erase (const_iterator position)
+// iterator erase (const_iterator first, const_iterator last);
+// swap
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::clear()
+{
+  if(nullptr != m_Array && m_OwnsData)
+  {
+    deallocate();
+  }
+  m_Array = nullptr;
+  m_Size = 0;
+  m_OwnsData = true;
+  m_MaxId = 0;
+  m_IsAllocated = false;
+  m_NumTuples = 0;
+}
+// emplace
+// emplace_back
+
+// =================================== END STL COMPATIBLE INTERFACe ===================================================
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void DataArray<T>::deallocate()
+{
+  // We are going to splat 0xABABAB across the first value of the array as a debugging aid
+  auto cptr = reinterpret_cast<unsigned char*>(m_Array);
+  if(nullptr != cptr)
+  {
+    if(m_Size > 0)
+    {
+      if(sizeof(T) >= 1)
+      {
+        cptr[0] = 0xAB;
+      }
+      if(sizeof(T) >= 2)
+      {
+        cptr[1] = 0xAB;
+      }
+      if(sizeof(T) >= 4)
+      {
+        cptr[2] = 0xAB;
+        cptr[3] = 0xAB;
+      }
+      if(sizeof(T) >= 8)
+      {
+        cptr[4] = 0xAB;
+        cptr[5] = 0xAB;
+        cptr[6] = 0xAB;
+        cptr[7] = 0xAB;
+      }
+    }
+  }
+#if 0
+      if (MUD_FLAP_0 != 0xABABABABABABABABul
+          || MUD_FLAP_1 != 0xABABABABABABABABul
+          || MUD_FLAP_2 != 0xABABABABABABABABul
+          || MUD_FLAP_3 != 0xABABABABABABABABul
+          || MUD_FLAP_4 != 0xABABABABABABABABul
+          || MUD_FLAP_5 != 0xABABABABABABABABul)
+      {
+        Q_ASSERT(false);
+      }
+#endif
+  delete[](m_Array);
+
+  m_Array = nullptr;
+  m_IsAllocated = false;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+int32_t DataArray<T>::resizeTotalElements(size_t size)
+{
+  // std::cout << "DataArray::resizeTotalElements(" << size << ")" << std::endl;
+  if(size == 0)
+  {
+    clear();
+    return 1;
+  }
+  T* ptr = resizeAndExtend(size);
+  if(nullptr != ptr)
+  {
+    return 1;
+  }
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+T* DataArray<T>::resizeAndExtend(size_t size)
+{
+  T* newArray = nullptr;
+  size_t newSize = 0;
+  size_t oldSize = 0;
+
+  if(size == m_Size) // Requested size is equal to current size.  Do nothing.
+  {
+    return m_Array;
+  }
+  newSize = size;
+  oldSize = m_Size;
+
+  // Wipe out the array completely if new size is zero.
+  if(newSize == 0)
+  {
+    clear();
+    return m_Array;
+  }
+
+  newArray = new T[newSize]();
+  if(!newArray)
+  {
+    qDebug() << "Unable to allocate " << newSize << " elements of size " << sizeof(T) << " bytes. ";
+    return nullptr;
+  }
+
+  // Copy the data from the old array.
+  if(m_Array != nullptr)
+  {
+    std::memcpy(newArray, m_Array, (newSize < m_Size ? newSize : m_Size) * sizeof(T));
+  }
+
+  // Allocate a new array if we DO NOT own the current array
+  if((nullptr != m_Array) && m_OwnsData)
+  {
+    // Free the old array
+    deallocate();
+  }
+
+  // Allocation was successful.  Save it.
+  m_Size = newSize;
+  m_Array = newArray;
+
+  // This object has now allocated its memory and owns it.
+  m_OwnsData = true;
+
+  m_MaxId = newSize - 1;
+  m_IsAllocated = true;
+
+  // Initialize the new tuples if newSize is larger than old size
+  if(newSize > oldSize)
+  {
+    initializeWithValue(m_InitValue, oldSize);
+  }
+
+  return m_Array;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+
+template class DataArray<bool>;
+
+template class DataArray<char>;
+
+template class DataArray<int8_t>;
+template class DataArray<uint8_t>;
+
+template class DataArray<int16_t>;
+template class DataArray<uint16_t>;
+
+template class DataArray<int32_t>;
+template class DataArray<uint32_t>;
+
+template class DataArray<int64_t>;
+template class DataArray<uint64_t>;
+
+template class DataArray<float>;
+template class DataArray<double>;
+
+template class DataArray<size_t>;

--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -1298,8 +1298,24 @@ QString DataArray<T>::getInfoString(SIMPL::InfoStringFormat format) const
     ss << "</tbody></table>\n";
     ss << "</body></html>";
   }
-  else
+  else if(format == SIMPL::MarkDown)
   {
+    ss << "+ Name: " << getName() << "\n";
+    ss << "+ Type: " << getTypeAsString() << "\n";
+    ss << "+ Num. Tuple: " << getNumberOfTuples() << "\n";
+    QString compDimStr = "(";
+    for(size_t i = 0; i < m_CompDims.size(); i++)
+    {
+      compDimStr = compDimStr + QString::number(m_CompDims[i]);
+      if(i < m_CompDims.size() - 1)
+      {
+        compDimStr = compDimStr + QString(", ");
+      }
+    }
+    compDimStr = compDimStr + ")";
+    ss << "+ Comp. Dims: " << compDimStr << "\n";
+    ss << "+ Total Elements:  " << m_Size << "\n";
+    ss << "+ Total Memory: " << (m_Size * sizeof(T)) << "\n";
   }
   return info;
 }

--- a/Source/SIMPLib/DataArrays/DataArray.hpp
+++ b/Source/SIMPLib/DataArrays/DataArray.hpp
@@ -35,27 +35,20 @@
 
 #pragma once
 
+#include <hdf5.h>
+
 // STL Includes
 #include <cassert>
-#include <cstring>
-#include <functional>
-#include <iostream>
-#include <numeric>
-#include <string>
 #include <vector>
+#include <iterator>
+#include <memory>
 
+#include <QtCore/QString>
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/SIMPLib.h"
-
+#include "SIMPLib/Common/Constants.h"
 #include "SIMPLib/DataArrays/IDataArray.h"
-#include "SIMPLib/HDF5/H5DataArrayReader.h"
-#include "SIMPLib/HDF5/H5DataArrayWriter.hpp"
-
-#define mxa_bswap(s, d, t)                                                                                                                                                                             \
-  t[0] = ptr[s];                                                                                                                                                                                       \
-  ptr[s] = ptr[d];                                                                                                                                                                                     \
-  ptr[d] = t[0];
 
 /**
  * @class DataArray
@@ -71,34 +64,23 @@ public:
   using ConstPointer = std::shared_ptr<const Self>;
   using WeakPointer = std::weak_ptr<Self>;
   using ConstWeakPointer = std::weak_ptr<const Self>;
-  static Pointer NullPointer()
-  {
-    return Pointer(static_cast<Self*>(nullptr));
-  }
+
+  static Pointer NullPointer();
 
   /**
    * @brief Returns the name of the class for AbstractMessage
    */
-  QString getNameOfClass() const override
-  {
-    return QString("DataArray<T>");
-  }
+  QString getNameOfClass() const override;
   /**
    * @brief Returns the name of the class for AbstractMessage
    */
-  static QString ClassName()
-  {
-    return QString("DataArray<T>");
-  }
+  static QString ClassName();
 
   /**
    * @brief Returns the version of this class.
    * @return
    */
-  int32_t getClassVersion() const override
-  {
-    return 2;
-  }
+  int32_t getClassVersion() const override;
 
   DataArray(const DataArray&) = default;           // Copy Constructor default Implemented
   DataArray(DataArray&&) = delete;                 // Move Constructor Not Implemented
@@ -118,7 +100,7 @@ public:
   using ContainterType = std::vector<Pointer>;
 
   //========================================= Constructing DataArray Objects =================================
-  DataArray() = default;
+  DataArray();
 
   /**
    * @brief Constructor
@@ -126,13 +108,7 @@ public:
    * @param name The name of the DataArray
    * @param initValue The value to use when initializing each element of the array
    */
-  DataArray(size_t numTuples, const QString& name, T initValue)
-  : IDataArray(name)
-  , m_InitValue(initValue)
-  {
-    resizeTuples(numTuples);
-  }
-
+  DataArray(size_t numTuples, const QString& name, T initValue);
   /**
    * @brief DataArray
    * @param numTuples The number of Tuples in the DataArray
@@ -142,15 +118,7 @@ public:
    *
    * For example if you have a 2D image dimensions of 80(w) x 60(h) then the "cdims" would be [80][60]
    */
-  DataArray(size_t numTuples, const QString& name, comp_dims_type compDims, T initValue)
-  : IDataArray(name)
-  , m_NumTuples(numTuples)
-  , m_CompDims(std::move(compDims))
-  {
-    m_NumComponents = std::accumulate(m_CompDims.begin(), m_CompDims.end(), static_cast<size_t>(1), std::multiplies<>());
-    m_InitValue = initValue;
-    m_Array = resizeAndExtend(m_NumTuples * m_NumComponents);
-  }
+  DataArray(size_t numTuples, const QString& name, comp_dims_type compDims, T initValue);
 
   /**
    * @brief Protected Constructor
@@ -160,31 +128,9 @@ public:
    * @param initValue The value to use when initializing each element of the array
    * @param allocate Will all the memory be allocated at time of construction
    */
-  DataArray(size_t numTuples, const QString& name, comp_dims_type compDims, T initValue, bool allocate)
-  : IDataArray(name)
-  , m_NumTuples(numTuples)
-  , m_CompDims(std::move(compDims))
-  {
-    m_NumComponents = std::accumulate(m_CompDims.begin(), m_CompDims.end(), static_cast<size_t>(1), std::multiplies<>());
-    m_InitValue = initValue;
-    if(allocate)
-    {
-      resizeTuples(numTuples);
-    }
-    else
-    {
-      m_Size = m_NumTuples * m_NumComponents;
-      m_MaxId = (m_Size > 0) ? m_Size - 1 : m_Size;
-    }
-#if 0
-      MUD_FLAP_0 = MUD_FLAP_1 = MUD_FLAP_2 = MUD_FLAP_3 = MUD_FLAP_4 = MUD_FLAP_5 = 0xABABABABABABABABul;
-#endif
-  }
+  DataArray(size_t numTuples, const QString& name, comp_dims_type compDims, T initValue, bool allocate);
 
-  ~DataArray() override
-  {
-    clear();
-  }
+  ~DataArray() override;
 
   //========================================= Static Constructing DataArray Objects =================================
   /**
@@ -194,26 +140,7 @@ public:
    * @param allocate Will all the memory be allocated at time of construction
    * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
    */
-  static Pointer CreateArray(size_t numTuples, const QString& name, bool allocate)
-  {
-    if(name.isEmpty())
-    {
-      return NullPointer();
-    }
-    comp_dims_type cDims = {1};
-    auto d = new DataArray<T>(numTuples, name, cDims, static_cast<T>(0), allocate);
-    if(allocate)
-    {
-      if(d->allocate() < 0)
-      {
-        // Could not allocate enough memory, reset the pointer to null and return
-        delete d;
-        return DataArray<T>::NullPointer();
-      }
-    }
-    Pointer ptr(d);
-    return ptr;
-  }
+  static Pointer CreateArray(size_t numTuples, const QString& name, bool allocate);
 
   /**
    * @brief Static constructor
@@ -224,30 +151,7 @@ public:
    * @param allocate Will all the memory be allocated at time of construction
    * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
    */
-  static Pointer CreateArray(size_t numTuples, int rank, const size_t* dims, const QString& name, bool allocate)
-  {
-    if(name.isEmpty())
-    {
-      return NullPointer();
-    }
-    comp_dims_type cDims(rank);
-    for(int i = 0; i < rank; i++)
-    {
-      cDims[i] = dims[i];
-    }
-    auto d = new DataArray<T>(numTuples, name, cDims, static_cast<T>(0), allocate);
-    if(allocate)
-    {
-      if(d->allocate() < 0)
-      {
-        // Could not allocate enough memory, reset the pointer to null and return
-        delete d;
-        return DataArray<T>::NullPointer();
-      }
-    }
-    Pointer ptr(d);
-    return ptr;
-  }
+  static Pointer CreateArray(size_t numTuples, int rank, const size_t* dims, const QString& name, bool allocate);
 
   /**
    * @brief Static constructor
@@ -257,25 +161,7 @@ public:
    * @param allocate Will all the memory be allocated at time of construction
    * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
    */
-  static Pointer CreateArray(size_t numTuples, const comp_dims_type& compDims, const QString& name, bool allocate)
-  {
-    if(name.isEmpty())
-    {
-      return NullPointer();
-    }
-    DataArray<T>* d = new DataArray<T>(numTuples, name, compDims, static_cast<T>(0), allocate);
-    if(allocate)
-    {
-      if(d->allocate() < 0)
-      {
-        // Could not allocate enough memory, reset the pointer to null and return
-        delete d;
-        return DataArray<T>::NullPointer();
-      }
-    }
-    Pointer ptr(d);
-    return ptr;
-  }
+  static Pointer CreateArray(size_t numTuples, const comp_dims_type& compDims, const QString& name, bool allocate);
 
   /**
    * @brief Static constructor
@@ -286,28 +172,7 @@ public:
    * @param allocate Will all the memory be allocated at time of construction
    * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
    */
-  static Pointer CreateArray(const comp_dims_type& tupleDims, const comp_dims_type& compDims, const QString& name, bool allocate)
-  {
-    if(name.isEmpty())
-    {
-      return NullPointer();
-    }
-
-    size_t numTuples = std::accumulate(tupleDims.begin(), tupleDims.end(), static_cast<size_t>(1), std::multiplies<>());
-
-    auto d = new DataArray<T>(numTuples, name, compDims, static_cast<T>(0), allocate);
-    if(allocate)
-    {
-      if(d->allocate() < 0)
-      {
-        // Could not allocate enough memory, reset the pointer to null and return
-        delete d;
-        return DataArray<T>::NullPointer();
-      }
-    }
-    Pointer ptr(d);
-    return ptr;
-  }
+  static Pointer CreateArray(const comp_dims_type& tupleDims, const comp_dims_type& compDims, const QString& name, bool allocate);
 
   //========================================= Instance Constructing DataArray Objects =================================
   /**
@@ -319,11 +184,7 @@ public:
    * @param allocate Will all the memory be allocated at time of construction
    * @return
    */
-  IDataArray::Pointer createNewArray(size_t numTuples, int rank, const size_t* compDims, const QString& name, bool allocate) const override
-  {
-    IDataArray::Pointer p = DataArray<T>::CreateArray(numTuples, rank, compDims, name, allocate);
-    return p;
-  }
+  IDataArray::Pointer createNewArray(size_t numTuples, int rank, const size_t* compDims, const QString& name, bool allocate) const override;
 
   /**
    * @brief createNewArray
@@ -333,11 +194,7 @@ public:
    * @param allocate Will all the memory be allocated at time of construction
    * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
    */
-  IDataArray::Pointer createNewArray(size_t numTuples, const comp_dims_type& compDims, const QString& name, bool allocate) const override
-  {
-    IDataArray::Pointer p = DataArray<T>::CreateArray(numTuples, compDims, name, allocate);
-    return p;
-  }
+  IDataArray::Pointer createNewArray(size_t numTuples, const comp_dims_type& compDims, const QString& name, bool allocate) const override;
 
   /**
    * @brief Static Method to create a DataArray from a QVector through a deep copy of the data
@@ -346,16 +203,7 @@ public:
    * @param name The name of the array
    * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
    */
-  static Pointer FromQVector(QVector<T>& vec, const QString& name)
-  {
-
-    Pointer p = CreateArray(vec.size(), name, true);
-    if(nullptr != p.get())
-    {
-      std::memcpy(p->getPointer(0), vec.data(), vec.size() * sizeof(T));
-    }
-    return p;
-  }
+  static Pointer FromQVector(QVector<T>& vec, const QString& name);
 
   /**
    * @brief Static Method to create a DataArray from a std::vector through a deep copy of the data
@@ -364,16 +212,7 @@ public:
    * @param name The name of the array
    * @return Std::Shared_Ptr wrapping an instance of DataArrayTemplate<T>
    */
-  static Pointer FromStdVector(std::vector<T>& vec, const QString& name)
-  {
-    comp_dims_type cDims = {1};
-    Pointer p = CreateArray(vec.size(), cDims, name, true);
-    if(nullptr != p.get())
-    {
-      std::memcpy(p->getPointer(0), &(vec.front()), vec.size() * sizeof(T));
-    }
-    return p;
-  }
+  static Pointer FromStdVector(std::vector<T>& vec, const QString& name);
 
   /**
    * @brief FromPointer Creates a DataArray<T> object with a <b>DEEP COPY</b> of the data
@@ -382,15 +221,7 @@ public:
    * @param name
    * @return
    */
-  static Pointer CopyFromPointer(T* data, size_t size, const QString& name)
-  {
-    Pointer p = CreateArray(size, name, true);
-    if(nullptr != p.get())
-    {
-      std::memcpy(p->getPointer(0), data, size * sizeof(T));
-    }
-    return p;
-  }
+  static Pointer CopyFromPointer(T* data, size_t size, const QString& name);
 
   /**
    * @brief WrapPointer Creates a DataArray<T> object that references the pointer. The original caller can
@@ -403,22 +234,7 @@ public:
    * @param ownsData
    * @return
    */
-  static Pointer WrapPointer(T* data, size_t numTuples, const comp_dims_type& compDims, const QString& name, bool ownsData)
-  {
-    // Allocate on the heap
-    auto d = new DataArray(numTuples, name, compDims, static_cast<T>(0), false);
-    // Wrap that heap pointer with a shared_pointer to make it reference counted
-    Pointer p(d);
-
-    p->m_Array = data;        // Now set the internal array to the raw pointer
-    p->m_OwnsData = ownsData; // Set who owns the data, i.e., who is going to "free" the memory
-    if(nullptr != data)
-    {
-      p->m_IsAllocated = true;
-    }
-
-    return p;
-  }
+  static Pointer WrapPointer(T* data, size_t numTuples, const comp_dims_type& compDims, const QString& name, bool ownsData);
 
   //========================================= Begin API =================================
 
@@ -427,23 +243,7 @@ public:
    * @param forceNoAllocate
    * @return
    */
-  IDataArray::Pointer deepCopy(bool forceNoAllocate = false) const override
-  {
-    bool allocate = m_IsAllocated;
-    if(forceNoAllocate)
-    {
-      allocate = false;
-    }
-    IDataArray::Pointer daCopy = createNewArray(getNumberOfTuples(), getComponentDimensions(), getName(), allocate);
-    if(m_IsAllocated && !forceNoAllocate)
-    {
-      T* src = getPointer(0);
-      void* dest = daCopy->getVoidPointer(0);
-      size_t totalBytes = (getNumberOfTuples() * getNumberOfComponents() * sizeof(T));
-      std::memcpy(dest, src, totalBytes);
-    }
-    return daCopy;
-  }
+  IDataArray::Pointer deepCopy(bool forceNoAllocate = false) const override;
 
   /**
    * @brief GetTypeName Returns a string representation of the type of data that is stored by this class. This
@@ -451,133 +251,14 @@ public:
    * @return
    */
 
-  SIMPL::NumericTypes::Type getType() const
-  {
-    T value = static_cast<T>(0x00);
-    if(typeid(value) == typeid(int8_t))
-    {
-      return SIMPL::NumericTypes::Type::Int8;
-    }
-    if(typeid(value) == typeid(uint8_t))
-    {
-      return SIMPL::NumericTypes::Type::UInt8;
-    }
-
-    if(typeid(value) == typeid(int16_t))
-    {
-      return SIMPL::NumericTypes::Type::Int16;
-    }
-    if(typeid(value) == typeid(uint16_t))
-    {
-      return SIMPL::NumericTypes::Type::UInt16;
-    }
-
-    if(typeid(value) == typeid(int32_t))
-    {
-      return SIMPL::NumericTypes::Type::Int32;
-    }
-    if(typeid(value) == typeid(uint32_t))
-    {
-      return SIMPL::NumericTypes::Type::UInt32;
-    }
-
-    if(typeid(value) == typeid(int64_t))
-    {
-      return SIMPL::NumericTypes::Type::Int64;
-    }
-    if(typeid(value) == typeid(uint64_t))
-    {
-      return SIMPL::NumericTypes::Type::UInt64;
-    }
-
-    if(typeid(value) == typeid(float))
-    {
-      return SIMPL::NumericTypes::Type::Float;
-    }
-    if(typeid(value) == typeid(double))
-    {
-      return SIMPL::NumericTypes::Type::Double;
-    }
-
-    if(typeid(value) == typeid(bool))
-    {
-      return SIMPL::NumericTypes::Type::Bool;
-    }
-
-    return SIMPL::NumericTypes::Type::UnknownNumType;
-  }
+  SIMPL::NumericTypes::Type getType() const;
 
   /**
    * @brief GetTypeName Returns a string representation of the type of data that is stored by this class. This
    * can be a primitive like char, float, int or the name of a class.
    * @return
    */
-  void getXdmfTypeAndSize(QString& xdmfTypeName, int& precision) const override
-  {
-    T value = static_cast<T>(0x00);
-    xdmfTypeName = "UNKNOWN";
-    precision = 0;
-    if(typeid(value) == typeid(int8_t))
-    {
-      xdmfTypeName = "Char";
-      precision = 1;
-    }
-    if(typeid(value) == typeid(uint8_t))
-    {
-      xdmfTypeName = "UChar";
-      precision = 1;
-    }
-
-    if(typeid(value) == typeid(int16_t))
-    {
-      xdmfTypeName = "Int";
-      precision = 2;
-    }
-    if(typeid(value) == typeid(uint16_t))
-    {
-      xdmfTypeName = "UInt";
-      precision = 2;
-    }
-
-    if(typeid(value) == typeid(int32_t))
-    {
-      xdmfTypeName = "Int";
-      precision = 4;
-    }
-    if(typeid(value) == typeid(uint32_t))
-    {
-      xdmfTypeName = "UInt";
-      precision = 4;
-    }
-
-    if(typeid(value) == typeid(int64_t))
-    {
-      xdmfTypeName = "Int";
-      precision = 8;
-    }
-    if(typeid(value) == typeid(uint64_t))
-    {
-      xdmfTypeName = "UInt";
-      precision = 8;
-    }
-
-    if(typeid(value) == typeid(float))
-    {
-      xdmfTypeName = "Float";
-      precision = 4;
-    }
-    if(typeid(value) == typeid(double))
-    {
-      xdmfTypeName = "Float";
-      precision = 8;
-    }
-
-    if(typeid(value) == typeid(bool))
-    {
-      xdmfTypeName = "uchar";
-      precision = 1;
-    }
-  }
+  void getXdmfTypeAndSize(QString& xdmfTypeName, int& precision) const override;
   // This line must be here, because we are overloading the copyData pure virtual function in IDataArray.
   // This is required so that other classes can call this version of copyData from the subclasses.
   using IDataArray::copyFromArray;
@@ -601,161 +282,52 @@ public:
    * @param sourceArray
    * @return
    */
-  bool copyFromArray(size_t destTupleOffset, IDataArray::Pointer sourceArray, size_t srcTupleOffset, size_t totalSrcTuples) override
-  {
-    if(!m_IsAllocated)
-    {
-      return false;
-    }
-    if(nullptr == m_Array)
-    {
-      return false;
-    }
-    if(destTupleOffset > m_MaxId)
-    {
-      return false;
-    }
-    if(!sourceArray->isAllocated())
-    {
-      return false;
-    }
-    Self* source = dynamic_cast<Self*>(sourceArray.get());
-    if(nullptr == source->getPointer(0))
-    {
-      return false;
-    }
-
-    if(sourceArray->getNumberOfComponents() != getNumberOfComponents())
-    {
-      return false;
-    }
-
-    if(srcTupleOffset + totalSrcTuples > sourceArray->getNumberOfTuples())
-    {
-      return false;
-    }
-
-    if(totalSrcTuples * sourceArray->getNumberOfComponents() + destTupleOffset * getNumberOfComponents() > m_Size)
-    {
-      return false;
-    }
-
-    size_t elementStart = destTupleOffset * getNumberOfComponents();
-    size_t totalBytes = (totalSrcTuples * sourceArray->getNumberOfComponents()) * sizeof(T);
-    std::memcpy(m_Array + elementStart, source->getPointer(srcTupleOffset * sourceArray->getNumberOfComponents()), totalBytes);
-    return true;
-  }
+  bool copyFromArray(size_t destTupleOffset, IDataArray::Pointer sourceArray, size_t srcTupleOffset, size_t totalSrcTuples) override;
 
   /**
    * @brief copyIntoArray
    * @param dest
    */
-  bool copyIntoArray(Pointer dest) const
-  {
-    if(m_IsAllocated && dest->isAllocated() && m_Array && dest->getPointer(0))
-    {
-      size_t totalBytes = m_Size * sizeof(T);
-      std::memcpy(dest->getPointer(0), m_Array, totalBytes);
-      return true;
-    }
-    return false;
-  }
+  bool copyIntoArray(Pointer dest) const;
 
   /**
    * @brief isAllocated
    * @return
    */
-  bool isAllocated() const override
-  {
-    return m_IsAllocated;
-  }
-
+  bool isAllocated() const override;
   /**
    * @brief Gives this array a human readable name
    * @param name The name of this array
    */
-  virtual void setInitValue(T initValue)
-  {
-    m_InitValue = initValue;
-  }
+  virtual void setInitValue(T initValue);
 
   /**
    * @brief Makes this class responsible for freeing the memory
    */
-  void takeOwnership() override
-  {
-    m_OwnsData = true;
-  }
+  void takeOwnership() override;
 
   /**
    * @brief This class will NOT free the memory associated with the internal pointer.
    * This can be useful if the user wishes to keep the data around after this
    * class goes out of scope.
    */
-  void releaseOwnership() override
-  {
-    m_OwnsData = false;
-  }
+  void releaseOwnership() override;
 
   /**
    * @brief Allocates the memory needed for this class
    * @return 1 on success, -1 on failure
    */
-  virtual int32_t allocate()
-  {
-    if((nullptr != m_Array) && (true == m_OwnsData))
-    {
-      deallocate();
-    }
-    m_Array = nullptr;
-    m_OwnsData = true;
-    m_IsAllocated = false;
-    if(m_Size == 0)
-    {
-      clear();
-      return 1;
-    }
-
-    size_t newSize = m_Size;
-    m_Array = new T[newSize]();
-    if(!m_Array)
-    {
-      qDebug() << "Unable to allocate " << newSize << " elements of size " << sizeof(T) << " bytes. ";
-      return -1;
-    }
-    m_Size = newSize;
-    m_IsAllocated = true;
-
-    return 1;
-  }
+  virtual int32_t allocate();
 
   /**
    * @brief Sets all the values to zero.
    */
-  void initializeWithZeros() override
-  {
-    if(!m_IsAllocated || nullptr == m_Array)
-    {
-      return;
-    }
-    size_t typeSize = sizeof(T);
-    ::memset(m_Array, 0, m_Size * typeSize);
-  }
+  void initializeWithZeros() override;
 
   /**
    * @brief Sets all the values to value.
    */
-  virtual void initializeWithValue(T initValue, size_t offset = 0)
-  {
-    if(!m_IsAllocated || nullptr == m_Array)
-    {
-      return;
-    }
-    for(size_t i = offset; i < m_Size; i++)
-    {
-      m_Array[i] = initValue;
-    }
-  }
+  virtual void initializeWithValue(T initValue, size_t offset = 0);
 
   /**
    * @brief Removes Tuples from the m_Array. If the size of the vector is Zero nothing is done. If the size of the
@@ -765,116 +337,7 @@ public:
    * @param idxs The indices to remove
    * @return error code.
    */
-  int eraseTuples(comp_dims_type& idxs) override
-  {
-    int err = 0;
-
-    // If nothing is to be erased just return
-    if(idxs.empty())
-    {
-      return 0;
-    }
-    auto idxs_size = static_cast<size_t>(idxs.size());
-    if(idxs_size >= getNumberOfTuples())
-    {
-      resizeTuples(0);
-      return 0;
-    }
-
-    // Sanity Check the Indices in the vector to make sure we are not trying to remove any indices that are
-    // off the end of the array and return an error code.
-    for(size_t& idx : idxs)
-    {
-      if(idx * m_NumComponents > m_MaxId)
-      {
-        return -100;
-      }
-    }
-
-    // Calculate the new size of the array to copy into
-    size_t newSize = (getNumberOfTuples() - idxs.size()) * m_NumComponents;
-
-    // Create a new m_Array to copy into
-    T* newArray = new T[newSize]();
-
-    // Splat AB across the array so we know if we are copying the values or not
-    ::memset(newArray, 0xAB, newSize * sizeof(T));
-
-    // Keep the current Destination Pointer
-    T* currentDest = newArray;
-    size_t j = 0;
-    int k = 0;
-    // Find the first chunk to copy by walking the idxs array until we get an
-    // index that is NOT a continuous increment from the start
-    for(k = 0; k < idxs.size(); ++k)
-    {
-      if(j == idxs[k])
-      {
-        ++j;
-      }
-      else
-      {
-        break;
-      }
-    }
-
-    if(k == idxs.size()) // Only front elements are being dropped
-    {
-      T* currentSrc = m_Array + (j * m_NumComponents);
-      std::memcpy(currentDest, currentSrc, (getNumberOfTuples() - idxs.size()) * m_NumComponents * sizeof(T));
-      deallocate(); // We are done copying - delete the current m_Array
-      m_Size = newSize;
-      m_Array = newArray;
-      m_OwnsData = true;
-      m_MaxId = newSize - 1;
-      m_IsAllocated = true;
-      return 0;
-    }
-
-    comp_dims_type srcIdx(idxs.size() + 1);
-    comp_dims_type destIdx(idxs.size() + 1);
-    comp_dims_type copyElements(idxs.size() + 1);
-    srcIdx[0] = 0;
-    destIdx[0] = 0;
-    copyElements[0] = (idxs[0] - 0) * m_NumComponents;
-
-    for(int i = 1; i < srcIdx.size(); ++i)
-    {
-      srcIdx[i] = (idxs[i - 1] + 1) * m_NumComponents;
-
-      if(i < srcIdx.size() - 1)
-      {
-        copyElements[i] = (idxs[i] - idxs[i - 1] - 1) * m_NumComponents;
-      }
-      else
-      {
-        copyElements[i] = (getNumberOfTuples() - idxs[i - 1] - 1) * m_NumComponents;
-      }
-      destIdx[i] = copyElements[i - 1] + destIdx[i - 1];
-    }
-
-    // Copy the data
-    for(int i = 0; i < srcIdx.size(); ++i)
-    {
-      currentDest = newArray + destIdx[i];
-      T* currentSrc = m_Array + srcIdx[i];
-      size_t bytes = copyElements[i] * sizeof(T);
-      std::memcpy(currentDest, currentSrc, bytes);
-    }
-
-    // We are done copying - delete the current m_Array
-    deallocate();
-
-    // Allocation was successful.  Save it.
-    m_Size = newSize;
-    m_Array = newArray;
-    // This object has now allocated its memory and owns it.
-    m_OwnsData = true;
-    m_IsAllocated = true;
-    m_MaxId = newSize - 1;
-
-    return err;
-  }
+  int eraseTuples(comp_dims_type& idxs) override;
 
   /**
    * @brief
@@ -882,19 +345,7 @@ public:
    * @param newPos
    * @return
    */
-  int copyTuple(size_t currentPos, size_t newPos) override
-  {
-    size_t max = ((m_MaxId + 1) / m_NumComponents);
-    if(currentPos >= max || newPos >= max)
-    {
-      return -1;
-    }
-    T* src = m_Array + (currentPos * m_NumComponents);
-    T* dest = m_Array + (newPos * m_NumComponents);
-    size_t bytes = sizeof(T) * m_NumComponents;
-    std::memcpy(dest, src, bytes);
-    return 0;
-  }
+  int copyTuple(size_t currentPos, size_t newPos) override;
 
   /**
    * @brief Returns the number of bytes that make up the data type.
@@ -903,46 +354,31 @@ public:
    * 4 = 32 bit integer/Float
    * 8 = 64 bit integer/Double
    */
-  size_t getTypeSize() const override
-  {
-    return sizeof(T);
-  }
+  size_t getTypeSize() const override;
 
   /**
    * @brief Returns the number of elements in the internal array.
    */
-  size_t getNumberOfTuples() const override
-  {
-    return m_NumTuples;
-  }
+  size_t getNumberOfTuples() const override;
 
   /**
    * @brief Returns the total number of elements that make up this array. Equal to NumTuples * NumComponents
    */
-  size_t getSize() const override
-  {
-    return m_Size;
-  }
+  size_t getSize() const override;
 
   /**
    * @brief Returns the dimensions for the data residing at each Tuple. For example if you have a simple Scalar value
    * at each tuple then this will return a single element QVector. If you have a 1x3 array (like EUler Angles) then
    * this will return a 3 Element QVector.
    */
-  comp_dims_type getComponentDimensions() const override
-  {
-    return m_CompDims;
-  }
+  comp_dims_type getComponentDimensions() const override;
 
   /**
    * @brief Returns the number component values at each Tuple location. For example if you have a
    * 3 element component (vector) then this will be 3. If you are storing a small image of size 80x60
    * at each Tuple (like EBSD Kikuchi patterns) then the result would be 4800.
    */
-  int getNumberOfComponents() const override
-  {
-    return m_NumComponents;
-  }
+  int getNumberOfComponents() const override;
 
   /**
    * @brief Returns a void pointer pointing to the index of the array. nullptr
@@ -951,41 +387,19 @@ public:
    * @param i The index to have the returned pointer pointing to.
    * @return Void Pointer. Possibly nullptr.
    */
-  void* getVoidPointer(size_t i) override
-  {
-    if(i >= m_Size)
-    {
-      return nullptr;
-    }
-
-    return (void*)(&(m_Array[i]));
-  }
+  void* getVoidPointer(size_t i) override;
 
   /**
    * @brief Returns a list of the contents of DataArray (For Python Binding)
    * @return std::list. Possibly empty
    */
-  std::list<T> getArray() const
-  {
-    return std::list<T>(m_Array, m_Array + (m_Size * sizeof(T)) / sizeof(T));
-  }
+  std::list<T> getArray() const;
 
   /**
    * @brief Sets the contents of the array to the list (For Python Binding)
    * @param std::list. New array contents
    */
-  void setArray(std::list<T> newArray)
-  {
-    if(newArray.size() != m_Size)
-    {
-      return;
-    }
-    int i = 0;
-    for(auto elem : newArray)
-    {
-      m_Array[i++] = elem;
-    }
-  }
+  void setArray(std::list<T> newArray);
 
   /**
    * @brief Returns the pointer to a specific index into the array. No checks are made
@@ -994,61 +408,25 @@ public:
    * @param i The index to return the pointer to.
    * @return The pointer to the index
    */
-  virtual T* getPointer(size_t i) const
-  {
-#ifndef NDEBUG
-    if(m_Size > 0)
-    {
-      Q_ASSERT(i < m_Size);
-    }
-#endif
-    return (T*)(&(m_Array[i]));
-  }
+  virtual T* getPointer(size_t i) const;
 
   /**
    * @brief Returns the value for a given index
    * @param i The index to return the value at
    * @return The value at index i
    */
-  virtual T getValue(size_t i) const
-  {
-#ifndef NDEBUG
-    if(m_Size > 0)
-    {
-      Q_ASSERT(i < m_Size);
-    }
-#endif
-    return m_Array[i];
-  }
+  virtual T getValue(size_t i) const;
 
   /**
    * @brief Sets a specific value in the array
    * @param i The index of the value to set
    * @param value The new value to be set at the specified index
    */
-  void setValue(size_t i, T value)
-  {
-#ifndef NDEBUG
-    if(m_Size > 0)
-    {
-      Q_ASSERT(i < m_Size);
-    }
-#endif
-    m_Array[i] = value;
-  }
+  void setValue(size_t i, T value);
 
   //----------------------------------------------------------------------------
   // These can be overridden for more efficiency
-  T getComponent(size_t i, int j) const
-  {
-#ifndef NDEBUG
-    if(m_Size > 0)
-    {
-      Q_ASSERT(i * m_NumComponents + j < m_Size);
-    }
-#endif
-    return m_Array[i * m_NumComponents + j];
-  }
+  T getComponent(size_t i, int j) const;
 
   /**
    * @brief Sets a specific component of the Tuple located at i
@@ -1056,105 +434,41 @@ public:
    * @param j The Component index into the Tuple
    * @param c The value to set
    */
-  void setComponent(size_t i, int j, T c)
-  {
-#ifndef NDEBUG
-    if(m_Size > 0)
-    {
-      Q_ASSERT(i * m_NumComponents + j < m_Size);
-    }
-#endif
-    m_Array[i * m_NumComponents + j] = c;
-  }
+  void setComponent(size_t i, int j, T c);
 
   /**
    * @brief setTuple
    * @param tupleIndex
    * @param data
    */
-  void setTuple(size_t tupleIndex, T* data)
-  {
-#ifndef NDEBUG
-    if(m_Size > 0)
-    {
-      Q_ASSERT(tupleIndex * m_NumComponents + (m_NumComponents - 1) < m_Size);
-    }
-#endif
-    std::memcpy(getTuplePointer(tupleIndex), data, m_NumComponents * sizeof(T));
-  }
+  void setTuple(size_t tupleIndex, T* data);
 
   /**
    * @brief setTuple
    * @param tupleIndex
    * @param data
    */
-  void setTuple(size_t tupleIndex, const std::vector<T>& data)
-  {
-#ifndef NDEBUG
-    if(m_Size > 0)
-    {
-      Q_ASSERT(tupleIndex * m_NumComponents + (m_NumComponents - 1) < m_Size);
-    }
-#endif
-    std::memcpy(getTuplePointer(tupleIndex), data.data(), m_NumComponents * sizeof(T));
-  }
+  void setTuple(size_t tupleIndex, const std::vector<T>& data);
 
   /**
    * @brief Splats the same value c across all values in the Tuple
    * @param i The index of the Tuple
    * @param c The value to splat across all components in the tuple
    */
-  void initializeTuple(size_t i, void* p) override
-  {
-    if(!m_IsAllocated)
-    {
-      return;
-    }
-#ifndef NDEBUG
-    if(m_Size > 0)
-    {
-      Q_ASSERT(i * m_NumComponents < m_Size);
-    }
-#endif
-    if(nullptr == p)
-    {
-      return;
-    }
-    T* c = reinterpret_cast<T*>(p);
-    for(size_t j = 0; j < m_NumComponents; ++j)
-    {
-      m_Array[i * m_NumComponents + j] = *c;
-    }
-  }
+  void initializeTuple(size_t i, void* p) override;
 
   /**
    * @brief getTuplePointer Returns the pointer to a specific tuple
    * @param tupleIndex The index of tuple
    */
-  T* getTuplePointer(size_t tupleIndex) const
-  {
-#ifndef NDEBUG
-    if(m_Size > 0)
-    {
-      Q_ASSERT(tupleIndex * m_NumComponents < m_Size);
-    }
-#endif
-    return m_Array + (tupleIndex * m_NumComponents);
-  }
+  T* getTuplePointer(size_t tupleIndex) const;
 
   /**
    * @brief resize
    * @param numTuples
    * @return
    */
-  void resizeTuples(size_t numTuples) override
-  {
-    T* ptr = resizeAndExtend(numTuples * m_NumComponents);
-    if(nullptr != ptr)
-    {
-      m_NumTuples = numTuples;
-    }
-  }
+  void resizeTuples(size_t numTuples) override;
 
   /**
    * @brief printTuple
@@ -1162,29 +476,7 @@ public:
    * @param i
    * @param delimiter
    */
-  void printTuple(QTextStream& out, size_t i, char delimiter = ',') const override
-  {
-    int precision = out.realNumberPrecision();
-    T value = static_cast<T>(0x00);
-    if(typeid(value) == typeid(float))
-    {
-      out.setRealNumberPrecision(8);
-    }
-    if(typeid(value) == typeid(double))
-    {
-      out.setRealNumberPrecision(16);
-    }
-
-    for(size_t j = 0; j < m_NumComponents; ++j)
-    {
-      if(j != 0)
-      {
-        out << delimiter;
-      }
-      out << m_Array[i * m_NumComponents + j];
-    }
-    out.setRealNumberPrecision(precision);
-  }
+  void printTuple(QTextStream& out, size_t i, char delimiter = ',') const override;
 
   /**
    * @brief printComponent
@@ -1192,10 +484,7 @@ public:
    * @param i
    * @param j
    */
-  void printComponent(QTextStream& out, size_t i, int j) const override
-  {
-    out << m_Array[i * m_NumComponents + j];
-  }
+  void printComponent(QTextStream& out, size_t i, int j) const override;
 
   /**
    * @brief Returns the HDF Type for a given primitive value.
@@ -1203,180 +492,20 @@ public:
    * from
    * @return The HDF5 native type for the value
    */
-  QString getFullNameOfClass() const
-  {
-    QString theType = getTypeAsString();
-    theType = "DataArray<" + theType + ">";
-    return theType;
-  }
+  QString getFullNameOfClass() const;
 
   /**
    * @brief getTypeAsString
    * @return
    */
-  QString getTypeAsString() const override
-  {
-    T value = static_cast<T>(0);
-    if(typeid(value) == typeid(float))
-    {
-      return "float";
-    }
-    if(typeid(value) == typeid(double))
-    {
-      return "double";
-    }
-
-    if(typeid(value) == typeid(int8_t))
-    {
-      return "int8_t";
-    }
-    if(typeid(value) == typeid(uint8_t))
-    {
-      return "uint8_t";
-    }
-#if CMP_TYPE_CHAR_IS_SIGNED
-    if(typeid(value) == typeid(char))
-    {
-      return "char";
-    }
-#else
-    if(typeid(value) == typeid(char))
-    {
-      return "char";
-    }
-#endif
-    if(typeid(value) == typeid(signed char))
-    {
-      return "signed char";
-    }
-    if(typeid(value) == typeid(unsigned char))
-    {
-      return "unsigned char";
-    }
-
-    if(typeid(value) == typeid(int16_t))
-    {
-      return "int16_t";
-    }
-    if(typeid(value) == typeid(short))
-    {
-      return "short";
-    }
-    if(typeid(value) == typeid(signed short))
-    {
-      return "signed short";
-    }
-    if(typeid(value) == typeid(uint16_t))
-    {
-      return "uint16_t";
-    }
-    if(typeid(value) == typeid(unsigned short))
-    {
-      return "unsigned short";
-    }
-
-    if(typeid(value) == typeid(int32_t))
-    {
-      return "int32_t";
-    }
-    if(typeid(value) == typeid(uint32_t))
-    {
-      return "uint32_t";
-    }
-#if(CMP_SIZEOF_INT == 4)
-    if(typeid(value) == typeid(int))
-    {
-      return "int";
-    }
-    if(typeid(value) == typeid(signed int))
-    {
-      return "signed int";
-    }
-    if(typeid(value) == typeid(unsigned int))
-    {
-      return "unsigned int";
-    }
-#endif
-
-    if(typeid(value) == typeid(int64_t))
-    {
-      return "int64_t";
-    }
-    if(typeid(value) == typeid(uint64_t))
-    {
-      return "uint64_t";
-    }
-
-#if(CMP_SIZEOF_LONG == 4)
-    if(typeid(value) == typeid(long int))
-    {
-      return "long int";
-    }
-    if(typeid(value) == typeid(signed long int))
-    {
-      return "signed long int";
-    }
-    if(typeid(value) == typeid(unsigned long int))
-    {
-      return "unsigned long int";
-    }
-#elif(CMP_SIZEOF_LONG == 8)
-    if(typeid(value) == typeid(long int))
-    {
-      return "long int";
-    }
-    if(typeid(value) == typeid(signed long int))
-    {
-      return "signed long int";
-    }
-    if(typeid(value) == typeid(unsigned long int))
-    {
-      return "unsigned long int";
-    }
-#endif
-
-#if(CMP_SIZEOF_LONG_LONG == 8)
-    if(typeid(value) == typeid(long long int))
-    {
-      return "long long int";
-    }
-    if(typeid(value) == typeid(signed long long int))
-    {
-      return "signed long long int";
-    }
-    if(typeid(value) == typeid(unsigned long long int))
-    {
-      return "unsigned long long int";
-    }
-#endif
-
-    if(typeid(value) == typeid(bool))
-    {
-      return "bool";
-    }
-
-    // qDebug()  << "Error: HDFTypeForPrimitive - Unknown Type: " << (typeid(value).name()) ;
-    const char* name = typeid(value).name();
-    if(nullptr != name && name[0] == 'l')
-    {
-      qDebug() << "You are using 'long int' as a type which is not 32/64 bit safe. Suggest you use one of the H5SupportTypes defined in <Common/H5SupportTypes.h> such as int32_t or uint32_t.";
-    }
-    return "UnknownType";
-  }
+  QString getTypeAsString() const override;
 
   /**
    *
    * @param parentId
    * @return
    */
-  int writeH5Data(hid_t parentId, comp_dims_type tDims) const override
-  {
-    if(m_Array == nullptr)
-    {
-      return -85648;
-    }
-    return H5DataArrayWriter::writeDataArray<Self>(parentId, this, tDims);
-  }
+  int writeH5Data(hid_t parentId, comp_dims_type tDims) const override;
 
   /**
    * @brief writeXdmfAttribute
@@ -1384,170 +513,26 @@ public:
    * @param volDims
    * @return
    */
-  int writeXdmfAttribute(QTextStream& out, int64_t* volDims, const QString& hdfFileName, const QString& groupPath, const QString& label) const override
-  {
-    if(m_Array == nullptr)
-    {
-      return -85648;
-    }
-    QString dimStr;
-    int precision = 0;
-    QString xdmfTypeName;
-    getXdmfTypeAndSize(xdmfTypeName, precision);
-    if(0 == precision)
-    {
-      out << "<!-- " << getName() << " has unknown type or unsupported type or precision for XDMF to understand"
-          << " -->"
-          << "\n";
-      return -100;
-    }
-
-    int numComp = getNumberOfComponents();
-    out << "    <Attribute Name=\"" << getName() << label << "\" ";
-    if(numComp == 1)
-    {
-      out << "AttributeType=\"Scalar\" ";
-      dimStr = QString("%1 %2 %3 ").arg(volDims[2]).arg(volDims[1]).arg(volDims[0]);
-    }
-    else if(numComp == 6)
-    {
-      out << "AttributeType=\"Tensor6\" ";
-      dimStr = QString("%1 %2 %3 %4 ").arg(volDims[2]).arg(volDims[1]).arg(volDims[0]).arg(numComp);
-    }
-    else if(numComp == 9)
-    {
-      out << "AttributeType=\"Tensor\" ";
-      dimStr = QString("%1 %2 %3 %4 ").arg(volDims[2]).arg(volDims[1]).arg(volDims[0]).arg(numComp);
-    }
-    else
-    {
-      out << "AttributeType=\"Vector\" ";
-      dimStr = QString("%1 %2 %3 %4 ").arg(volDims[2]).arg(volDims[1]).arg(volDims[0]).arg(numComp);
-    }
-    out << "Center=\"Cell\">\n";
-    // Open the <DataItem> Tag
-    out << R"(      <DataItem Format="HDF" Dimensions=")" << dimStr << R"(" )";
-    out << "NumberType=\"" << xdmfTypeName << "\" "
-        << "Precision=\"" << precision << "\" >\n";
-
-    out << "        " << hdfFileName << groupPath << "/" << getName() << "\n";
-    out << "      </DataItem>"
-        << "\n";
-    out << "    </Attribute>"
-        << "\n";
-    return 1;
-  }
+  int writeXdmfAttribute(QTextStream& out, int64_t* volDims, const QString& hdfFileName, const QString& groupPath, const QString& label) const override;
 
   /**
    * @brief getInfoString
    * @return Returns a formatted string that contains general infomation about
    * the instance of the object.
    */
-  QString getInfoString(SIMPL::InfoStringFormat format) const override
-  {
-
-    QLocale usa(QLocale::English, QLocale::UnitedStates);
-
-    QString info;
-    QTextStream ss(&info);
-    if(format == SIMPL::HtmlFormat)
-    {
-      ss << "<html><head></head>\n";
-      ss << "<body>\n";
-      ss << "<table cellpadding=\"4\" cellspacing=\"0\" border=\"0\">\n";
-      ss << "<tbody>\n";
-      ss << "<tr bgcolor=\"#FFFCEA\"><th colspan=2>Attribute Array Info</th></tr>";
-
-      ss << R"(<tr bgcolor="#E9E7D6"><th align="right">Name:</th><td>)" << getName() << "</td></tr>";
-
-      ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Type:</th><td> DataArray&lt;)" << getTypeAsString() << "&gt;</td></tr>";
-      QString numStr = usa.toString(static_cast<qlonglong>(getNumberOfTuples()));
-      ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Number of Tuples:</th><td>)" << numStr << "</td></tr>";
-
-      QString compDimStr = "(";
-      for(int i = 0; i < m_CompDims.size(); i++)
-      {
-        compDimStr = compDimStr + QString::number(m_CompDims[i]);
-        if(i < m_CompDims.size() - 1)
-        {
-          compDimStr = compDimStr + QString(", ");
-        }
-      }
-      compDimStr = compDimStr + ")";
-      ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Component Dimensions:</th><td>)" << compDimStr << "</td></tr>";
-      numStr = usa.toString(static_cast<qlonglong>(m_Size));
-      ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Total Elements:</th><td>)" << numStr << "</td></tr>";
-      numStr = usa.toString(static_cast<qlonglong>(m_Size * sizeof(T)));
-      ss << R"(<tr bgcolor="#FFFCEA"><th align="right">Total Memory Required:</th><td>)" << numStr << "</td></tr>";
-      ss << "</tbody></table>\n";
-      ss << "</body></html>";
-    }
-    else
-    {
-    }
-    return info;
-  }
+  QString getInfoString(SIMPL::InfoStringFormat format) const override;
 
   /**
    * @brief
    * @param parentId
    * @return
    */
-  int readH5Data(hid_t parentId) override
-  {
-    int err = 0;
-
-    resizeTuples(0);
-    IDataArray::Pointer p = H5DataArrayReader::ReadIDataArray(parentId, getName());
-    if(p.get() == nullptr)
-    {
-      return -1;
-    }
-    m_Array = reinterpret_cast<T*>(p->getVoidPointer(0));
-    m_Size = p->getSize();
-    m_OwnsData = true;
-    m_MaxId = (m_Size == 0) ? 0 : m_Size - 1;
-    m_IsAllocated = true;
-    setName(p->getName());
-    m_NumTuples = p->getNumberOfTuples();
-    m_CompDims = p->getComponentDimensions();
-    m_NumComponents = p->getNumberOfComponents();
-
-    // Tell the intermediate DataArray to release ownership of the data as we are going to be responsible
-    // for deleting the memory
-    p->releaseOwnership();
-    return err;
-  }
+  int readH5Data(hid_t parentId) override;
 
   /**
    * @brief
    */
-  virtual void byteSwapElements()
-  {
-    char* ptr = (char*)(m_Array);
-    char t[8];
-    size_t size = getTypeSize();
-    for(uint64_t var = 0; var < m_Size; ++var)
-    {
-      if(sizeof(T) == 2)
-      {
-        mxa_bswap(0, 1, t);
-      }
-      else if(sizeof(T) == 4)
-      {
-        mxa_bswap(0, 3, t);
-        mxa_bswap(1, 2, t);
-      }
-      else if(sizeof(T) == 8)
-      {
-        mxa_bswap(0, 7, t);
-        mxa_bswap(1, 6, t);
-        mxa_bswap(2, 5, t);
-        mxa_bswap(3, 4, t);
-      }
-      ptr += size; // increment the pointer
-    }
-  }
+  virtual void byteSwapElements();
 
   //========================================= STL INTERFACE COMPATIBILITY =================================
 
@@ -1571,8 +556,9 @@ public:
       ptr_ = ptr_ + num_comps_;
       return *this;
     } // PREFIX
-    self_type operator++(int junk)
+    self_type operator++(int ununsed)
     {
+      std::ignore = ununsed;
       self_type i = *this;
       ptr_ = ptr_ + num_comps_;
       return i;
@@ -1623,8 +609,9 @@ public:
       ptr_ = ptr_ + num_comps_;
       return *this;
     } // PREFIX
-    self_type operator++(int junk)
+    self_type operator++(int ununsed)
     {
+      std::ignore = ununsed;
       self_type i = *this;
       ptr_ = ptr_ + num_comps_;
       return i;
@@ -1672,6 +659,7 @@ public:
     iterator(pointer ptr, size_type ununsed)
     : ptr_(ptr)
     {
+      std::ignore = ununsed;
     }
 
     self_type operator++()
@@ -1679,8 +667,9 @@ public:
       ptr_++;
       return *this;
     } // PREFIX
-    self_type operator++(int junk)
+    self_type operator++(int ununsed)
     {
+      std::ignore = ununsed;
       self_type i = *this;
       ptr_++;
       return i;
@@ -1767,34 +756,42 @@ public:
   };
 
   // ######### Iterators #########
-
+  /**
+   *
+   */
   template <typename IteratorType> IteratorType begin()
   {
     return IteratorType(m_Array, m_NumComponents);
   }
-  iterator begin()
-  {
-    return iterator(m_Array);
-  }
+
+  /**
+   * @brief begin
+   * @return
+   */
+  iterator begin();
 
   template <typename IteratorType> IteratorType end()
   {
     return IteratorType(m_Array + m_Size, m_NumComponents);
   }
-  iterator end()
-  {
-    return iterator(m_Array + m_Size);
-  }
 
-  const_iterator begin() const
-  {
-    return const_iterator(m_Array);
-  }
+  /**
+   * @brief end
+   * @return
+   */
+  iterator end();
 
-  const_iterator end() const
-  {
-    return const_iterator(m_Array + m_Size);
-  }
+  /**
+   * @brief begin
+   * @return
+   */
+  const_iterator begin() const;
+
+  /**
+   * @brief end
+   * @return
+   */
+  const_iterator end() const;
 
   // rbegin
   // rend
@@ -1805,28 +802,16 @@ public:
 
   // ######### Capacity #########
 
-  size_type size() const
-  {
-    return m_Size;
-  }
+  size_type size() const;
 
-  size_type max_size() const
-  {
-    return m_Size;
-  }
+  size_type max_size() const;
   //  void resize(size_type n) override
   //  {
   //    resizeAndExtend(n);
   //  }
   // void resize (size_type n, const value_type& val);
-  size_type capacity() const noexcept
-  {
-    return m_Size;
-  }
-  bool empty() const noexcept
-  {
-    return (m_Size == 0);
-  }
+  size_type capacity() const noexcept;
+  bool empty() const noexcept;
   // reserve()
   // shrink_to_fit()
 
@@ -1889,7 +874,8 @@ public:
    * @brief In the range version (1), the new contents are elements constructed from each of the elements in the range
    * between first and last, in the same order.
    */
-  template <class InputIterator> void assign(InputIterator first, InputIterator last) // range (1)
+  template <class InputIterator>
+  void assign(InputIterator first, InputIterator last) // range (1)
   {
     size_type size = last - first;
     resizeAndExtend(size);
@@ -1906,50 +892,29 @@ public:
    * @param n
    * @param val
    */
-  void assign(size_type n, const value_type& val) // fill (2)
-  {
-    resizeAndExtend(n);
-    for(size_t i = 0; i < n; i++)
-    {
-      m_Array[i] = val;
-    }
-  }
+  void assign(size_type n, const value_type& val);
 
   /**
    * @brief In the initializer list version (3), the new contents are copies of the values passed as initializer list, in the same order.
    * @param il
    */
-  void assign(std::initializer_list<value_type> il) //  initializer list (3)
-  {
-    assign(il.begin(), il.end());
-  }
+  void assign(std::initializer_list<value_type> il);
 
   /**
    * @brief push_back
    * @param val
    */
-  void push_back(const value_type& val)
-  {
-    resizeAndExtend(m_Size + 1);
-    m_Array[m_MaxId] = val;
-  }
+  void push_back(const value_type& val);
   /**
    * @brief push_back
    * @param val
    */
-  void push_back(value_type&& val)
-  {
-    resizeAndExtend(m_Size + 1);
-    m_Array[m_MaxId] = val;
-  }
+  void push_back(value_type&& val);
 
   /**
    * @brief pop_back
    */
-  void pop_back()
-  {
-    resizeAndExtend(m_Size - 1);
-  }
+  void pop_back();
   // insert
   // iterator erase (const_iterator position)
   // iterator erase (const_iterator first, const_iterator last);
@@ -1958,19 +923,7 @@ public:
   /**
    * @brief Removes all elements from the array (which are destroyed), leaving the container with a size of 0.
    */
-  void clear()
-  {
-    if(nullptr != m_Array && m_OwnsData)
-    {
-      deallocate();
-    }
-    m_Array = nullptr;
-    m_Size = 0;
-    m_OwnsData = true;
-    m_MaxId = 0;
-    m_IsAllocated = false;
-    m_NumTuples = 0;
-  }
+  void clear();
   // emplace
   // emplace_back
 
@@ -1980,7 +933,8 @@ public:
    * @param range2
    * @return
    */
-  template <typename Range1, typename Range2> bool equal(Range1 const& range1, Range2 const& range2)
+  template <typename Range1, typename Range2>
+  bool equal(Range1 const& range1, Range2 const& range2)
   {
     if(range1.size() != range2.size())
     {
@@ -1997,137 +951,21 @@ protected:
   /**
    * @brief deallocates the memory block
    */
-  void deallocate()
-  {
-    // We are going to splat 0xABABAB across the first value of the array as a debugging aid
-    auto cptr = reinterpret_cast<unsigned char*>(m_Array);
-    if(nullptr != cptr)
-    {
-      if(m_Size > 0)
-      {
-        if(sizeof(T) >= 1)
-        {
-          cptr[0] = 0xAB;
-        }
-        if(sizeof(T) >= 2)
-        {
-          cptr[1] = 0xAB;
-        }
-        if(sizeof(T) >= 4)
-        {
-          cptr[2] = 0xAB;
-          cptr[3] = 0xAB;
-        }
-        if(sizeof(T) >= 8)
-        {
-          cptr[4] = 0xAB;
-          cptr[5] = 0xAB;
-          cptr[6] = 0xAB;
-          cptr[7] = 0xAB;
-        }
-      }
-    }
-#if 0
-      if (MUD_FLAP_0 != 0xABABABABABABABABul
-          || MUD_FLAP_1 != 0xABABABABABABABABul
-          || MUD_FLAP_2 != 0xABABABABABABABABul
-          || MUD_FLAP_3 != 0xABABABABABABABABul
-          || MUD_FLAP_4 != 0xABABABABABABABABul
-          || MUD_FLAP_5 != 0xABABABABABABABABul)
-      {
-        Q_ASSERT(false);
-      }
-#endif
-    delete[](m_Array);
-
-    m_Array = nullptr;
-    m_IsAllocated = false;
-  }
+  void deallocate();
 
   /**
    * @brief Resizes the internal array
    * @param size The new size of the internal array
    * @return 1 on success, 0 on failure
    */
-  int32_t resizeTotalElements(size_t size) override
-  {
-    // std::cout << "DataArray::resizeTotalElements(" << size << ")" << std::endl;
-    if(size == 0)
-    {
-      clear();
-      return 1;
-    }
-    T* ptr = resizeAndExtend(size);
-    if(nullptr != ptr)
-    {
-      return 1;
-    }
-    return 0;
-  }
+  int32_t resizeTotalElements(size_t size) override;
 
   /**
    * @brief resizes the internal array to be 'size' elements in length
    * @param size
    * @return Pointer to the internal array
    */
-  virtual T* resizeAndExtend(size_t size)
-  {
-    T* newArray = nullptr;
-    size_t newSize = 0;
-    size_t oldSize = 0;
-
-    if(size == m_Size) // Requested size is equal to current size.  Do nothing.
-    {
-      return m_Array;
-    }
-    newSize = size;
-    oldSize = m_Size;
-
-    // Wipe out the array completely if new size is zero.
-    if(newSize == 0)
-    {
-      clear();
-      return m_Array;
-    }
-
-    newArray = new T[newSize]();
-    if(!newArray)
-    {
-      qDebug() << "Unable to allocate " << newSize << " elements of size " << sizeof(T) << " bytes. ";
-      return nullptr;
-    }
-
-    // Copy the data from the old array.
-    if(m_Array != nullptr)
-    {
-      std::memcpy(newArray, m_Array, (newSize < m_Size ? newSize : m_Size) * sizeof(T));
-    }
-
-    // Allocate a new array if we DO NOT own the current array
-    if((nullptr != m_Array) && m_OwnsData)
-    {
-      // Free the old array
-      deallocate();
-    }
-
-    // Allocation was successful.  Save it.
-    m_Size = newSize;
-    m_Array = newArray;
-
-    // This object has now allocated its memory and owns it.
-    m_OwnsData = true;
-
-    m_MaxId = newSize - 1;
-    m_IsAllocated = true;
-
-    // Initialize the new tuples if newSize is larger than old size
-    if(newSize > oldSize)
-    {
-      initializeWithValue(m_InitValue, oldSize);
-    }
-
-    return m_Array;
-  }
+  virtual T* resizeAndExtend(size_t size);
 
 private:
   T* m_Array = nullptr;
@@ -2142,11 +980,37 @@ private:
 };
 
 // -----------------------------------------------------------------------------
-//
+// These are specialized for bool type as std::vector<bool> uses bits instead of bytes
+template <>
+typename DataArray<bool>::Pointer DataArray<bool>::FromStdVector(std::vector<bool>& vec, const QString& name);
+
+template <>
+void DataArray<bool>::setTuple(size_t tupleIndex, const std::vector<bool>& data);
+
 // -----------------------------------------------------------------------------
+// Declare our extern templates
+extern template class DataArray<bool>;
+
+extern template class DataArray<char>;
+extern template class DataArray<unsigned char>;
+
+extern template class DataArray<int8_t>;
+extern template class DataArray<uint8_t>;
+extern template class DataArray<int16_t>;
+extern template class DataArray<uint16_t>;
+extern template class DataArray<int32_t>;
+extern template class DataArray<uint32_t>;
+extern template class DataArray<int64_t>;
+extern template class DataArray<uint64_t>;
+
+extern template class DataArray<float>;
+extern template class DataArray<double>;
+
+extern template class DataArray<size_t>;
 
 using BoolArrayType = DataArray<bool>;
 
+using CharArrayType = DataArray<char>;
 using UCharArrayType = DataArray<unsigned char>;
 
 using Int8ArrayType = DataArray<int8_t>;

--- a/Source/SIMPLib/DataArrays/DataArray.hpp
+++ b/Source/SIMPLib/DataArrays/DataArray.hpp
@@ -1008,6 +1008,8 @@ extern template class DataArray<double>;
 
 extern template class DataArray<size_t>;
 
+// -----------------------------------------------------------------------------
+// Declare our aliases
 using BoolArrayType = DataArray<bool>;
 
 using CharArrayType = DataArray<char>;

--- a/Source/SIMPLib/DataArrays/SourceList.cmake
+++ b/Source/SIMPLib/DataArrays/SourceList.cmake
@@ -14,6 +14,7 @@ set(SIMPLib_${SUBDIR_NAME}_HDRS
 )
 
 set(SIMPLib_${SUBDIR_NAME}_SRCS
+  ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/DataArray.cpp
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/IDataArray.cpp
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/IDataArrayFilter.cpp
   ${SIMPLib_SOURCE_DIR}/${SUBDIR_NAME}/StatsDataArray.cpp

--- a/Source/SIMPLib/DataArrays/StatsDataArray.cpp
+++ b/Source/SIMPLib/DataArrays/StatsDataArray.cpp
@@ -36,21 +36,20 @@
 #include "StatsDataArray.h"
 
 #include <QtCore/QList>
-
 #include <QtCore/QTextStream>
-
 #include <QtCore/QDebug>
 
-#include "SIMPLib/Common/PhaseType.h"
+#include "H5Support/H5ScopedSentinel.h"
+#include "H5Support/QH5Utilities.h"
+#include "H5Support/QH5Lite.h"
 
+#include "SIMPLib/Common/PhaseType.h"
 #include "SIMPLib/StatsData/BoundaryStatsData.h"
 #include "SIMPLib/StatsData/MatrixStatsData.h"
 #include "SIMPLib/StatsData/PrecipitateStatsData.h"
 #include "SIMPLib/StatsData/PrimaryStatsData.h"
 #include "SIMPLib/StatsData/TransformationStatsData.h"
-
-#include "H5Support/H5ScopedSentinel.h"
-#include "H5Support/QH5Utilities.h"
+#include "SIMPLib/HDF5/H5DataArrayWriter.hpp"
 
 // -----------------------------------------------------------------------------
 //

--- a/Source/SIMPLib/DataArrays/StructArray.hpp
+++ b/Source/SIMPLib/DataArrays/StructArray.hpp
@@ -37,18 +37,17 @@
 *    United States Prime Contract Navy N00173-07-C-2068
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
-
 #pragma once
 
-#include <QtCore/QString>
+#include <cstring>
 
+#include <QtCore/QString>
 #include <QtCore/QTextStream>
 
-#include "SIMPLib/DataArrays/IDataArray.h"
-
-#include "SIMPLib/DataArrays/IDataArrayFilter.h"
 #include "SIMPLib/SIMPLib.h"
+#include "SIMPLib/DataArrays/IDataArray.h"
+#include "SIMPLib/DataArrays/IDataArrayFilter.h"
+
 
 template<typename T>
 class StructArray : public IDataArray

--- a/Source/SIMPLib/DataArrays/Testing/Cxx/DataArrayTest.cpp
+++ b/Source/SIMPLib/DataArrays/Testing/Cxx/DataArrayTest.cpp
@@ -435,8 +435,6 @@ public:
     TEST_TYPE_STRING(quint16)
     TEST_TYPE_STRING(qint32)
     TEST_TYPE_STRING(quint32)
-    TEST_TYPE_STRING(qint64)
-    TEST_TYPE_STRING(quint64)
 
     TEST_TYPE_STRING(int8_t)
     TEST_TYPE_STRING(uint8_t)
@@ -448,11 +446,7 @@ public:
     TEST_TYPE_STRING(uint64_t)
     TEST_TYPE_STRING(float)
     TEST_TYPE_STRING(double)
-    //   long long int myint = 50;
-    //   std::cout << "myint has type: " << typeid(myint).name() << '\n';
-
-    //   qDebug() << typeid(int64_t).name() << " " << typeid(qint64).name() << " " << typeid(signed long long int).name() << " " << typeid(long long int).name() << " " << typeid(long long).name();
-  }
+}
 
   // -----------------------------------------------------------------------------
   //

--- a/Source/SIMPLib/DataArrays/Testing/Cxx/DataArrayTest.cpp
+++ b/Source/SIMPLib/DataArrays/Testing/Cxx/DataArrayTest.cpp
@@ -1016,8 +1016,8 @@ true);
 
     typename DataArray<T>::Pointer copy = DataArray<T>::CreateArray(numTuples, cDims, name, false);
 
-    DREAM3D_REQUIRED(copy->getNumberOfTuples(), ==, src->getNumberOfTuples());
-    DREAM3D_REQUIRED(copy->isAllocated(), ==, src->isAllocated());
+    DREAM3D_REQUIRED(copy->getNumberOfTuples(), ==, src->getNumberOfTuples())
+    DREAM3D_REQUIRED(copy->isAllocated(), ==, src->isAllocated())
 
     // Create the array again, this time allocating the data and putting in some known data
     src = DataArray<T>::CreateArray(numTuples, cDims, name, true);
@@ -1195,7 +1195,7 @@ true);
   template <typename T> void TestSetTupleForType()
   {
     size_t numTuples = 10;
-    std::vector<size_t> cDims(1, 5);
+    std::vector<size_t> cDims = {5};
     QString name("Source Array");
 
     // Each index of the vector is a tuple with a vector containing the components for that tuple
@@ -1229,6 +1229,9 @@ true);
       {
         T val = src->getComponent(i, j);
         DREAM3D_REQUIRE_EQUAL(data[i][j], val)
+
+        T* ptr = src->getPointer((cDims[0] * i) + j);
+        DREAM3D_REQUIRE_EQUAL(*ptr, val);
       }
     }
   }

--- a/Source/SIMPLib/DataContainers/DataContainerBundle.cpp
+++ b/Source/SIMPLib/DataContainers/DataContainerBundle.cpp
@@ -35,13 +35,13 @@
 
 #include "DataContainerBundle.h"
 
-#include "H5Support/QH5Utilities.h"
-#include "H5Support/H5ScopedSentinel.h"
-
 #include <QtCore/QDebug>
 
-#include "SIMPLib/DataArrays/StringDataArray.h"
+#include "H5Support/QH5Utilities.h"
+#include "H5Support/QH5Lite.h"
+#include "H5Support/H5ScopedSentinel.h"
 
+#include "SIMPLib/DataArrays/StringDataArray.h"
 #include "SIMPLib/DataContainers/DataArrayPath.h"
 #include "SIMPLib/DataContainers/DataContainer.h"
 

--- a/Source/SIMPLib/Filtering/ThresholdFilterHelper.cpp
+++ b/Source/SIMPLib/Filtering/ThresholdFilterHelper.cpp
@@ -54,16 +54,24 @@ ThresholdFilterHelper::~ThresholdFilterHelper() = default;
 //
 // -----------------------------------------------------------------------------
 #define FILTER_DATA_HELPER(dType, ops, Type)                                                                                                                                                           \
-  if(dType.compare(#Type) == 0)                                                                                                                                                                        \
+  if(dType == #Type)                                                                                                                                                                                   \
   {                                                                                                                                                                                                    \
     if(ops == SIMPL::Comparison::Operator_LessThan)                                                                                                                                                    \
+    {                                                                                                                                                                                                  \
       filterDataLessThan<Type>(input);                                                                                                                                                                 \
+    }                                                                                                                                                                                                  \
     else if(ops == SIMPL::Comparison::Operator_GreaterThan)                                                                                                                                            \
+    {                                                                                                                                                                                                  \
       filterDataGreaterThan<Type>(input);                                                                                                                                                              \
+    }                                                                                                                                                                                                  \
     else if(ops == SIMPL::Comparison::Operator_Equal)                                                                                                                                                  \
+    {                                                                                                                                                                                                  \
       filterDataEqualTo<Type>(input);                                                                                                                                                                  \
+    }                                                                                                                                                                                                  \
     else if(ops == SIMPL::Comparison::Operator_NotEqual)                                                                                                                                               \
+    {                                                                                                                                                                                                  \
       filterDataNotEqualTo<Type>(input);                                                                                                                                                               \
+    }                                                                                                                                                                                                  \
     return 1;                                                                                                                                                                                          \
   }
 
@@ -79,52 +87,53 @@ int ThresholdFilterHelper::execute(const IDataArray::Pointer& input, IDataArray*
   m_Output->initializeWithZeros();
   QString dType = input->getTypeAsString();
 
-  FILTER_DATA_HELPER(dType, comparisonOperator, float);
-  FILTER_DATA_HELPER(dType, comparisonOperator, double);
+  FILTER_DATA_HELPER(dType, comparisonOperator, float)
+  FILTER_DATA_HELPER(dType, comparisonOperator, double)
 
-  FILTER_DATA_HELPER(dType, comparisonOperator, int8_t);
-  FILTER_DATA_HELPER(dType, comparisonOperator, uint8_t);
-#if CMP_TYPE_CHAR_IS_SIGNED
-  FILTER_DATA_HELPER(dType, comparisonOperator, char);
-#else
-  FILTER_DATA_HELPER(dType, comparisonOperator, char);
-#endif
-  FILTER_DATA_HELPER(dType, comparisonOperator, signed char);
-  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned char);
+  FILTER_DATA_HELPER(dType, comparisonOperator, int8_t)
+  FILTER_DATA_HELPER(dType, comparisonOperator, uint8_t)
+  //#if CMP_TYPE_CHAR_IS_SIGNED
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, char);
+  //#else
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, char);
+  //#endif
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, signed char)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned char)
 
-  FILTER_DATA_HELPER(dType, comparisonOperator, int16_t);
-  FILTER_DATA_HELPER(dType, comparisonOperator, short);
-  FILTER_DATA_HELPER(dType, comparisonOperator, signed short);
-  FILTER_DATA_HELPER(dType, comparisonOperator, uint16_t);
-  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned short);
+  FILTER_DATA_HELPER(dType, comparisonOperator, int16_t)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, short)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, signed short)
+  FILTER_DATA_HELPER(dType, comparisonOperator, uint16_t)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned short)
 
-  FILTER_DATA_HELPER(dType, comparisonOperator, int32_t);
-  FILTER_DATA_HELPER(dType, comparisonOperator, uint32_t);
-#if(CMP_SIZEOF_INT == 4)
-  FILTER_DATA_HELPER(dType, comparisonOperator, int);
-  FILTER_DATA_HELPER(dType, comparisonOperator, signed int);
-  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned int);
-#endif
+  FILTER_DATA_HELPER(dType, comparisonOperator, int32_t)
+  FILTER_DATA_HELPER(dType, comparisonOperator, uint32_t)
+  //#if(CMP_SIZEOF_INT == 4)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, int)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, signed int)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned int)
+  //#endif
 
-#if(CMP_SIZEOF_LONG == 4)
-  FILTER_DATA_HELPER(dType, comparisonOperator, long int);
-  FILTER_DATA_HELPER(dType, comparisonOperator, signed long int);
-  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned long int);
-#elif(CMP_SIZEOF_LONG == 8)
-  FILTER_DATA_HELPER(dType, comparisonOperator, long int);
-  FILTER_DATA_HELPER(dType, comparisonOperator, signed long int);
-  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned long int);
-#endif
+  //#if(CMP_SIZEOF_LONG == 4)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, long int)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, signed long int)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned long int)
+  //#elif(CMP_SIZEOF_LONG == 8)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, long int)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, signed long int)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned long int)
+  //#endif
 
-#if(CMP_SIZEOF_LONG_LONG == 8)
-  FILTER_DATA_HELPER(dType, comparisonOperator, long long int);
-  FILTER_DATA_HELPER(dType, comparisonOperator, signed long long int);
-  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned long long int);
-#endif
-  FILTER_DATA_HELPER(dType, comparisonOperator, int64_t);
-  FILTER_DATA_HELPER(dType, comparisonOperator, uint64_t);
+  //#if(CMP_SIZEOF_LONG_LONG == 8)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, long long int)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, signed long long int)
+  //  FILTER_DATA_HELPER(dType, comparisonOperator, unsigned long long int)
+  //#endif
 
-  FILTER_DATA_HELPER(dType, comparisonOperator, bool);
+  FILTER_DATA_HELPER(dType, comparisonOperator, int64_t)
+  FILTER_DATA_HELPER(dType, comparisonOperator, uint64_t)
+
+  FILTER_DATA_HELPER(dType, comparisonOperator, bool)
 
   return -1;
 }

--- a/Source/SIMPLib/ITK/itkImageReaderHelper.cpp
+++ b/Source/SIMPLib/ITK/itkImageReaderHelper.cpp
@@ -20,7 +20,7 @@
 class ITK_IMAGE_READER_CLASS_NAME : public AbstractFilter
 {
 public:
-  ITK_IMAGE_READER_CLASS_NAME() = deafult;
+  ITK_IMAGE_READER_CLASS_NAME() = default;
   ~ITK_IMAGE_READER_CLASS_NAME() = default;
 
 protected:
@@ -31,15 +31,15 @@ protected:
 
   template <typename TComponent>
   void readImage(const DataArrayPath& dataArrayPath, const itk::ImageIOBase::Pointer& imageIO, const QString& filename, bool dataCheck);
-  template <typename TComponent, unsigned int dimensions>
+  template <typename TComponent, uint32_t dimensions>
   void readImage(const DataArrayPath& dataArrayPath, const itk::ImageIOBase::Pointer& imageIO, const QString& filename, bool dataCheck);
 
-  template <typename TPixel, unsigned int dimensions>
+  template <typename TPixel, uint32_t dimensions>
   void readImage(const DataArrayPath& dataArrayPath, const QString& filename, bool dataCheck);
 
   void readImage(const DataArrayPath& dataArrayPath, bool dataCheck);
 
-  template <typename TPixel, unsigned int dimensions>
+  template <typename TPixel, uint32_t dimensions>
   void readImageOutputInformation(const DataArrayPath& dataArrayPath, typename itk::ImageFileReader<itk::Image<TPixel, dimensions>>::Pointer& reader, DataContainer::Pointer& container);
 };
 
@@ -53,7 +53,7 @@ void
 ITK_IMAGE_READER_CLASS_NAME
 ::readImage(const DataArrayPath& dataArrayPath, const itk::ImageIOBase::Pointer& imageIO, const QString& filename, bool dataCheck)
 {
-  const unsigned int dimensions = imageIO->GetNumberOfDimensions();
+  const uint32_t dimensions = imageIO->GetNumberOfDimensions();
   switch(dimensions)
   {
   case 1:
@@ -77,15 +77,13 @@ ITK_IMAGE_READER_CLASS_NAME
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-template <typename TComponent, unsigned int dimensions>
-void
-ITK_IMAGE_READER_CLASS_NAME
-::readImage(const DataArrayPath& dataArrayPath, const itk::ImageIOBase::Pointer& imageIO, const QString& filename, bool dataCheck)
+template <typename TComponent, uint32_t dimensions>
+void ITK_IMAGE_READER_CLASS_NAME ::readImage(const DataArrayPath& dataArrayPath, const itk::ImageIOBase::Pointer& imageIO, const QString& filename, bool dataCheck)
 {
   using PixelTypeType = itk::ImageIOBase::IOPixelType;
   PixelTypeType pixel = imageIO->GetPixelType();
 
-  const unsigned int nbComponents = imageIO->GetNumberOfComponents();
+  const uint32_t nbComponents = imageIO->GetNumberOfComponents();
   switch(pixel)
   {
   case itk::ImageIOBase::SCALAR:
@@ -135,10 +133,8 @@ ITK_IMAGE_READER_CLASS_NAME
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-template <typename TPixel, unsigned int dimensions>
-void
-ITK_IMAGE_READER_CLASS_NAME
-::readImage(const DataArrayPath& dataArrayPath, const QString& filename, bool dataCheck)
+template <typename TPixel, uint32_t dimensions>
+void ITK_IMAGE_READER_CLASS_NAME ::readImage(const DataArrayPath& dataArrayPath, const QString& filename, bool dataCheck)
 {
   DataContainer::Pointer container = getDataContainerArray()->getDataContainer(dataArrayPath.getDataContainerName());
   if(nullptr == container.get())
@@ -195,28 +191,28 @@ ITK_IMAGE_READER_CLASS_NAME
     switch(component)
     {
     case itk::ImageIOBase::UCHAR:
-      readImage<unsigned char>(dataArrayPath, imageIO, filename, dataCheck);
+      readImage<uint8_t>(dataArrayPath, imageIO, filename, dataCheck);
       break;
     case itk::ImageIOBase::CHAR:
-      readImage<char>(dataArrayPath, imageIO, filename, dataCheck);
+      readImage<int8_t>(dataArrayPath, imageIO, filename, dataCheck);
       break;
     case itk::ImageIOBase::USHORT:
-      readImage<unsigned short>(dataArrayPath, imageIO, filename, dataCheck);
+      readImage<uint16_t>(dataArrayPath, imageIO, filename, dataCheck);
       break;
     case itk::ImageIOBase::SHORT:
-      readImage<short>(dataArrayPath, imageIO, filename, dataCheck);
+      readImage<int16_t>(dataArrayPath, imageIO, filename, dataCheck);
       break;
     case itk::ImageIOBase::UINT:
-      readImage<unsigned int>(dataArrayPath, imageIO, filename, dataCheck);
+      readImage<uint32_t>(dataArrayPath, imageIO, filename, dataCheck);
       break;
     case itk::ImageIOBase::INT:
-      readImage<int>(dataArrayPath, imageIO, filename, dataCheck);
+      readImage<int32_t>(dataArrayPath, imageIO, filename, dataCheck);
       break;
     case itk::ImageIOBase::ULONG:
-      readImage<unsigned long>(dataArrayPath, imageIO, filename, dataCheck);
+      readImage<uint64_t>(dataArrayPath, imageIO, filename, dataCheck);
       break;
     case itk::ImageIOBase::LONG:
-      readImage<long>(dataArrayPath, imageIO, filename, dataCheck);
+      readImage<int64_t>(dataArrayPath, imageIO, filename, dataCheck);
       break;
     case itk::ImageIOBase::FLOAT:
       readImage<float>(dataArrayPath, imageIO, filename, dataCheck);
@@ -240,7 +236,7 @@ ITK_IMAGE_READER_CLASS_NAME
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-template <typename TPixel, unsigned int dimensions>
+template <typename TPixel, uint32_t dimensions>
 void ITK_IMAGE_READER_CLASS_NAME ::readImageOutputInformation(const DataArrayPath& dataArrayPath, typename itk::ImageFileReader<itk::Image<TPixel, dimensions>>::Pointer& reader,
                                                               DataContainer::Pointer& container)
 {
@@ -256,9 +252,9 @@ void ITK_IMAGE_READER_CLASS_NAME ::readImageOutputInformation(const DataArrayPat
   SizeVec3Type tDims = {1, 1, 1};
   for(size_t i = 0; i < dimensions; i++)
   {
-    torigin[i] = origin[i];
-    tspacing[i] = spacing[i];
-    tDims[i] = size[i];
+    torigin[i] = static_cast<float>(origin[i]);
+    tspacing[i] = static_cast<float>(spacing[i]);
+    tDims[i] = static_cast<float>(size[i]);
   }
   ImageGeom::Pointer image = ImageGeom::CreateGeometry(SIMPL::Geometry::ImageGeometry);
   image->setDimensions(tDims);

--- a/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.hxx
+++ b/Source/SIMPLib/ITK/itkInPlaceImageToDream3DDataFilter.hxx
@@ -8,16 +8,14 @@
 namespace itk
 {
 
-template<typename PixelType, unsigned int VDimension>
-InPlaceImageToDream3DDataFilter<PixelType,VDimension>
-::InPlaceImageToDream3DDataFilter()
+template <typename PixelType, unsigned int VDimension>
+InPlaceImageToDream3DDataFilter<PixelType, VDimension>::InPlaceImageToDream3DDataFilter()
 {
   m_DataArrayName = (SIMPL::Defaults::CellAttributeMatrixName).toStdString();
   m_AttributeMatrixArrayName = (SIMPL::CellData::ImageData).toStdString();
   // Create the output. We use static_cast<> here because we know the default
   // output must be of type DecoratorType
-  typename DecoratorType::Pointer output =
-    static_cast< DecoratorType * >(this->MakeOutput(0).GetPointer());
+  typename DecoratorType::Pointer output = static_cast<DecoratorType*>(this->MakeOutput(0).GetPointer());
   this->ProcessObject::SetNumberOfRequiredOutputs(1);
   this->ProcessObject::SetNthOutput(0, output.GetPointer());
   this->SetNumberOfRequiredInputs(1);
@@ -25,13 +23,10 @@ InPlaceImageToDream3DDataFilter<PixelType,VDimension>
   m_InPlace = true;
 }
 
-
-template< typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter< PixelType, VDimension >
-::SetDataContainer(DataContainer::Pointer dc)
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::SetDataContainer(DataContainer::Pointer dc)
 {
-  DecoratorType *outputPtr = this->GetOutput();
+  DecoratorType* outputPtr = this->GetOutput();
   outputPtr->Set(dc);
 }
 
@@ -41,32 +36,24 @@ ProcessObject::DataObjectPointer InPlaceImageToDream3DDataFilter<PixelType, VDim
   return DecoratorType::New().GetPointer();
 }
 
-
-template<typename PixelType, unsigned int VDimension>
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::~InPlaceImageToDream3DDataFilter()
+template <typename PixelType, unsigned int VDimension>
+InPlaceImageToDream3DDataFilter<PixelType, VDimension>::~InPlaceImageToDream3DDataFilter()
 {
 }
 
-template< typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter< PixelType, VDimension >
-::SetInput(const ImageType *input)
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::SetInput(const ImageType* input)
 {
   // Process object is not const-correct so the const_cast is required here
-  this->ProcessObject::SetNthInput(0,
-    const_cast< ImageType * >(input));
+  this->ProcessObject::SetNthInput(0, const_cast<ImageType*>(input));
 }
 
-
-template<typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::GenerateOutputInformation()
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::GenerateOutputInformation()
 {
-  DecoratorType *outputPtr = this->GetOutput();
+  DecoratorType* outputPtr = this->GetOutput();
   DataContainer::Pointer dataContainer = outputPtr->Get();
-  //float tol = 0.000001;
+  // float tol = 0.000001;
   QVector<float> torigin(3, 0);
   QVector<float> tspacing(3, 1);
   std::vector<size_t> tDims(3, 1);
@@ -78,10 +65,10 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   //// Create image geometry (data container)
   ImageGeom::Pointer imageGeom;
   IGeometry::Pointer geom = dataContainer->getGeometry();
-  if (geom)
+  if(geom)
   {
     imageGeom = std::dynamic_pointer_cast<ImageGeom>(geom);
-    if (!imageGeom)
+    if(!imageGeom)
     {
       itkExceptionMacro("Data container contains a geometry that is not ImageGeometry");
     }
@@ -89,16 +76,16 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   else
   {
     imageGeom = ImageGeom::CreateGeometry(SIMPL::Geometry::ImageGeometry);
-    if (!imageGeom)
+    if(!imageGeom)
     {
       itkExceptionMacro("Could not create image geometry");
     }
   }
-  for (size_t i = 0; i < VDimension; i++)
+  for(size_t i = 0; i < VDimension; i++)
   {
-	  torigin[i] = origin[i];
-	  tspacing[i] = spacing[i];
-	  tDims[i] = size[i];
+    torigin[i] = origin[i];
+    tspacing[i] = spacing[i];
+    tDims[i] = size[i];
   }
   imageGeom->setOrigin(FloatVec3Type(torigin[0], torigin[1], torigin[2]));
   imageGeom->setSpacing(FloatVec3Type(tspacing[0], tspacing[1], tspacing[2]));
@@ -106,12 +93,10 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   dataContainer->setGeometry(imageGeom);
 }
 
-template<typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::GenerateData()
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::GenerateData()
 {
-  DecoratorType *outputPtr = this->GetOutput();
+  DecoratorType* outputPtr = this->GetOutput();
   DataContainer::Pointer dataContainer = outputPtr->Get();
   ImagePointer inputPtr = dynamic_cast<ImageType*>(this->GetInput(0));
   // Create data array
@@ -121,54 +106,52 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   std::vector<size_t> tDims = imageGeom->getDimensions().toContainer<std::vector<size_t>>();
 
   AttributeMatrix::Pointer attrMat;
-  if( dataContainer->doesAttributeMatrixExist(m_AttributeMatrixArrayName.c_str()))
+  if(dataContainer->doesAttributeMatrixExist(m_AttributeMatrixArrayName.c_str()))
   {
-	attrMat = dataContainer->getAttributeMatrix(m_AttributeMatrixArrayName.c_str());
-	// Check that attribute matrix type is 'cell'
-	if (attrMat->getType() != AttributeMatrix::Type::Cell)
-	{
-		itkExceptionMacro("Attribute matrix is not of type AttributeMatrix::Type::Cell.");
-	}
-	// Check that if size does not match, there are no other data array than the one we expect.
-	// That makes it possible to modify the attribute matrix without having to worry.
-	std::vector<size_t> matDims = attrMat->getTupleDimensions();
-	if (matDims != tDims)
-	{
-    if (! ((attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()) && attrMat->getNumAttributeArrays() == 1)
-      || ! (attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()) && attrMat->getNumAttributeArrays() == 0)) )
-		{
-			itkExceptionMacro("Tuples dimension of existing matrix array do not match image size and other attribute arrays are contained in this attribute matrix.");
-		}
-		dataContainer->removeAttributeMatrix(m_AttributeMatrixArrayName.c_str());
-		attrMat = dataContainer->createAndAddAttributeMatrix(tDims, m_AttributeMatrixArrayName.c_str(), AttributeMatrix::Type::Cell);
-	}
+    attrMat = dataContainer->getAttributeMatrix(m_AttributeMatrixArrayName.c_str());
+    // Check that attribute matrix type is 'cell'
+    if(attrMat->getType() != AttributeMatrix::Type::Cell)
+    {
+      itkExceptionMacro("Attribute matrix is not of type AttributeMatrix::Type::Cell.");
+    }
+    // Check that if size does not match, there are no other data array than the one we expect.
+    // That makes it possible to modify the attribute matrix without having to worry.
+    std::vector<size_t> matDims = attrMat->getTupleDimensions();
+    if(matDims != tDims)
+    {
+      if(!((attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()) && attrMat->getNumAttributeArrays() == 1) ||
+           !(attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()) && attrMat->getNumAttributeArrays() == 0)))
+      {
+        itkExceptionMacro("Tuples dimension of existing matrix array do not match image size and other attribute arrays are contained in this attribute matrix.");
+      }
+      dataContainer->removeAttributeMatrix(m_AttributeMatrixArrayName.c_str());
+      attrMat = dataContainer->createAndAddAttributeMatrix(tDims, m_AttributeMatrixArrayName.c_str(), AttributeMatrix::Type::Cell);
+    }
   }
   else
   {
     attrMat = dataContainer->createAndAddAttributeMatrix(tDims, m_AttributeMatrixArrayName.c_str(), AttributeMatrix::Type::Cell);
   }
   // Checks if doesAttributeArray exists and remove it if it is the case
-  if (attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()))
+  if(attrMat->doesAttributeArrayExist(m_DataArrayName.c_str()))
   {
-	  IDataArray::Pointer attrArray = attrMat->getAttributeArray(m_DataArrayName.c_str());
-	  if (attrArray->getNumberOfTuples() != imageGeom->getNumberOfElements())
-	  {
-		  attrMat->removeAttributeArray(m_DataArrayName.c_str());
-	  }
+    IDataArray::Pointer attrArray = attrMat->getAttributeArray(m_DataArrayName.c_str());
+    if(attrArray->getNumberOfTuples() != imageGeom->getNumberOfElements())
+    {
+      attrMat->removeAttributeArray(m_DataArrayName.c_str());
+    }
   }
   typename DataArrayPixelType::Pointer data;
-  inputPtr->SetBufferedRegion( inputPtr->GetLargestPossibleRegion() );
-  if( m_InPlace )
+  inputPtr->SetBufferedRegion(inputPtr->GetLargestPossibleRegion());
+  if(m_InPlace)
   {
-    inputPtr->GetPixelContainer()->SetContainerManageMemory( false );
-    data = DataArrayPixelType::WrapPointer( reinterpret_cast<ValueType*>(inputPtr->GetBufferPointer()),
-              imageGeom->getNumberOfElements(), cDims, this->GetDataArrayName().c_str(), true );
+    inputPtr->GetPixelContainer()->SetContainerManageMemory(false);
+    data = DataArrayPixelType::WrapPointer(reinterpret_cast<ValueType*>(inputPtr->GetBufferPointer()), imageGeom->getNumberOfElements(), cDims, this->GetDataArrayName().c_str(), true);
   }
   else
   {
-    data = DataArrayPixelType::CreateArray(imageGeom->getNumberOfElements(), cDims,
-              m_DataArrayName.c_str(), true);
-    if (nullptr != data.get())
+    data = DataArrayPixelType::CreateArray(imageGeom->getNumberOfElements(), cDims, m_DataArrayName.c_str(), true);
+    if(nullptr != data.get())
     {
       ::memcpy(data->getPointer(0), reinterpret_cast<ValueType*>(inputPtr->GetBufferPointer()), imageGeom->getNumberOfElements() * sizeof(ValueType));
     }
@@ -178,38 +161,33 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
 }
 
 // Check that names has been initialized correctly
-template<typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::CheckValidArrayPathComponentName(std::string var) const
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::CheckValidArrayPathComponentName(std::string var) const
 {
-  if (var.find('/') != std::string::npos)
+  if(var.find('/') != std::string::npos)
   {
     itkExceptionMacro("Name contains a '/'");
   }
-  if (var.empty())
+  if(var.empty())
   {
     itkExceptionMacro("Name is empty");
   }
 }
 
-
 // Check that the inputs have been initialized correctly
-template<typename PixelType, unsigned int VDimension>
-void
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::VerifyPreconditions() ITKv5_CONST
+template <typename PixelType, unsigned int VDimension>
+void InPlaceImageToDream3DDataFilter<PixelType, VDimension>::VerifyPreconditions() ITKv5_CONST
 {
-  //Test only works if image if of dimension 2 or 3
-  if (VDimension != 2 && VDimension != 3)
+  // Test only works if image if of dimension 2 or 3
+  if(VDimension != 2 && VDimension != 3)
   {
     itkExceptionMacro("Dimension must be 2 or 3.");
   }
   CheckValidArrayPathComponentName(m_AttributeMatrixArrayName);
   CheckValidArrayPathComponentName(m_DataArrayName);
   // Verify data container
-  const DecoratorType *outputPtr = this->GetOutput();
-  if (!outputPtr->Get())
+  const DecoratorType* outputPtr = this->GetOutput();
+  if(!outputPtr->Get())
   {
     itkExceptionMacro("Data container not set");
   }
@@ -218,23 +196,18 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
 }
 
 /**
-*
-*/
-template<typename PixelType, unsigned int VDimension>
-typename InPlaceImageToDream3DDataFilter<PixelType, VDimension>::DecoratorType*
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::GetOutput()
+ *
+ */
+template <typename PixelType, unsigned int VDimension>
+typename InPlaceImageToDream3DDataFilter<PixelType, VDimension>::DecoratorType* InPlaceImageToDream3DDataFilter<PixelType, VDimension>::GetOutput()
 {
-  return itkDynamicCastInDebugMode< DecoratorType * >(this->GetPrimaryOutput());
+  return itkDynamicCastInDebugMode<DecoratorType*>(this->GetPrimaryOutput());
 }
 
-template<typename PixelType, unsigned int VDimension>
-const typename InPlaceImageToDream3DDataFilter<PixelType, VDimension>::DecoratorType*
-InPlaceImageToDream3DDataFilter<PixelType, VDimension>
-::GetOutput() const
+template <typename PixelType, unsigned int VDimension>
+const typename InPlaceImageToDream3DDataFilter<PixelType, VDimension>::DecoratorType* InPlaceImageToDream3DDataFilter<PixelType, VDimension>::GetOutput() const
 {
-  return itkDynamicCastInDebugMode< const DecoratorType * >(this->GetPrimaryOutput());
+  return itkDynamicCastInDebugMode<const DecoratorType*>(this->GetPrimaryOutput());
 }
 
-} // end of itk namespace
-
+} // namespace itk

--- a/Source/SIMPLib/SIMPLibConfiguration.h.in
+++ b/Source/SIMPLib/SIMPLibConfiguration.h.in
@@ -26,12 +26,6 @@
 /* define to 1 if we are supporting ITK Filters */
 #cmakedefine SIMPL_USE_ITK
 
-/* define if Python wrapping is enabled through Pybind11 */
-#cmakedefine SIMPL_ENABLE_PYTHON
-
-/* define to 1 if we are checking relative paths */
-#cmakedefine SIMPL_RELATIVE_PATH_CHECK @SIMPL_RELATIVE_PATH_CHECK@
-
 /* ****************************************************************************
 * These define features that SIMPL will have when compiled.
 **************************************************************************** */
@@ -39,8 +33,11 @@
 /* define to 1 if we are enabling NTFS file checking */
 #cmakedefine SIMPL_NTFS_FILE_CHECK @SIMPL_NTFS_FILE_CHECK@
 
-/* define to 1 if we are enabling Python Wrapping through Pybind11 */
+/* define if Python wrapping is enabled through Pybind11 */
 #cmakedefine SIMPL_ENABLE_PYTHON
+
+/* define to 1 if we are checking relative paths */
+#cmakedefine SIMPL_RELATIVE_PATH_CHECK @SIMPL_RELATIVE_PATH_CHECK@
 
 /* ****************************************************************************
 * These define what source groups are being compiled

--- a/Source/SIMPLib/Utilities/SIMPLH5DataReader.cpp
+++ b/Source/SIMPLib/Utilities/SIMPLH5DataReader.cpp
@@ -36,15 +36,15 @@
 
 #include <QtCore/QDebug>
 
-#include "SIMPLib/Common/IObserver.h"
+#include "H5Support/QH5Lite.h"
+#include "H5Support/QH5Utilities.h"
+#include "H5Support/H5ScopedSentinel.h"
 
+#include "SIMPLib/Common/IObserver.h"
 #include "SIMPLib/DataContainers/DataContainerArray.h"
 #include "SIMPLib/DataContainers/DataContainerBundle.h"
 #include "SIMPLib/Utilities/SIMPLH5DataReaderRequirements.h"
 #include "SIMPLib/DataContainers/DataContainer.h"
-
-#include "H5Support/QH5Utilities.h"
-#include "H5Support/H5ScopedSentinel.h"
 
 const QString Title = "HDF5 Read Error";
 

--- a/Source/SIMPLib/VTKUtils/VTKFileReader.cpp
+++ b/Source/SIMPLib/VTKUtils/VTKFileReader.cpp
@@ -146,35 +146,35 @@ int VTKFileReader::ignoreData(std::ifstream& in, int byteSize, char* text, int x
   int err = 0;
   if(strcmp(text, cunsigned_char) == 0)
   {
-    err |= skipVolume<unsigned char>(in, byteSize, xDim, yDim, zDim);
+    err |= skipVolume<uint8_t>(in, byteSize, xDim, yDim, zDim);
   }
   if(strcmp(text, cchar) == 0)
   {
-    err |= skipVolume<char>(in, byteSize, xDim, yDim, zDim);
+    err |= skipVolume<int8_t>(in, byteSize, xDim, yDim, zDim);
   }
   if(strcmp(text, cunsigned_short) == 0)
   {
-    err |= skipVolume<unsigned short>(in, byteSize, xDim, yDim, zDim);
+    err |= skipVolume<uint16_t>(in, byteSize, xDim, yDim, zDim);
   }
   if(strcmp(text, cshort) == 0)
   {
-    err |= skipVolume<short>(in, byteSize, xDim, yDim, zDim);
+    err |= skipVolume<int16_t>(in, byteSize, xDim, yDim, zDim);
   }
   if(strcmp(text, cunsigned_int) == 0)
   {
-    err |= skipVolume<unsigned int>(in, byteSize, xDim, yDim, zDim);
+    err |= skipVolume<uint32_t>(in, byteSize, xDim, yDim, zDim);
   }
   if(strcmp(text, cint) == 0)
   {
-    err |= skipVolume<int>(in, byteSize, xDim, yDim, zDim);
+    err |= skipVolume<int32_t>(in, byteSize, xDim, yDim, zDim);
   }
   if(strcmp(text, cunsigned_long) == 0)
   {
-    err |= skipVolume<unsigned long long int>(in, byteSize, xDim, yDim, zDim);
+    err |= skipVolume<uint64_t>(in, byteSize, xDim, yDim, zDim);
   }
   if(strcmp(text, clong) == 0)
   {
-    err |= skipVolume<long long int>(in, byteSize, xDim, yDim, zDim);
+    err |= skipVolume<int64_t>(in, byteSize, xDim, yDim, zDim);
   }
   if(strcmp(text, cfloat) == 0)
   {

--- a/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.cpp
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/ImportHDF5DatasetWidget.cpp
@@ -42,6 +42,7 @@
 
 #include <QtGui/QKeyEvent>
 #include <QtGui/QPainter>
+#include <QtCore/QTextStream>
 
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QMenu>
@@ -49,11 +50,9 @@
 #include "H5Support/H5Lite.h"
 #include "H5Support/H5Utilities.h"
 #include "H5Support/QH5Utilities.h"
-
-#include <QtCore/QTextStream>
+#include "H5Support/QH5Lite.h"
 
 #include "SIMPLib/CoreFilters/ImportHDF5Dataset.h"
-
 #include "SIMPLib/FilterParameters/ImportHDF5DatasetFilterParameter.h"
 #include "SIMPLib/Utilities/SIMPLDataPathValidator.h"
 #include "SIMPLib/DataContainers/DataContainerArray.h"


### PR DESCRIPTION
Use 'extern' and explicitly instantiated templates to cut down on compiled code bloat and reduce compile times.