### PR TITLE
Fixed bug where LinkedChoicesFilterParameter wouldn't get values from GUI

### DIFF
--- a/Source/SIMPLib/FilterParameters/LinkedChoicesFilterParameter.cpp
+++ b/Source/SIMPLib/FilterParameters/LinkedChoicesFilterParameter.cpp
@@ -81,9 +81,9 @@ QString LinkedChoicesFilterParameter::getWidgetType() const
 void LinkedChoicesFilterParameter::readJson(const QJsonObject& json)
 {
   QJsonValue jsonValue = json[getPropertyName()];
-  if(!jsonValue.isUndefined() && m_SetterCallback)
+  if(!jsonValue.isUndefined() && getSetterCallback())
   {
-    m_SetterCallback(jsonValue.toInt(0.0));
+    getSetterCallback()(jsonValue.toInt(0.0));
   }
 }
 
@@ -92,9 +92,9 @@ void LinkedChoicesFilterParameter::readJson(const QJsonObject& json)
 // -----------------------------------------------------------------------------
 void LinkedChoicesFilterParameter::writeJson(QJsonObject& json)
 {
-  if(m_GetterCallback)
+  if(getGetterCallback())
   {
-    json[getPropertyName()] = m_GetterCallback();
+    json[getPropertyName()] = getGetterCallback()();
   }
 }
 
@@ -133,28 +133,4 @@ void LinkedChoicesFilterParameter::setLinkedProperties(const QStringList& value)
 QStringList LinkedChoicesFilterParameter::getLinkedProperties() const
 {
   return m_LinkedProperties;
-}
-
-// -----------------------------------------------------------------------------
-void LinkedChoicesFilterParameter::setSetterCallback(const LinkedChoicesFilterParameter::SetterCallbackType& value)
-{
-  m_SetterCallback = value;
-}
-
-// -----------------------------------------------------------------------------
-LinkedChoicesFilterParameter::SetterCallbackType LinkedChoicesFilterParameter::getSetterCallback() const
-{
-  return m_SetterCallback;
-}
-
-// -----------------------------------------------------------------------------
-void LinkedChoicesFilterParameter::setGetterCallback(const LinkedChoicesFilterParameter::GetterCallbackType& value)
-{
-  m_GetterCallback = value;
-}
-
-// -----------------------------------------------------------------------------
-LinkedChoicesFilterParameter::GetterCallbackType LinkedChoicesFilterParameter::getGetterCallback() const
-{
-  return m_GetterCallback;
 }

--- a/Source/SIMPLib/FilterParameters/LinkedChoicesFilterParameter.h
+++ b/Source/SIMPLib/FilterParameters/LinkedChoicesFilterParameter.h
@@ -67,9 +67,6 @@ class SIMPLib_EXPORT LinkedChoicesFilterParameter : public ChoiceFilterParameter
      */
     static QString ClassName();
 
-    using SetterCallbackType = std::function<void(int)>;
-    using GetterCallbackType = std::function<int(void)>;
-
     /**
      * @brief New This function instantiates an instance of the LinkedChoicesFilterParameter. Although this function is available to be used,
      * the preferable way to instantiate an instance of this class is to use the SIMPL_NEW_LINKED_CHOICES_FP(...) macro at the top of this file.
@@ -125,36 +122,6 @@ class SIMPLib_EXPORT LinkedChoicesFilterParameter : public ChoiceFilterParameter
      */
     void writeJson(QJsonObject& json) override;
 
-    /**
-    * @param SetterCallback The method in the AbstractFilter subclass that <i>sets</i> the value of the property
-    * that this FilterParameter subclass represents.
-    * from the filter parameter.
-    */
-    /**
-     * @brief Setter property for SetterCallback
-     */
-    void setSetterCallback(const LinkedChoicesFilterParameter::SetterCallbackType& value);
-    /**
-     * @brief Getter property for SetterCallback
-     * @return Value of SetterCallback
-     */
-    LinkedChoicesFilterParameter::SetterCallbackType getSetterCallback() const;
-
-    /**
-    * @param GetterCallback The method in the AbstractFilter subclass that <i>gets</i> the value of the property
-    * that this FilterParameter subclass represents.
-    * @return The GetterCallback
-    */
-    /**
-     * @brief Setter property for GetterCallback
-     */
-    void setGetterCallback(const LinkedChoicesFilterParameter::GetterCallbackType& value);
-    /**
-     * @brief Getter property for GetterCallback
-     * @return Value of GetterCallback
-     */
-    LinkedChoicesFilterParameter::GetterCallbackType getGetterCallback() const;
-
   protected:
       /**
        * @brief LinkedChoicesFilterParameter The default constructor.  It is protected because this
@@ -170,7 +137,5 @@ class SIMPLib_EXPORT LinkedChoicesFilterParameter : public ChoiceFilterParameter
 
   private:
     QStringList m_LinkedProperties = {};
-    LinkedChoicesFilterParameter::SetterCallbackType m_SetterCallback = {};
-    LinkedChoicesFilterParameter::GetterCallbackType m_GetterCallback = {};
 };
 


### PR DESCRIPTION
* Removed LinkedChoicesFilterParameter's Setter and Getter callback
functions which shadowed the ChoiceFilterParameter functions
* ChoiceWidget casts to ChoiceFilterParameter not
LinkedChoicesFilterParameter