### PR TITLE
DataArray iterators

### DIFF
--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -367,8 +367,10 @@ typename DataArray<T>::Pointer DataArray<T>::WrapPointer(T* data, size_t numTupl
   // Allocate on the heap
   auto d = std::make_shared<DataArray<T>>(numTuples, name, compDims, static_cast<T>(0), false);
 
-  d->m_Array = data;        // Now set the internal array to the raw pointer
-  d->m_OwnsData = ownsData; // Set who owns the data, i.e., who is going to "free" the memory
+  // Now set the internal array to the raw pointer
+  d->m_Array = data;
+  // Set who owns the data, i.e., who is going to "free" the memory
+  d->m_OwnsData = ownsData;
   if(nullptr != data)
   {
     d->m_IsAllocated = true;

--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -559,8 +559,8 @@ bool DataArray<T>::copyFromArray(size_t destTupleOffset, IDataArray::ConstPointe
     return false;
   }
 
-  auto srcBegin = source->cbegin() + (srcTupleOffset * m_NumComponents);
-  auto srcEnd = srcBegin + (totalSrcTuples * m_NumComponents);
+  auto srcBegin = source->cbegin() + (srcTupleOffset * source->m_NumComponents);
+  auto srcEnd = srcBegin + (totalSrcTuples * source->m_NumComponents);
   auto dstBegin = begin() + (destTupleOffset * m_NumComponents);
   std::copy(srcBegin, srcEnd, dstBegin);
   return true;

--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -1358,6 +1358,42 @@ typename DataArray<T>::const_reverse_iterator DataArray<T>::crend() const
   return rend();
 }
 
+template <typename T>
+typename DataArray<T>::tuple_iterator DataArray<T>::tupleBegin()
+{
+  return tuple_iterator(m_Array, m_NumComponents);
+}
+
+template <typename T>
+typename DataArray<T>::tuple_iterator DataArray<T>::tupleEnd()
+{
+  return tuple_iterator(m_Array + m_Size, m_NumComponents);
+}
+
+template <typename T>
+typename DataArray<T>::const_tuple_iterator DataArray<T>::tupleBegin() const
+{
+  return const_tuple_iterator(m_Array, m_NumComponents);
+}
+
+template <typename T>
+typename DataArray<T>::const_tuple_iterator DataArray<T>::tupleEnd() const
+{
+  return const_tuple_iterator(m_Array + m_Size, m_NumComponents);
+}
+
+template <typename T>
+typename DataArray<T>::const_tuple_iterator DataArray<T>::constTupleBegin() const
+{
+  return tupleBegin();
+}
+
+template <typename T>
+typename DataArray<T>::const_tuple_iterator DataArray<T>::constTupleEnd() const
+{
+  return tupleEnd();
+}
+
 // ######### Capacity #########
 template <typename T>
 typename DataArray<T>::size_type DataArray<T>::size() const

--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -513,9 +513,6 @@ void DataArray<T>::getXdmfTypeAndSize(QString& xdmfTypeName, int32_t& precision)
     precision = 1;
   }
 }
-// This line must be here, because we are overloading the copyData pure  function in IDataArray.
-// This is required so that other classes can call this version of copyData from the subclasses.
-// using IDataArray::copyFromArray;
 
 // -----------------------------------------------------------------------------
 template <typename T>
@@ -716,12 +713,14 @@ int32_t DataArray<T>::eraseTuples(const comp_dims_type& idxs)
     }
   }
 
