### PR TITLE
Rotate sample ref frame bugs

### DIFF
--- a/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.cpp
+++ b/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.cpp
@@ -410,9 +410,18 @@ public:
           // Now we know what voxel the new cell center maps back to in the original geometry.
           if(errorResult == ImageGeom::ErrorType::NoError)
           {
+            // This is such a BAD idea but is needed here due to the ReadH5Ebsd and how it needs a very
+            // particular transformation performed. UNDER Probably NO other circumstances should slice-by-slice be used
+            // for any other kind of transformation.
+            if(m_SliceBySlice)
+
+            {
+              oldGeomIndices[2] = k;
+            }
             size_t oldIndex = (origImageGeomDims[0] * origImageGeomDims[1] * oldGeomIndices[2]) + (origImageGeomDims[0] * oldGeomIndices[1]) + oldGeomIndices[0];
             if(!m_TargetArray->copyFromArray(newIndex, m_SourceArray, oldIndex, 1))
             {
+              m_Filter->setErrorCondition(-99000, "RotateSampleReferenceFrame: Error occured when copying data to the rotated geometry. This should not have happened.");
               return;
             }
           }
@@ -779,6 +788,7 @@ void RotateSampleRefFrame::sendThreadSafeProgressMessage(int64_t counter)
   lastProgressInt = progressInt;
 }
 
+// -----------------------------------------------------------------------------
 void RotateSampleRefFrame::sendThreadSafeProgressMessage(const QString& message)
 {
   static std::mutex mutex;

--- a/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.h
+++ b/Source/SIMPLib/CoreFilters/RotateSampleRefFrame.h
@@ -274,6 +274,8 @@ public:
    */
   void sendThreadSafeProgressMessage(int64_t counter);
 
+  void sendThreadSafeProgressMessage(const QString& message);
+
 protected:
   RotateSampleRefFrame();
 
@@ -310,6 +312,7 @@ private:
   mutable std::mutex m_ProgressMessage_Mutex;
   size_t m_InstanceIndex = {0};
   int64_t m_TotalElements = {};
+  qint64 m_Millis = QDateTime::currentMSecsSinceEpoch();
 
   /**
    * @brief This is an alternate version of the execute that attempted to parallelize over each DataArray. Turns out this was


### PR DESCRIPTION
If an arbitrary transformation was selected the data would not fall into the correct spots on the new geometry.