### PR TITLE
Only copy public filters to the documentation directory

### DIFF
--- a/Source/SIMPLib/SIMPLibMacros.cmake
+++ b/Source/SIMPLib/SIMPLibMacros.cmake
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 # Add Unit Test for Plugins and Filters
-# 
+#-------------------------------------------------------------------------------
 function(SIMPL_GenerateUnitTestFile)
   set(options USE_QTGUI)
   set(oneValueArgs PLUGIN_NAME TEST_DATA_DIR)
@@ -110,7 +110,7 @@ endfunction()
 
 #-------------------------------------------------------------------------------
 # SIMPL_ADD_UNIT_TEST
-# 
+#-------------------------------------------------------------------------------
 macro(SIMPL_ADD_UNIT_TEST TEST_NAMES UNIT_TEST_SOURCE_DIR)
   foreach(name ${TEST_NAMES})
     set( ${SIMPL_UNIT_TEST}_TEST_SRCS
@@ -133,7 +133,7 @@ endmacro()
 
 #-------------------------------------------------------------------------------
 # SIMPL_ADD_UNIT_TEST_MOC_FILE
-# 
+#-------------------------------------------------------------------------------
 macro(SIMPL_ADD_UNIT_TEST_MOC_FILE SOURCE_FILE UNIT_TEST_SOURCE_DIR)
 
   # QT5_WRAP_CPP( simpl_unit_test_moc ${UNIT_TEST_SOURCE_DIR}/${SOURCE_FILE}.cpp)
@@ -152,8 +152,8 @@ endmacro()
 # @param REGISTER_KNOWN_FILTERS_FILE
 # @param FILTER_GROUP
 # @param BINARY_DIR
+#-------------------------------------------------------------------------------
 function(SIMPL_START_FILTER_GROUP)
-
   set(options)
   set(oneValueArgs ALL_FILTERS_HEADERFILE REGISTER_KNOWN_FILTERS_FILE FILTER_GROUP BINARY_DIR)
   set(multiValueArgs)
@@ -174,7 +174,7 @@ function(SIMPL_START_FILTER_GROUP)
   if("${P_FILTER_GROUP}" STREQUAL "Core")
     set(P_FILTER_GROUP "SIMPLib")
   endif()
-  file(WRITE "${SIMPLProj_BINARY_DIR}/${P_FILTER_GROUP}PublicFilters.txt" "# ${P_FILTER_GROUP} Public Filters\n")
+  file(WRITE "${SIMPLProj_BINARY_DIR}/${P_FILTER_GROUP}Filters.txt" "# ${P_FILTER_GROUP} Public Filters\n")
 endfunction()
 
 #-------------------------------------------------------------------------------
@@ -182,6 +182,7 @@ endfunction()
 # @param WidgetsBinaryDir
 # @param filterGroup
 # @param humanGroup
+#-------------------------------------------------------------------------------
 macro(SIMPL_END_FILTER_GROUP WidgetsBinaryDir filterGroup humanGroup)
 endmacro()
 
@@ -195,6 +196,7 @@ endmacro()
 
 #-------------------------------------------------------------------------------
 # Macro ADD_SIMPL_SUPPORT_MOC_HEADER
+#-------------------------------------------------------------------------------
 macro(ADD_SIMPL_SUPPORT_MOC_HEADER SourceDir filterGroup headerFileName)
   # QT5_WRAP_CPP( _moc_filter_source  ${SourceDir}/${filterGroup}/${headerFileName})
   # set_source_files_properties( ${_moc_filter_source} PROPERTIES GENERATED TRUE)
@@ -209,6 +211,7 @@ endmacro()
 
 #-------------------------------------------------------------------------------
 # Macro ADD_SIMPL_SUPPORT_HEADER_SUBDIR
+#-------------------------------------------------------------------------------
 macro(ADD_SIMPL_SUPPORT_HEADER_SUBDIR SourceDir filterGroup headerFileName subdir)
     set(Project_SRCS ${Project_SRCS}
                     ${SourceDir}/${filterGroup}/${subdir}/${headerFileName})
@@ -217,6 +220,7 @@ endmacro()
 
 #-------------------------------------------------------------------------------
 # Macro ADD_SIMPL_SUPPORT_SOURCE
+#-------------------------------------------------------------------------------
 macro(ADD_SIMPL_SUPPORT_SOURCE SourceDir filterGroup sourceFileName)
     set(Project_SRCS ${Project_SRCS}
                     ${SourceDir}/${filterGroup}/${sourceFileName})
@@ -240,6 +244,7 @@ endmacro()
 # @param filterName The base filename of the filter, i.e., SomeFilter.cpp would be "SomeFilter"
 # @param filterDocPath The absolute path to the .md documentation file
 # @param publicFilter  Boolean TRUE or FALSE
+#-------------------------------------------------------------------------------
 macro(ADD_SIMPL_FILTER FilterLib WidgetLib filterGroup filterName filterDocPath publicFilter)
 
   # QT5_WRAP_CPP( _moc_filter_source  ${${FilterLib}_SOURCE_DIR}/${filterGroup}/${filterName}.h)
@@ -265,20 +270,24 @@ macro(ADD_SIMPL_FILTER FilterLib WidgetLib filterGroup filterName filterDocPath 
   file(APPEND ${AllFiltersHeaderFile} "#include \"${FilterLib}/${filterGroup}/${filterName}.h\"\n")
 
   if( ${publicFilter} STREQUAL TRUE)
-      file(APPEND ${RegisterKnownFiltersFile} "   FilterFactory<${filterName}>::Pointer ${filterName}Factory = FilterFactory<${filterName}>::New();\n")
-      file(APPEND ${RegisterKnownFiltersFile} "   fm->addFilterFactory(\"${filterName}\",${filterName}Factory);\n\n")
+    file(APPEND ${RegisterKnownFiltersFile} "   FilterFactory<${filterName}>::Pointer ${filterName}Factory = FilterFactory<${filterName}>::New();\n")
+    file(APPEND ${RegisterKnownFiltersFile} "   fm->addFilterFactory(\"${filterName}\",${filterName}Factory);\n\n")
 
-      #-- Check to make sure we have a Documentation file for the filter
-      if(NOT EXISTS ${filterDocPath} )
-        message(FATAL_ERROR "*** Missing Documentation File for ${filterDocPath}")
-      endif()
+    #-- Check to make sure we have a Documentation file for the filter
+    if(NOT EXISTS ${filterDocPath} )
+      message(FATAL_ERROR "*** Missing Documentation File for ${filterDocPath}")
+    endif()
 
-      get_property(DREAM3DDocRoot GLOBAL PROPERTY DREAM3DDocRoot)
-      set_property(GLOBAL APPEND PROPERTY DREAM3DDoc_${filterGroup} ${filterDocPath})
+    get_property(DREAM3DDocRoot GLOBAL PROPERTY DREAM3DDocRoot)
+    set_property(GLOBAL APPEND PROPERTY DREAM3DDoc_${filterGroup} ${filterDocPath})
+    # This bit of code creates a text file that the Python Bindings Generator is going to read from. We have to
+    # special case the "Core" filters that are part of SIMPLib to get the file naming correct.
+    if("${filterGroup}" STREQUAL "CoreFilters")
+      file(APPEND "${SIMPLProj_BINARY_DIR}/SIMPLibFilters.txt" "${filterName}.h\n")
+    else()
+      file(APPEND "${SIMPLProj_BINARY_DIR}/${filterGroup}.txt" "${filterName}.h\n")
+    endif()    
   endif()
-
-  file(APPEND ${SIMPLProj_BINARY_DIR}/${FilterLib}PublicFilters.txt "${filterName}.h\n")
-
 endmacro()
 
 #-------------------------------------------------------------------------------

--- a/Source/SVWidgetsLib/QtSupport/QtSDocServer.cpp
+++ b/Source/SVWidgetsLib/QtSupport/QtSDocServer.cpp
@@ -198,7 +198,7 @@ QUrl QtSDocServer::GenerateHTMLUrl(const QString& className)
     QString pluginName;
     if(factory)
     {
-      pluginName = "/Filters/" + factory->getCompiledLibraryName() + "Filters";
+      pluginName = "/Filters/" + factory->getCompiledLibraryName() + "_Filters";
     }
     s = s.append(pluginName).append("/").append(className).append("/index.html");
     return QUrl(s);

--- a/Source/SVWidgetsLib/QtSupport/QtSHelpUrlGenerator.cpp
+++ b/Source/SVWidgetsLib/QtSupport/QtSHelpUrlGenerator.cpp
@@ -35,9 +35,14 @@
 
 #include "QtSHelpUrlGenerator.h"
 
+#include <iostream>
+
+#include <QtCore/QTextStream>
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDir>
+
 #include <QtGui/QDesktopServices>
+
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QWidget>
@@ -90,25 +95,18 @@ QUrl QtSHelpUrlGenerator::GenerateHTMLUrl(QString htmlName)
 
 #ifdef SIMPL_USE_MKDOCS
   {
-    FilterManager* fm = FilterManager::Instance();
-
-    IFilterFactory::Pointer factory = fm->getFactoryFromClassName(htmlName);
-    QString pluginName;
-    if(factory.get() != nullptr)
-    {
-      pluginName = "/Filters/" + factory->getCompiledLibraryName();
-    }
-
-    QString helpFilePath = QString("/%2%3Filters/%4/index.html").arg(helpDir.absolutePath()).arg(QCoreApplication::instance()->applicationName()).arg(pluginName).arg(htmlName);
+    QString helpFilePath;
+    QTextStream out(&helpFilePath);
+    out << helpDir.absolutePath() << "/"
+        << "Filters" << factory->getCompiledLibraryName() << "_Filters" << htmlName;
     QFileInfo fi(helpFilePath);
     if(!fi.exists())
     {
-      // The help file does not exist at the default location because we are probably running from Visual Studio or Xcode
-      // Try up one more directory
       helpDir.cdUp();
-      helpFilePath = QString("%1/Help/%2%3/%4/%4.html").arg(helpDir.absolutePath()).arg(QCoreApplication::instance()->applicationName()).arg(pluginName).arg(htmlName);
+      helpFilePath.clear();
+      out << helpDir.absolutePath() << "/"
+          << "Filters" << factory->getCompiledLibraryName() << "_Filters" << htmlName;
     }
-
     s = s + helpFilePath;
   }
 #endif

--- a/Source/SVWidgetsLib/QtSupport/QtSHelpUrlGenerator.cpp
+++ b/Source/SVWidgetsLib/QtSupport/QtSHelpUrlGenerator.cpp
@@ -93,6 +93,10 @@ QUrl QtSHelpUrlGenerator::GenerateHTMLUrl(QString htmlName)
   }
 #endif
 
+    FilterManager* fm = FilterManager::Instance();
+
+    IFilterFactory::Pointer factory = fm->getFactoryFromClassName(htmlName);
+
 #ifdef SIMPL_USE_MKDOCS
   {
     QString helpFilePath;
@@ -113,9 +117,6 @@ QUrl QtSHelpUrlGenerator::GenerateHTMLUrl(QString htmlName)
 
 #ifdef SIMPL_USE_DISCOUNT
   {
-    FilterManager* fm = FilterManager::Instance();
-
-    IFilterFactory::Pointer factory = fm->getFactoryFromClassName(htmlName);
     QString pluginName;
     if(factory.get())
     {

--- a/Wrapping/Python/Binding/CreatePybind11Module.cmake
+++ b/Wrapping/Python/Binding/CreatePybind11Module.cmake
@@ -132,7 +132,7 @@ function(CreatePybind11Plugin)
 
   CreatePybind11Module(MODULE_NAME ${PLUGIN_NAME_lower}
     OUTPUT_DIR "${${ARGS_PLUGIN_NAME}_BINARY_DIR}/Wrapping/PythonCore"
-    FILE_LIST_PATH "${SIMPLProj_BINARY_DIR}/${ARGS_PLUGIN_NAME}PublicFilters.txt"
+    FILE_LIST_PATH "${SIMPLProj_BINARY_DIR}/${ARGS_PLUGIN_NAME}Filters.txt"
     SOURCE_DIR "${${ARGS_PLUGIN_NAME}_SOURCE_DIR}/${ARGS_PLUGIN_NAME}Filters"
     INCLUDE_DIR "${${ARGS_PLUGIN_NAME}_SOURCE_DIR}"
     PYTHON_OUTPUT_DIR "${SIMPLProj_BINARY_DIR}/Wrapping/dream3d"

--- a/Wrapping/Python/Pybind11/CodeScraper/PyBind11Generator.cpp
+++ b/Wrapping/Python/Pybind11/CodeScraper/PyBind11Generator.cpp
@@ -43,7 +43,7 @@ void PyBind11Generator::readFilterList()
   {
     libName = QString("SIMPLib");
   }
-  QString listFilePath = SIMPL::PyBind11::SIMPLProjBinaryDir + "/" + libName + "PublicFilters.txt";
+  QString listFilePath = SIMPL::PyBind11::SIMPLProjBinaryDir + "/" + libName + "Filters.txt";
   QFileInfo listFileInfo(listFilePath);
   if(!listFileInfo.exists())
   {


### PR DESCRIPTION
Update codes to use this newer layout of "[PLUGIN]Filters" to
"[PLUGIN]_Filters" which allows mkdocs to insert a space character in the
TOC that is generated making the TOC more readable.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>