-  if(k == idxs.size()) // Only front elements are being dropped
+  // Only front elements are being dropped
+  if(k == idxs.size())
   {
     auto srcBegin = begin() + (j * m_NumComponents);
     auto srcEnd = srcBegin + (getNumberOfTuples() - idxs.size()) * m_NumComponents;
     std::copy(srcBegin, srcEnd, newArray);
-    deallocate(); // We are done copying - delete the current m_Array
+    // We are done copying - delete the current m_Array
+    deallocate();
     m_Size = newSize;
     m_Array = newArray;
     m_OwnsData = true;
@@ -1350,16 +1349,7 @@ typename DataArray<T>::size_type DataArray<T>::size() const
 {
   return m_Size;
 }
-template <typename T>
-typename DataArray<T>::size_type DataArray<T>::max_size() const
-{
-  return std::min(static_cast<size_type>(std::numeric_limits<difference_type>::max()), static_cast<size_t>(-1) / sizeof(value_type));
-}
-//  void resize(size_type n)
-//  {
-//    resizeAndExtend(n);
-//  }
-// void resize (size_type n, const value_type& val);
+
 template <typename T>
 typename DataArray<T>::size_type DataArray<T>::capacity() const noexcept
 {
@@ -1371,8 +1361,6 @@ bool DataArray<T>::empty() const noexcept
 {
   return (m_Size == 0);
 }
-// reserve()
-// shrink_to_fit()
 
 // ######### Element Access #########
 
@@ -1400,6 +1388,7 @@ void DataArray<T>::push_back(const value_type& val)
   resizeAndExtend(m_Size + 1);
   m_Array[m_MaxId] = val;
 }
+
 // -----------------------------------------------------------------------------
 template <typename T>
 void DataArray<T>::push_back(value_type&& val)
@@ -1414,10 +1403,6 @@ void DataArray<T>::pop_back()
 {
   resizeAndExtend(m_Size - 1);
 }
-// insert
-// iterator erase (const_iterator position)
-// iterator erase (const_iterator first, const_iterator last);
-// swap
 
 // -----------------------------------------------------------------------------
 template <typename T>
@@ -1434,8 +1419,6 @@ void DataArray<T>::clear()
   m_IsAllocated = false;
   m_NumTuples = 0;
 }
-// emplace
-// emplace_back
 
 // =================================== END STL COMPATIBLE INTERFACe ===================================================
 
@@ -1506,7 +1489,8 @@ T* DataArray<T>::resizeAndExtend(size_t size)
   size_t newSize = 0;
   size_t oldSize = 0;
 
-  if(size == m_Size) // Requested size is equal to current size.  Do nothing.
+  // Requested size is equal to current size.  Do nothing.
+  if(size == m_Size)
   {
     return m_Array;
   }

--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -317,7 +317,6 @@ IDataArray::Pointer DataArray<T>::createNewArray(size_t numTuples, const comp_di
 template <typename T>
 typename DataArray<T>::Pointer DataArray<T>::FromQVector(const QVector<T>& vec, const QString& name)
 {
-
   Pointer p = CreateArray(static_cast<size_t>(vec.size()), name, true);
   if(nullptr != p)
   {
@@ -614,7 +613,7 @@ void DataArray<T>::releaseOwnership()
 template <typename T>
 int32_t DataArray<T>::allocate()
 {
-  if((nullptr != m_Array) && (true == m_OwnsData))
+  if((nullptr != m_Array) && m_OwnsData)
   {
     deallocate();
   }

--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -1367,7 +1367,7 @@ typename DataArray<T>::size_type DataArray<T>::size() const
 template <typename T>
 typename DataArray<T>::size_type DataArray<T>::max_size() const
 {
-  return m_Size;
+  return std::min(static_cast<size_type>(std::numeric_limits<difference_type>::max()), static_cast<size_t>(-1) / sizeof(value_type));
 }
 //  void resize(size_type n)
 //  {

--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -208,6 +208,9 @@ DataArray<T>::DataArray(size_t numTuples, const QString& name, const comp_dims_t
     m_Size = m_NumTuples * m_NumComponents;
     m_MaxId = (m_Size > 0) ? m_Size - 1 : m_Size;
   }
+#if 0
+      MUD_FLAP_0 = MUD_FLAP_1 = MUD_FLAP_2 = MUD_FLAP_3 = MUD_FLAP_4 = MUD_FLAP_5 = 0xABABABABABABABABul;
+#endif
 }
 
 template <typename T>
@@ -1457,6 +1460,17 @@ void DataArray<T>::deallocate()
       }
     }
   }
+#endif
+#if 0
+      if (MUD_FLAP_0 != 0xABABABABABABABABul
+          || MUD_FLAP_1 != 0xABABABABABABABABul
+          || MUD_FLAP_2 != 0xABABABABABABABABul
+          || MUD_FLAP_3 != 0xABABABABABABABABul
+          || MUD_FLAP_4 != 0xABABABABABABABABul
+          || MUD_FLAP_5 != 0xABABABABABABABABul)
+      {
+        Q_ASSERT(false);
+      }
 #endif
 
   delete[](m_Array);

--- a/Source/SIMPLib/DataArrays/DataArray.cpp
+++ b/Source/SIMPLib/DataArrays/DataArray.cpp
@@ -1310,12 +1310,53 @@ typename DataArray<T>::const_iterator DataArray<T>::end() const
   return const_iterator(m_Array + m_Size);
 }
 
-// rbegin
-// rend
-// cbegin
-// cend
-// crbegin
-// crend
+template <typename T>
+typename DataArray<T>::const_iterator DataArray<T>::cbegin() const
+{
+  return begin();
+}
+
+template <typename T>
+typename DataArray<T>::const_iterator DataArray<T>::cend() const
+{
+  return end();
+}
+
+template <typename T>
+typename DataArray<T>::reverse_iterator DataArray<T>::rbegin()
+{
+  return std::make_reverse_iterator(end());
+}
+
+template <typename T>
+typename DataArray<T>::reverse_iterator DataArray<T>::rend()
+{
+  return std::make_reverse_iterator(begin());
+}
+
+template <typename T>
+typename DataArray<T>::const_reverse_iterator DataArray<T>::rbegin() const
+{
+  return std::make_reverse_iterator(end());
+}
+
+template <typename T>
+typename DataArray<T>::const_reverse_iterator DataArray<T>::rend() const
+{
+  return std::make_reverse_iterator(begin());
+}
+
+template <typename T>
+typename DataArray<T>::const_reverse_iterator DataArray<T>::crbegin() const
+{
+  return rbegin();
+}
+
+template <typename T>
+typename DataArray<T>::const_reverse_iterator DataArray<T>::crend() const
+{
+  return rend();
+}
 
 // ######### Capacity #########
 template <typename T>

--- a/Source/SIMPLib/DataArrays/DataArray.hpp
+++ b/Source/SIMPLib/DataArrays/DataArray.hpp
@@ -678,156 +678,274 @@ public:
     using value_type = T;
     using reference = T&;
     using pointer = T*;
-    using difference_type = value_type;
-    using iterator_category = std::forward_iterator_tag;
+    using difference_type = ptrdiff_t;
+    using iterator_category = std::random_access_iterator_tag;
 
-    iterator(pointer ptr)
-    : ptr_(ptr)
+    iterator() = delete;
+
+    iterator(const self_type& iter)
+    : ptr_(iter.ptr_)
     {
     }
-    iterator(pointer ptr, size_type ununsed)
-    : ptr_(ptr)
-    {
-      std::ignore = ununsed;
-    }
 
-    self_type operator++()
+    self_type& operator++()
     {
       ptr_++;
       return *this;
     } // PREFIX
-    self_type operator++(int32_t ununsed)
+    self_type operator++(int32_t unused)
     {
-      std::ignore = ununsed;
+      // Replace with [[maybe_unused]] in C++ 17
+      (void) unused;
       self_type i = *this;
       ptr_++;
       return i;
     } // POSTFIX
-    self_type operator+(int32_t amt)
+    self_type& operator--()
+    {
+      ptr_--;
+      return *this;
+    } // PREFIX
+    self_type operator--(int32_t unused)
+    {
+      // Replace with [[maybe_unused]] in C++ 17
+      (void)unused;
+      self_type i = *this;
+      ptr_--;
+      return i;
+    } // POSTFIX
+    self_type& operator+=(difference_type amt)
     {
       ptr_ += amt;
       return *this;
     }
-    reference operator*()
+    self_type operator+(difference_type amt) const
+    {
+      return self_type(ptr_ + amt);
+    }
+    self_type& operator-=(difference_type amt)
+    {
+      ptr_ -= amt;
+      return *this;
+    }
+    self_type operator-(difference_type amt) const
+    {
+      return self_type(ptr_ - amt);
+    }
+    difference_type operator-(const self_type& rhs) const
+    {
+      return ptr_ - rhs.ptr_;
+    }
+    friend self_type operator+(difference_type lhs, const self_type& rhs)
+    {
+      return self_type(lhs + rhs.ptr_);
+    }
+    reference operator[](difference_type amt) const
+    {
+      return ptr_[amt];
+    }
+    reference operator*() const
     {
       return *ptr_;
     }
-    pointer operator->()
+    pointer operator->() const
     {
       return ptr_;
     }
-    bool operator==(const self_type& rhs)
+    bool operator==(const self_type& rhs) const
     {
       return ptr_ == rhs.ptr_;
     }
-    bool operator!=(const self_type& rhs)
+    bool operator!=(const self_type& rhs) const
     {
       return ptr_ != rhs.ptr_;
     }
+    bool operator>(const self_type& rhs) const
+    {
+      return ptr_ > rhs.ptr_;
+    }
+    bool operator<(const self_type& rhs) const
+    {
+      return ptr_ < rhs.ptr_;
+    }
+    bool operator>=(const self_type& rhs) const
+    {
+      return ptr_ >= rhs.ptr_;
+    }
+    bool operator<=(const self_type& rhs) const
+    {
+      return ptr_ <= rhs.ptr_;
+    }
+
+  protected:
+    iterator(pointer ptr)
+    : ptr_(ptr)
+    {
+    }
+
+    friend class DataArray;
 
   private:
     pointer ptr_;
   };
+
+  using reverse_iterator = std::reverse_iterator<iterator>;
 
   class const_iterator
   {
   public:
     using self_type = const_iterator;
     using value_type = T;
-    using reference = T&;
-    using pointer = T*;
-    using difference_type = value_type;
-    using iterator_category = std::forward_iterator_tag;
-    const_iterator(pointer ptr)
-    : ptr_(ptr)
-    {
-    }
-    const_iterator(pointer ptr, size_type unused)
-    : ptr_(ptr)
+    using reference = const T&;
+    using pointer = const T*;
+    using difference_type = ptrdiff_t;
+    using iterator_category = std::random_access_iterator_tag;
+
+    const_iterator() = delete;
+
+    const_iterator(const self_type& iter)
+    : ptr_(iter.ptr_)
     {
     }
 
-    self_type operator++()
+    self_type& operator++()
     {
       ptr_++;
       return *this;
     } // PREFIX
-    self_type operator++(int32_t amt)
+    self_type operator++(int32_t unused)
     {
+      // Replace with [[maybe_unused]] in C++ 17
+      (void)unused;
       self_type i = *this;
-      ptr_ += amt;
+      ptr_++;
       return i;
     } // POSTFIX
-    self_type operator+(int32_t amt)
+    self_type& operator--()
+    {
+      ptr_--;
+      return *this;
+    } // PREFIX
+    self_type operator--(int32_t unused)
+    {
+      // Replace with [[maybe_unused]] in C++ 17
+      (void)unused;
+      self_type i = *this;
+      ptr_--;
+      return i;
+    } // POSTFIX
+    self_type& operator+=(difference_type amt)
     {
       ptr_ += amt;
       return *this;
     }
-    const value_type& operator*()
+    self_type operator+(difference_type amt) const
+    {
+      return self_type(ptr_ + amt);
+    }
+    self_type& operator-=(difference_type amt)
+    {
+      ptr_ -= amt;
+      return *this;
+    }
+    self_type operator-(difference_type amt) const
+    {
+      return self_type(ptr_ - amt);
+    }
+    difference_type operator-(const self_type& rhs) const
+    {
+      return ptr_ - rhs.ptr_;
+    }
+    friend self_type operator+(difference_type lhs, const self_type& rhs)
+    {
+      return self_type(lhs + rhs.ptr_);
+    }
+    const reference operator[](difference_type amt) const
+    {
+      return ptr_[amt];
+    }
+    reference operator*() const
     {
       return *ptr_;
     }
-    const pointer operator->()
+    pointer operator->() const
     {
       return ptr_;
     }
-    bool operator==(const self_type& rhs)
+    bool operator==(const self_type& rhs) const
     {
       return ptr_ == rhs.ptr_;
     }
-    bool operator!=(const self_type& rhs)
+    bool operator!=(const self_type& rhs) const
     {
       return ptr_ != rhs.ptr_;
     }
+    bool operator>(const self_type& rhs) const
+    {
+      return ptr_ > rhs.ptr_;
+    }
+    bool operator<(const self_type& rhs) const
+    {
+      return ptr_ < rhs.ptr_;
+    }
+    bool operator>=(const self_type& rhs) const
+    {
+      return ptr_ >= rhs.ptr_;
+    }
+    bool operator<=(const self_type& rhs) const
+    {
+      return ptr_ <= rhs.ptr_;
+    }
+
+  protected:
+    const_iterator(pointer ptr)
+    : ptr_(ptr)
+    {
+    }
+
+    friend class DataArray;
 
   private:
     pointer ptr_;
   };
 
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
   // ######### Iterators #########
-  /**
-   *
-   */
-  template <typename IteratorType> IteratorType begin()
+
+  tuple_iterator tupleBegin()
   {
-    return IteratorType(m_Array, m_NumComponents);
+    return tuple_iterator(m_Array, m_NumComponents);
   }
 
-  /**
-   * @brief begin
-   * @return
-   */
+  tuple_iterator tupleEnd()
+  {
+    return tuple_iterator(m_Array + m_Size, m_NumComponents);
+  }
+
   iterator begin();
 
-  template <typename IteratorType> IteratorType end()
-  {
-    return IteratorType(m_Array + m_Size, m_NumComponents);
-  }
-
-  /**
-   * @brief end
-   * @return
-   */
   iterator end();
 
-  /**
-   * @brief begin
-   * @return
-   */
   const_iterator begin() const;
 
-  /**
-   * @brief end
-   * @return
-   */
   const_iterator end() const;
 
-  // rbegin
-  // rend
-  // cbegin
-  // cend
-  // crbegin
-  // crend
+  const_iterator cbegin() const;
+
+  const_iterator cend() const;
+
+  reverse_iterator rbegin();
+
+  reverse_iterator rend();
+
+  const_reverse_iterator rbegin() const;
+
+  const_reverse_iterator rend() const;
+
+  const_reverse_iterator crbegin() const;
+
+  const_reverse_iterator crend() const;
 
   // ######### Capacity #########
 

--- a/Source/SIMPLib/DataArrays/DataArray.hpp
+++ b/Source/SIMPLib/DataArrays/DataArray.hpp
@@ -1086,16 +1086,8 @@ public:
 
   size_type size() const;
 
-  size_type max_size() const;
-  //  void resize(size_type n) override
-  //  {
-  //    resizeAndExtend(n);
-  //  }
-  // void resize (size_type n, const value_type& val);
   size_type capacity() const noexcept;
   bool empty() const noexcept;
-  // reserve()
-  // shrink_to_fit()
 
   // ######### Element Access #########
 
@@ -1201,17 +1193,11 @@ public:
    * @brief pop_back
    */
   void pop_back();
-  // insert
-  // iterator erase (const_iterator position)
-  // iterator erase (const_iterator first, const_iterator last);
-  // swap
 
   /**
    * @brief Removes all elements from the array (which are destroyed), leaving the container with a size of 0.
    */
   void clear();
-  // emplace
-  // emplace_back
 
   /**
    * @brief equal

--- a/Source/SIMPLib/DataArrays/DataArray.hpp
+++ b/Source/SIMPLib/DataArrays/DataArray.hpp
@@ -571,46 +571,113 @@ public:
     using value_type = T;
     using reference = T&;
     using pointer = T*;
-    using difference_type = value_type;
-    using iterator_category = std::forward_iterator_tag;
+    using difference_type = ptrdiff_t;
+    using iterator_category = std::random_access_iterator_tag;
 
+    tuple_iterator() = delete;
+
+    self_type& operator++()
+    {
+      ptr_ += num_comps_;
+      return *this;
+    } // PREFIX
+    self_type operator++(int32_t unused)
+    {
+      // Replace with [[maybe_unused]] in C++ 17
+      (void)unused;
+      self_type i = *this;
+      ptr_ += num_comps_;
+      return i;
+    } // POSTFIX
+    self_type& operator--()
+    {
+      ptr_ -= num_comps_;
+      return *this;
+    } // PREFIX
+    self_type operator--(int32_t unused)
+    {
+      // Replace with [[maybe_unused]] in C++ 17
+      (void)unused;
+      self_type i = *this;
+      ptr_ -= num_comps_;
+      return i;
+    } // POSTFIX
+    self_type& operator+=(difference_type amt)
+    {
+      ptr_ += amt * num_comps_;
+      return *this;
+    }
+    self_type operator+(difference_type amt) const
+    {
+      return self_type(ptr_ + amt * num_comps_, num_comps_);
+    }
+    self_type& operator-=(difference_type amt)
+    {
+      ptr_ -= amt * num_comps_;
+      return *this;
+    }
+    self_type operator-(difference_type amt) const
+    {
+      return self_type(ptr_ - amt * num_comps_, num_comps_);
+    }
+    difference_type operator-(const self_type& rhs) const
+    {
+      return (ptr_ - rhs.ptr_) / static_cast<difference_type>(num_comps_);
+    }
+    friend self_type operator+(difference_type lhs, const self_type& rhs)
+    {
+      return self_type(lhs * rhs.num_comps_ + rhs.ptr_, rhs.num_comps_);
+    }
+    reference operator[](difference_type amt) const
+    {
+      return ptr_[amt * num_comps_];
+    }
+    reference operator*() const
+    {
+      return *ptr_;
+    }
+    pointer operator->() const
+    {
+      return ptr_;
+    }
+    bool operator==(const self_type& rhs) const
+    {
+      return ptr_ == rhs.ptr_;
+    }
+    bool operator!=(const self_type& rhs) const
+    {
+      return ptr_ != rhs.ptr_;
+    }
+    bool operator>(const self_type& rhs) const
+    {
+      return ptr_ > rhs.ptr_;
+    }
+    bool operator<(const self_type& rhs) const
+    {
+      return ptr_ < rhs.ptr_;
+    }
+    bool operator>=(const self_type& rhs) const
+    {
+      return ptr_ >= rhs.ptr_;
+    }
+    bool operator<=(const self_type& rhs) const
+    {
+      return ptr_ <= rhs.ptr_;
+    }
+
+    reference comp_value(size_type comp)
+    {
+      return *(ptr_ + comp);
+    }
+
+  protected:
     tuple_iterator(pointer ptr, size_type numComps)
     : ptr_(ptr)
     , num_comps_(numComps)
     {
     }
-    self_type operator++()
-    {
-      ptr_ = ptr_ + num_comps_;
-      return *this;
-    } // PREFIX
-    self_type operator++(int32_t ununsed)
-    {
-      std::ignore = ununsed;
-      self_type i = *this;
-      ptr_ = ptr_ + num_comps_;
-      return i;
-    } // POSTFIX
-    reference operator*()
-    {
-      return *ptr_;
-    }
-    pointer operator->()
-    {
-      return ptr_;
-    }
-    bool operator==(const self_type& rhs)
-    {
-      return ptr_ == rhs.ptr_;
-    }
-    bool operator!=(const self_type& rhs)
-    {
-      return ptr_ != rhs.ptr_;
-    }
-    reference comp_value(size_type comp)
-    {
-      return *(ptr_ + comp);
-    }
+
+    friend class DataArray;
 
   private:
     pointer ptr_;
@@ -622,48 +689,115 @@ public:
   public:
     using self_type = const_tuple_iterator;
     using value_type = T;
-    using reference = T&;
-    using pointer = T*;
-    using difference_type = value_type;
-    using iterator_category = std::forward_iterator_tag;
+    using reference = const T&;
+    using pointer = const T*;
+    using difference_type = ptrdiff_t;
+    using iterator_category = std::random_access_iterator_tag;
 
+    const_tuple_iterator() = delete;
+
+    self_type& operator++()
+    {
+      ptr_ += num_comps_;
+      return *this;
+    } // PREFIX
+    self_type operator++(int32_t unused)
+    {
+      // Replace with [[maybe_unused]] in C++ 17
+      (void)unused;
+      self_type i = *this;
+      ptr_ += num_comps_;
+      return i;
+    } // POSTFIX
+    self_type& operator--()
+    {
+      ptr_ -= num_comps_;
+      return *this;
+    } // PREFIX
+    self_type operator--(int32_t unused)
+    {
+      // Replace with [[maybe_unused]] in C++ 17
+      (void)unused;
+      self_type i = *this;
+      ptr_ -= num_comps_;
+      return i;
+    } // POSTFIX
+    self_type& operator+=(difference_type amt)
+    {
+      ptr_ += amt * num_comps_;
+      return *this;
+    }
+    self_type operator+(difference_type amt) const
+    {
+      return self_type(ptr_ + amt * num_comps_, num_comps_);
+    }
+    self_type& operator-=(difference_type amt)
+    {
+      ptr_ -= amt * num_comps_;
+      return *this;
+    }
+    self_type operator-(difference_type amt) const
+    {
+      return self_type(ptr_ - amt * num_comps_, num_comps_);
+    }
+    difference_type operator-(const self_type& rhs) const
+    {
+      return (ptr_ - rhs.ptr_) / static_cast<difference_type>(num_comps_);
+    }
+    friend self_type operator+(difference_type lhs, const self_type& rhs)
+    {
+      return self_type(lhs * rhs.num_comps_ + rhs.ptr_, rhs.num_comps_);
+    }
+    reference operator[](difference_type amt) const
+    {
+      return ptr_[amt * num_comps_];
+    }
+    reference operator*() const
+    {
+      return *ptr_;
+    }
+    pointer operator->() const
+    {
+      return ptr_;
+    }
+    bool operator==(const self_type& rhs) const
+    {
+      return ptr_ == rhs.ptr_;
+    }
+    bool operator!=(const self_type& rhs) const
+    {
+      return ptr_ != rhs.ptr_;
+    }
+    bool operator>(const self_type& rhs) const
+    {
+      return ptr_ > rhs.ptr_;
+    }
+    bool operator<(const self_type& rhs) const
+    {
+      return ptr_ < rhs.ptr_;
+    }
+    bool operator>=(const self_type& rhs) const
+    {
+      return ptr_ >= rhs.ptr_;
+    }
+    bool operator<=(const self_type& rhs) const
+    {
+      return ptr_ <= rhs.ptr_;
+    }
+
+    reference comp_value(size_type comp) const
+    {
+      return *(ptr_ + comp);
+    }
+
+  protected:
     const_tuple_iterator(pointer ptr, size_type numComps)
     : ptr_(ptr)
     , num_comps_(numComps)
     {
     }
-    self_type operator++()
-    {
-      ptr_ = ptr_ + num_comps_;
-      return *this;
-    } // PREFIX
-    self_type operator++(int32_t ununsed)
-    {
-      std::ignore = ununsed;
-      self_type i = *this;
-      ptr_ = ptr_ + num_comps_;
-      return i;
-    } // POSTFIX
-    const value_type& operator*()
-    {
-      return *ptr_;
-    }
-    const pointer operator->()
-    {
-      return ptr_;
-    }
-    bool operator==(const self_type& rhs)
-    {
-      return ptr_ == rhs.ptr_;
-    }
-    bool operator!=(const self_type& rhs)
-    {
-      return ptr_ != rhs.ptr_;
-    }
-    const value_type& comp_value(size_type comp)
-    {
-      return *(ptr_ + comp);
-    }
+
+    friend class DataArray;
 
   private:
     pointer ptr_;
@@ -912,15 +1046,17 @@ public:
 
   // ######### Iterators #########
 
-  tuple_iterator tupleBegin()
-  {
-    return tuple_iterator(m_Array, m_NumComponents);
-  }
+  tuple_iterator tupleBegin();
 
-  tuple_iterator tupleEnd()
-  {
-    return tuple_iterator(m_Array + m_Size, m_NumComponents);
-  }
+  tuple_iterator tupleEnd();
+
+  const_tuple_iterator tupleBegin() const;
+
+  const_tuple_iterator tupleEnd() const;
+
+  const_tuple_iterator constTupleBegin() const;
+
+  const_tuple_iterator constTupleEnd() const;
 
   iterator begin();
 

--- a/Source/SIMPLib/DataArrays/DataArray.hpp
+++ b/Source/SIMPLib/DataArrays/DataArray.hpp
@@ -1266,14 +1266,6 @@ private:
 };
 
 // -----------------------------------------------------------------------------
-// These are specialized for bool type as std::vector<bool> uses bits instead of bytes
-template <>
-typename DataArray<bool>::Pointer DataArray<bool>::FromStdVector(const std::vector<bool>& vec, const QString& name);
-
-template <>
-void DataArray<bool>::setTuple(size_t tupleIndex, const std::vector<bool>& data);
-
-// -----------------------------------------------------------------------------
 // Declare our extern templates
 extern template class DataArray<bool>;
 

--- a/Source/SIMPLib/DataArrays/DataArray.hpp
+++ b/Source/SIMPLib/DataArrays/DataArray.hpp
@@ -993,7 +993,7 @@ public:
     {
       return self_type(lhs + rhs.ptr_);
     }
-    const reference operator[](difference_type amt) const
+    reference operator[](difference_type amt) const
     {
       return ptr_[amt];
     }

--- a/Source/SIMPLib/DataArrays/DataArray.hpp
+++ b/Source/SIMPLib/DataArrays/DataArray.hpp
@@ -92,9 +92,8 @@ public:
   using size_type = size_t;
   using value_type = T;
   using reference = T&;
-  using iterator_category = std::input_iterator_tag;
   using pointer = T*;
-  using difference_type = value_type;
+  using difference_type = ptrdiff_t;
 
   //========================================= SIMPL INTERFACE COMPATIBILITY =================================
   using ContainterType = std::vector<Pointer>;

--- a/Source/SIMPLib/DataArrays/Testing/Cxx/DataArrayTest.cpp
+++ b/Source/SIMPLib/DataArrays/Testing/Cxx/DataArrayTest.cpp
@@ -1370,14 +1370,14 @@ true);
     CompDimsType cDims = {4};
     RgbaType rgba(10, QString("RGBA Array"), cDims, 0);
 
-    RgbaIterator begin = rgba.begin<RgbaIterator>();
+    RgbaIterator begin = rgba.tupleBegin();
     rgba.initializeWithValue(0xFF);
     rgba[0] = 0x65;
     rgba[1] = 0x66;
     rgba[2] = 0x67;
     rgba[3] = 0x68;
 
-    for(RgbaIterator rgbaIter = begin; rgbaIter != rgba.end<RgbaIterator>(); rgbaIter++)
+    for(RgbaIterator rgbaIter = begin; rgbaIter != rgba.tupleEnd(); rgbaIter++)
     {
       std::cout << "rgba: " << static_cast<int>(*rgbaIter) << std::endl;
       std::cout << " rgba[0] " << static_cast<int>(rgbaIter.comp_value(0)) << " rgba[1] " << static_cast<int>(rgbaIter.comp_value(1)) << " rgba[2] " << static_cast<int>(rgbaIter.comp_value(2))


### PR DESCRIPTION
* Fixed issue with iterator's operator+ which was implemented as +=
* Extended iterator API to be a random access iterator
* Added cbegin()/cend()
* Added reverse iterators
* Changed uses of std::memcpy to std::copy
  * Changed parts of DataArray implementation to use iterators instead
* Changed templated begin()/end() to tupleBegin()/tupleEnd()